### PR TITLE
Add option for syncer module to not always load all skinny tiddlers

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1363,7 +1363,7 @@ exports.getTiddlerText = function(title,defaultText) {
 	if(!tiddler) {
 		return defaultText;
 	}
-	if(!tiddler.hasField("_is_skinny")) {
+	if(!tiddler.hasField("_is_skinny") && tiddler.hasField("text")) {
 		// Just return the text if we've got it
 		return tiddler.fields.text || "";
 	} else {


### PR DESCRIPTION
This PR is meant to address this issue: https://github.com/Jermolene/TiddlyWiki5/issues/4598

## Option for `syncer` module to not always immediately fetch all skinny tiddlers

Currently, whenever some skinny tiddlers are fetched via `syncadaptor.getSkinnyTiddlers`, the `syncer` module will immediately load the fat version of those tiddlers, regardless if any of those tiddlers are viewed/loaded/needed by the user or not.

As mentioned in the issue referenced above, this behaviour completely defeats the purpose of having skinny tiddlers and lazy loading.

This PR adds a `alwaysFetchAllSkinnyTiddlers` option to the `syncer` module that's defaulted to `true` in order to maintain 
current default logic.

If `alwaysFetchAllSkinnyTiddlers` is set to `false` then the `syncer` module will no longer immediately fetch all skinny tiddlers, and will instead wait for the `lazyLoad` event for a particular skinny tiddler to trigger a fetch of the fat version of that tiddler.

---

## With Regarding to Setting the Value of the `alwaysFetchAllSkinnyTiddlers` Option

Currently the `syncer` module will attempt to call `syncadaptor.getStatus` before continuing with fetching skinny tiddlers, **in the constructor** of the `syncer` module.

This means that it's important to ensure `alwaysFetchAllSkinnyTiddlers` is set properly before the `syncer` module has an opportunities to fetch skinny tiddlers.

This means that a custom `syncadaptor` module should ensure that:

* It has a `getStatus` function
* That `getStatus` function do not call its `callback` before setting `$tw.syncer.alwaysFetchAllSkinnyTiddlers = false;`

The exact implementation there would depend on the implementation of the custom `syncadaptor` module. But the idea is that we have to make sure `$tw.syncer.alwaysFetchAllSkinnyTiddlers` is set to `false` before the `syncer` module's skinny tiddlers fetching code can run.

---

p.s. This PR also updates the "is the tiddler skinny" logic in the `syncer` module to check for the presence of the `_is_skinny` field, in addition to checking if the `text` field is missing or not.