### PR TITLE
Add reference to Window in Widget base class for convenience

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -42,6 +42,7 @@ Widget.prototype.initialise = function(parseTreeNode,options) {
 	this.variablesConstructor.prototype = this.parentWidget ? this.parentWidget.variables : {};
 	this.variables = new this.variablesConstructor();
 	this.document = options.document;
+	this.window = this.document.parentWindow || this.document.defaultView;
 	this.attributes = {};
 	this.children = [];
 	this.domNodes = [];


### PR DESCRIPTION
This PR adds a reference to the Window object in the widget base class. This is convenient when writing widgets that should work in new window as well as the main window.