### PR TITLE
Eventcatcher widget: add "matchSelector" attribute

### DIFF
--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -46,6 +46,7 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 	$tw.utils.each(this.types,function(type) {
 		domNode.addEventListener(type,function(event) {
 			var selector = self.getAttribute("selector"),
+				matchSelector = self.getAttribute("matchSelector"),
 				actions = self.getAttribute("$"+type) || self.getAttribute("actions-"+type),
 				stopPropagation = self.getAttribute("stopPropagation","onaction"),
 				selectedNode = event.target,
@@ -57,44 +58,47 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 				selectedNode = selectedNode.parentNode;
 			}
 			if(selector) {
+				// Check that the selected node matches any matchSelector
+				if(matchSelector && !$tw.utils.domMatchesSelector(selectedNode,matchSelector)) {
+					return false;
+				}
 				// Search ancestors for a node that matches the selector
 				while(!$tw.utils.domMatchesSelector(selectedNode,selector) && selectedNode !== domNode) {
 					selectedNode = selectedNode.parentNode;
 				}
-				// If we found one, copy the attributes as variables, otherwise exit
-				if($tw.utils.domMatchesSelector(selectedNode,selector)) {
-					// Only set up variables if we have actions to invoke
-					if(actions) {
-						$tw.utils.each(selectedNode.attributes,function(attribute) {
-							variables["dom-" + attribute.name] = attribute.value.toString();
-						});
-						//Add a variable with a popup coordinate string for the selected node
-						variables["tv-popup-coords"] = "(" + selectedNode.offsetLeft + "," + selectedNode.offsetTop +"," + selectedNode.offsetWidth + "," + selectedNode.offsetHeight + ")";
-
-						//Add variables for offset of selected node
-						variables["tv-selectednode-posx"] = selectedNode.offsetLeft.toString();
-						variables["tv-selectednode-posy"] = selectedNode.offsetTop.toString();
-						variables["tv-selectednode-width"] = selectedNode.offsetWidth.toString();
-						variables["tv-selectednode-height"] = selectedNode.offsetHeight.toString();
-						
-						if(event.clientX && event.clientY) {
-							//Add variables for event X and Y position relative to selected node
-							selectedNodeRect = selectedNode.getBoundingClientRect();
-							variables["event-fromselected-posx"] = (event.clientX - selectedNodeRect.left).toString();
-							variables["event-fromselected-posy"] = (event.clientY - selectedNodeRect.top).toString();
-
-							//Add variables for event X and Y position relative to event catcher node
-							catcherNodeRect = self.domNode.getBoundingClientRect();
-							variables["event-fromcatcher-posx"] = (event.clientX - catcherNodeRect.left).toString();
-							variables["event-fromcatcher-posy"] = (event.clientY - catcherNodeRect.top).toString();
-
-							//Add variables for event X and Y position relative to the viewport
-							variables["event-fromviewport-posx"] = event.clientX.toString();
-							variables["event-fromviewport-posy"] = event.clientY.toString();
-						}
-					}
-				} else {
+				// Exit if we didn't find one
+				if(selectedNode === domNode) {
 					return false;
+				}
+				// Only set up variables if we have actions to invoke
+				if(actions) {
+					$tw.utils.each(selectedNode.attributes,function(attribute) {
+						variables["dom-" + attribute.name] = attribute.value.toString();
+					});
+					//Add a variable with a popup coordinate string for the selected node
+					variables["tv-popup-coords"] = "(" + selectedNode.offsetLeft + "," + selectedNode.offsetTop +"," + selectedNode.offsetWidth + "," + selectedNode.offsetHeight + ")";
+
+					//Add variables for offset of selected node
+					variables["tv-selectednode-posx"] = selectedNode.offsetLeft.toString();
+					variables["tv-selectednode-posy"] = selectedNode.offsetTop.toString();
+					variables["tv-selectednode-width"] = selectedNode.offsetWidth.toString();
+					variables["tv-selectednode-height"] = selectedNode.offsetHeight.toString();
+					
+					if(event.clientX && event.clientY) {
+						//Add variables for event X and Y position relative to selected node
+						selectedNodeRect = selectedNode.getBoundingClientRect();
+						variables["event-fromselected-posx"] = (event.clientX - selectedNodeRect.left).toString();
+						variables["event-fromselected-posy"] = (event.clientY - selectedNodeRect.top).toString();
+
+						//Add variables for event X and Y position relative to event catcher node
+						catcherNodeRect = self.domNode.getBoundingClientRect();
+						variables["event-fromcatcher-posx"] = (event.clientX - catcherNodeRect.left).toString();
+						variables["event-fromcatcher-posy"] = (event.clientY - catcherNodeRect.top).toString();
+
+						//Add variables for event X and Y position relative to the viewport
+						variables["event-fromviewport-posx"] = event.clientX.toString();
+						variables["event-fromviewport-posy"] = event.clientY.toString();
+					}
 				}
 			}
 			// Execute our actions with the variables

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -57,11 +57,11 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 			if(selectedNode.nodeType === 3) {
 				selectedNode = selectedNode.parentNode;
 			}
+			// Check that the selected node matches any matchSelector
+			if(matchSelector && !$tw.utils.domMatchesSelector(selectedNode,matchSelector)) {
+				return false;
+			}
 			if(selector) {
-				// Check that the selected node matches any matchSelector
-				if(matchSelector && !$tw.utils.domMatchesSelector(selectedNode,matchSelector)) {
-					return false;
-				}
 				// Search ancestors for a node that matches the selector
 				while(!$tw.utils.domMatchesSelector(selectedNode,selector) && selectedNode !== domNode) {
 					selectedNode = selectedNode.parentNode;

--- a/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
@@ -1,5 +1,5 @@
 created: 20201123113532200
-modified: 20211031180336257
+modified: 20220311154749139
 tags: Widgets TriggeringWidgets
 title: EventCatcherWidget
 type: text/vnd.tiddlywiki
@@ -12,11 +12,12 @@ type: text/vnd.tiddlywiki
 
 The event catcher widget traps DOM-initiated Javascript events dispatched within its child content, and allows invoking a series of ActionWidgets in response to those events. 
 
-In order for the events to be trapped they must:
+In order for the events to be trapped:
 
-* be of one of the events specified in the event catcher widget's `events` attribute
-* arise within a DOM node specified by the widget's `selector` attribute
-* support event bubbling
+* The event must be of one of the events specified in the event catcher widget's `events` attribute
+* The event must target a DOM node with an ancestor that matches the widget's `selector` attribute
+* <<.from-version "5.2.2">> Optionally, the DOM node targetted by the event must also match the widgets `matchSelector` attribute
+* The event must support event bubbling
 
 Use of the event catcher widget is beneficial when using large numbers of other trigger widgets such as the ButtonWidget is causing performance problems. The workflow it enables is akin to what is referred to as "event delegation" in JavaScript parlance.
 
@@ -26,6 +27,7 @@ The content of the `<$eventcatcher>` widget is displayed normally.
 
 |!Attribute |!Description |
 |selector |A CSS selector. Only events originating inside a DOM node with this selector will be trapped |
+|matchSelector |<<.from-version "5.2.2">> An optional CSS selector. Only events targetting DOM nodes matching this selector will be trapped |
 |//{any attributes starting with $}// |<<.from-version "5.2.0">> Each attribute name (excluding the $) specifies the name of an event, and the value specifies the action string to be invoked. For example: `$click=<<clickActions>>`  |
 |tag |Optional. The HTML element the widget creates to capture the events, defaults to:<br>» `span` when parsed in inline-mode<br>» `div` when parsed in block-mode |
 |class |Optional. A CSS class name (or names) to be assigned to the widget HTML element |


### PR DESCRIPTION
This PR extends the eventcatcher widget with an optional new attribute to specify a "matchSelector" that must be matched by target DOM nodes in order for the event to be trapped. This makes it possible to selectively ignore events that occur within the descendent nodes of the root selector identified by the "selector" attribute.

