### PR TITLE
add location.hash to browser system info tiddlers

### DIFF
--- a/core/modules/info/platform.js
+++ b/core/modules/info/platform.js
@@ -21,10 +21,11 @@ exports.getInfoTiddlerFields = function() {
 	if($tw.browser) {
 		// Document location
 		var setLocationProperty = function(name,value) {
-				infoTiddlerFields.push({title: "$:/info/url/" + name, text: value});			
+				infoTiddlerFields.push({title: "$:/info/url/" + name, text: value});
 			},
 			location = document.location;
 		setLocationProperty("full", (location.toString()).split("#")[0]);
+		setLocationProperty("hash", location.hash);
 		setLocationProperty("host", location.host);
 		setLocationProperty("hostname", location.hostname);
 		setLocationProperty("protocol", location.protocol);

--- a/editions/tw5.com/tiddlers/mechanisms/InfoMechanism.tid
+++ b/editions/tw5.com/tiddlers/mechanisms/InfoMechanism.tid
@@ -10,6 +10,10 @@ type: text/vnd.tiddlywiki
 
 System tiddlers in the namespace `$:/info/` are used to expose information about the system (including the current browser) so that WikiText applications can adapt themselves to available features.
 
+! Important
+
+The values below are "snapshots". The values are initialized at the wiki startup.
+
 ! Information Tiddlers
 
 |!Title |!Description |

--- a/editions/tw5.com/tiddlers/mechanisms/InfoMechanism.tid
+++ b/editions/tw5.com/tiddlers/mechanisms/InfoMechanism.tid
@@ -19,6 +19,7 @@ System tiddlers in the namespace `$:/info/` are used to expose information about
 |[[$:/info/browser/screen/height]] |Screen height in pixels |
 |[[$:/info/node]] |Running under [[Node.js]]? ("yes" or "no") |
 |[[$:/info/url/full]] |<<.from-version "5.1.14">> Full URL of wiki (eg, ''<<example full>>'') |
+|[[$:/info/url/hash]] |<<.from-version "5.1.22">> Hash portion of URL of wiki (eg, ''#InfoMechanism'') |
 |[[$:/info/url/host]] |<<.from-version "5.1.14">> Host portion of URL of wiki (eg, ''<<example host>>'') |
 |[[$:/info/url/hostname]] |<<.from-version "5.1.14">> Hostname portion of URL of wiki (eg, ''<<example hostname>>'') |
 |[[$:/info/url/origin]] |<<.from-version "5.1.14">> Origin portion of URL of wiki (eg, ''<<example origin>>'') |

--- a/editions/tw5.com/tiddlers/mechanisms/InfoMechanism.tid
+++ b/editions/tw5.com/tiddlers/mechanisms/InfoMechanism.tid
@@ -23,7 +23,7 @@ The values below are "snapshots". The values are initialized at the wiki startup
 |[[$:/info/browser/screen/height]] |Screen height in pixels |
 |[[$:/info/node]] |Running under [[Node.js]]? ("yes" or "no") |
 |[[$:/info/url/full]] |<<.from-version "5.1.14">> Full URL of wiki (eg, ''<<example full>>'') |
-|[[$:/info/url/hash]] |<<.from-version "5.1.22">> Hash portion of URL of wiki (eg, ''<<example hash>>''). If empty click [[here|https://tiddlywiki.com/#InfoMechanism]]|
+|[[$:/info/url/hash]] |<<.from-version "5.1.22">> Hash portion of URL of wiki (eg, ''<<example hash>>'')|
 |[[$:/info/url/host]] |<<.from-version "5.1.14">> Host portion of URL of wiki (eg, ''<<example host>>'') |
 |[[$:/info/url/hostname]] |<<.from-version "5.1.14">> Hostname portion of URL of wiki (eg, ''<<example hostname>>'') |
 |[[$:/info/url/origin]] |<<.from-version "5.1.14">> Origin portion of URL of wiki (eg, ''<<example origin>>'') |

--- a/editions/tw5.com/tiddlers/mechanisms/InfoMechanism.tid
+++ b/editions/tw5.com/tiddlers/mechanisms/InfoMechanism.tid
@@ -19,7 +19,7 @@ System tiddlers in the namespace `$:/info/` are used to expose information about
 |[[$:/info/browser/screen/height]] |Screen height in pixels |
 |[[$:/info/node]] |Running under [[Node.js]]? ("yes" or "no") |
 |[[$:/info/url/full]] |<<.from-version "5.1.14">> Full URL of wiki (eg, ''<<example full>>'') |
-|[[$:/info/url/hash]] |<<.from-version "5.1.22">> Hash portion of URL of wiki (eg, ''#InfoMechanism'') |
+|[[$:/info/url/hash]] |<<.from-version "5.1.22">> Hash portion of URL of wiki (eg, ''<<example hash>>'') |
 |[[$:/info/url/host]] |<<.from-version "5.1.14">> Host portion of URL of wiki (eg, ''<<example host>>'') |
 |[[$:/info/url/hostname]] |<<.from-version "5.1.14">> Hostname portion of URL of wiki (eg, ''<<example hostname>>'') |
 |[[$:/info/url/origin]] |<<.from-version "5.1.14">> Origin portion of URL of wiki (eg, ''<<example origin>>'') |

--- a/editions/tw5.com/tiddlers/mechanisms/InfoMechanism.tid
+++ b/editions/tw5.com/tiddlers/mechanisms/InfoMechanism.tid
@@ -19,7 +19,7 @@ System tiddlers in the namespace `$:/info/` are used to expose information about
 |[[$:/info/browser/screen/height]] |Screen height in pixels |
 |[[$:/info/node]] |Running under [[Node.js]]? ("yes" or "no") |
 |[[$:/info/url/full]] |<<.from-version "5.1.14">> Full URL of wiki (eg, ''<<example full>>'') |
-|[[$:/info/url/hash]] |<<.from-version "5.1.22">> Hash portion of URL of wiki (eg, ''<<example hash>>'') |
+|[[$:/info/url/hash]] |<<.from-version "5.1.22">> Hash portion of URL of wiki (eg, ''<<example hash>>''). If empty click [[here|https://tiddlywiki.com/#InfoMechanism]]|
 |[[$:/info/url/host]] |<<.from-version "5.1.14">> Host portion of URL of wiki (eg, ''<<example host>>'') |
 |[[$:/info/url/hostname]] |<<.from-version "5.1.14">> Hostname portion of URL of wiki (eg, ''<<example hostname>>'') |
 |[[$:/info/url/origin]] |<<.from-version "5.1.14">> Origin portion of URL of wiki (eg, ''<<example origin>>'') |


### PR DESCRIPTION
Add some missing startup info. 

This will be a way for user, to know, how the wiki was opened.

see discussion in GG: https://groups.google.com/forum/#!topic/tiddlywiki/js4dpXZYMDg