### PR TITLE
2 way communication between contentScript and tiddlyfox.js

### DIFF
--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -149,7 +149,11 @@ SaverHandler.prototype.saveWiki = function(options) {
 		template = options.template || "$:/core/save/all",
 		downloadType = options.downloadType || "text/plain",
 		text = this.wiki.renderTiddler(downloadType,template,options),
-		callback = function(err) {
+		// callback(err, saverInfo), err = null ... no error
+		// SaverInfo is an Object, that contains info definde by the saver. eg: tiddlyfox.js
+		// as a return value after a successfull write action.
+		callback = function(err,saverInfo) {
+			saverInfo = saverInfo || {};
 			if(err) {
 				alert($tw.language.getString("Error/WhileSaving") + ":\n\n" + err);
 			} else {
@@ -160,7 +164,7 @@ SaverHandler.prototype.saveWiki = function(options) {
 				}
 				$tw.notifier.display(self.titleSavedNotification);
 				if(options.callback) {
-					options.callback();
+					options.callback(saverInfo);
 				}
 			}
 		};
@@ -171,7 +175,7 @@ SaverHandler.prototype.saveWiki = function(options) {
 	// Call the highest priority saver that supports this method
 	for(var t=this.savers.length-1; t>=0; t--) {
 		var saver = this.savers[t];
-		if(saver.info.capabilities.indexOf(method) !== -1 && saver.save(text,method,callback,{variables: {filename: variables.filename}})) {
+		if(saver.info.capabilities.indexOf(method) !== -1 && saver.save(text,method,callback,options)) {
 			this.logger.log("Saving wiki with method",method,"through saver",saver.info.name);
 			return true;
 		}

--- a/core/modules/savers/tiddlyfox.js
+++ b/core/modules/savers/tiddlyfox.js
@@ -15,8 +15,12 @@ Handles saving changes via the TiddlyFox file extension
 var TiddlyFoxSaver = function(wiki) {
 };
 
-TiddlyFoxSaver.prototype.save = function(text,method,callback) {
+TiddlyFoxSaver.prototype.save = function(text,method,callback,options) {
+	options = options || {};
+	var key,
+		opt = options.variables || {};
 	var messageBox = document.getElementById("tiddlyfox-message-box");
+
 	if(messageBox) {
 		// Get the pathname of this document
 		var pathname = document.location.toString().split("#")[0];
@@ -45,10 +49,18 @@ TiddlyFoxSaver.prototype.save = function(text,method,callback) {
 		var message = document.createElement("div");
 		message.setAttribute("data-tiddlyfox-path",decodeURIComponent(pathname));
 		message.setAttribute("data-tiddlyfox-content",text);
+		// make all the params available for TiddlyFox and its predecessors
+		for (key in opt) {
+    		if (Object.prototype.hasOwnProperty.call(opt, key)) {
+        		message.setAttribute("data-tiddlyfox-"+key,opt[key]);
+			}
+		}
 		messageBox.appendChild(message);
 		// Add an event handler for when the file has been saved
 		message.addEventListener("tiddlyfox-have-saved-file",function(event) {
-			callback(null);
+			// callback(err,response)
+			// response is a response Object {} after a succsessfull save.
+			callback(null,message.dataset);
 		}, false);
 		// Create and dispatch the custom event to the extension
 		var event = document.createEvent("Events");


### PR DESCRIPTION
**Work in progress - Don't merge atm**!

fixes #3004 "TiddlyFox saver tiddlyfox.js doesn't pass on options received from saver-handler.js"

See detailed comments in the code. ... The changes implemented here allow custom savers eg: tiddlyfox.js and others to get info from TW config UI. 

```
<$button class="tc-btn-big-green">
<$action-sendmessage $message="tm-save-wiki" $param="$:/editions/tw5.com/download-empty" filename="empty.html" backupdir="asdf" test={{test-test-test}}/> <---------- see filename, test and xxx
Download Empty {{$:/core/images/save-button}}
</$button>
```

The above button creates a custom "save-wiki" button, that allows users to define eg: "backupdir", which can then be used by custom saver modules and browser addOns.
