### PR TITLE
Add support for directly setting style.* attributes on HTML elements

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -314,21 +314,28 @@ excludeEventAttributes: ignores attributes whose name begins with "on"
 Widget.prototype.assignAttributes = function(domNode,options) {
 	options = options || {};
 	var self = this;
-	$tw.utils.each(this.attributes,function(v,a) {
-		// Check exclusions
-		if(options.excludeEventAttributes && a.substr(0,2) === "on") {
-			v = undefined;
+	$tw.utils.each(this.parseTreeNode.orderedAttributes,function(attribute,index) {
+		var name = attribute.name, value = self.getAttribute(name);
+		// Check for excluded attribute names
+		if(options.excludeEventAttributes && name.substr(0,2) === "on") {
+			value = undefined;
 		}
-		if(v !== undefined) {
-			var b = a.split(":");
-			// Setting certain attributes can cause a DOM error (eg xmlns on the svg element)
-			try {
-				if (b.length == 2 && b[0] == "xlink"){
-					domNode.setAttributeNS("http://www.w3.org/1999/xlink",b[1],v);
-				} else {
-					domNode.setAttributeNS(null,a,v);
+		if(value !== undefined) {
+			// Handle the xlink: namespace
+			var namespace = null;
+			if(name.substr(0,6) === "xlink:" && name.length > 6) {
+				namespace = "http://www.w3.org/1999/xlink";
+				name = name.substr(6);
+			}
+			// Handle styles
+			if(name.substr(0,6) === "style." && name.length > 6) {
+				domNode.style[$tw.utils.unHyphenateCss(name.substr(6))] = value;
+			} else {
+				// Setting certain attributes can cause a DOM error (eg xmlns on the svg element)
+				try {
+					domNode.setAttributeNS(namespace,name,value);
+				} catch(e) {
 				}
-			} catch(e) {
 			}
 		}
 	});

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -341,11 +341,11 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 	// Not all parse tree nodes have the orderedAttributes property
 	if(this.parseTreeNode.orderedAttributes) {
 		$tw.utils.each(this.parseTreeNode.orderedAttributes,function(attribute,index) {
-			assignAttribute(attribute.name,self.getAttribute(attribute.name));
+			assignAttribute(attribute.name,self.attributes[attribute.name]);
 		});	
 	} else {
-		$tw.utils.each(self.attributes,function(value,name) {
-			assignAttribute(name,value);
+		$tw.utils.each(Object.keys(self.attributes).sort(),function(name) {
+			assignAttribute(name,self.attributes[name]);
 		});	
 	}
 };

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -314,8 +314,7 @@ excludeEventAttributes: ignores attributes whose name begins with "on"
 Widget.prototype.assignAttributes = function(domNode,options) {
 	options = options || {};
 	var self = this;
-	$tw.utils.each(this.parseTreeNode.orderedAttributes,function(attribute,index) {
-		var name = attribute.name, value = self.getAttribute(name);
+	var assignAttribute = function(name,value) {
 		// Check for excluded attribute names
 		if(options.excludeEventAttributes && name.substr(0,2) === "on") {
 			value = undefined;
@@ -338,7 +337,17 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 				}
 			}
 		}
-	});
+	}
+	// Not all parse tree nodes have the orderedAttributes property
+	if(this.parseTreeNode.orderedAttributes) {
+		$tw.utils.each(this.parseTreeNode.orderedAttributes,function(attribute,index) {
+			assignAttribute(attribute.name,self.getAttribute(attribute.name));
+		});	
+	} else {
+		$tw.utils.each(self.attributes,function(value,name) {
+			assignAttribute(name,value);
+		});	
+	}
 };
 
 /*

--- a/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
@@ -58,6 +58,26 @@ In an extension of conventional HTML syntax, attributes of elements/widgets can 
 * a transclusion of a [[macro/variable|Macros in WikiText]]
 * as the result of a [[Filter Expression]]
 
+!! Style Attributes
+
+<<.from-version "5.2.2">> TiddlyWiki supports the usual HTML ''style'' attribute for assigning CSS styles to elements:
+
+```
+<div style="color:red;">Hello</div>
+```
+
+In an extension to HTML, TiddlyWiki also supports accessing individual CSS styles as independent attributes. For example:
+
+```
+<div style.color="red">Hello</div>
+```
+
+The advantage of this syntax is that it simplifies assigning computed values to CSS styles. For example:
+
+```
+<div style.color={{!!color}}>Hello</div>
+```
+
 !! Literal Attribute Values
 
 Literal attribute values can use several different styles of quoting:


### PR DESCRIPTION
## Introduction

It is currently possible to use the standard HTML "style" attribute to add styling to an HTML element:

```
<div style="background:red;">
```

It is proposed to add the ability to set individual style properties directly:

```
<div style.background="red">
```

Note that this extension is not part of the HTML standard.

This improvement makes it easier to use computed CSS property values:

```
<div style.background={{!!colour}}>
```

Instead of:

```
<div style={{{ [{!!colour}addprefix[background:]addsuffix[;]] }}}>
```

## Style property names

The present implementation accepts both the camelcase and dashed versions of CSS property names. Thus the following two examples will have the same effect:

```
<div style.backgroundColor="red">
<div style.background-color="red">
```

## Attribute ordering

There is a potential ambiguity in cases where the `style` attribute is specified alongside a direct style attribute. This is resolved by processing the attributes in the order that they appear. In the following example, the result is to set the background to blue and the foreground to green:

```
<div style="background:red;color:green;" style.background="blue">
```

Meanwhile, in this example, the background will be red and the foreground green:

```
<div style.background="blue" style="background:red;color:green;">
```

## Progress

* [x] Add support for direct style attributes to HTML element widget
* [ ] Add support for direct style attributes to other widgets
