### PR TITLE
Support nested macro definitions

### DIFF
--- a/core/modules/parsers/wikiparser/rules/macrodef.js
+++ b/core/modules/parsers/wikiparser/rules/macrodef.js
@@ -27,7 +27,7 @@ Instantiate parse rule
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /^\\define\s+([^(\s]+)\(\s*([^)]*)\)(\s*\r?\n)?/mg;
+	this.matchRegExp = /^(\\+)define\s+([^(\s]+)\(\s*([^)]*)\)(\s*\r?\n)?/mg;
 };
 
 /*
@@ -37,7 +37,7 @@ exports.parse = function() {
 	// Move past the macro name and parameters
 	this.parser.pos = this.matchRegExp.lastIndex;
 	// Parse the parameters
-	var paramString = this.match[2],
+	var paramString = this.match[3],
 		params = [];
 	if(paramString !== "") {
 		var reParam = /\s*([A-Za-z0-9\-_]+)(?:\s*:\s*(?:"""([\s\S]*?)"""|"([^"]*)"|'([^']*)'|\[\[([^\]]*)\]\]|([^"'\s]+)))?/mg,
@@ -56,9 +56,9 @@ exports.parse = function() {
 	}
 	// Is this a multiline definition?
 	var reEnd;
-	if(this.match[3]) {
+	if(this.match[4]) {
 		// If so, the end of the body is marked with \end
-		reEnd = /(\r?\n\\end[^\S\n\r]*(?:$|\r?\n))/mg;
+		reEnd = new RegExp("(\\r?\\n" + $tw.utils.repeat("\\\\",this.match[1].length) + "end[^\\S\\n\\r]*(?:$|\\r?\\n))","mg");
 	} else {
 		// Otherwise, the end of the definition is marked by the end of the line
 		reEnd = /($|\r?\n)/mg;
@@ -80,7 +80,7 @@ exports.parse = function() {
 	return [{
 		type: "set",
 		attributes: {
-			name: {type: "string", value: this.match[1]},
+			name: {type: "string", value: this.match[2]},
 			value: {type: "string", value: text}
 		},
 		children: [],

--- a/core/modules/parsers/wikiparser/rules/macrodef.js
+++ b/core/modules/parsers/wikiparser/rules/macrodef.js
@@ -27,7 +27,7 @@ Instantiate parse rule
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /^(\\+)define\s+([^(\s]+)\(\s*([^)]*)\)(\s*\r?\n)?/mg;
+	this.matchRegExp = /^\\define\s+([^(\s]+)\(\s*([^)]*)\)(\s*\r?\n)?/mg;
 };
 
 /*
@@ -37,7 +37,7 @@ exports.parse = function() {
 	// Move past the macro name and parameters
 	this.parser.pos = this.matchRegExp.lastIndex;
 	// Parse the parameters
-	var paramString = this.match[3],
+	var paramString = this.match[2],
 		params = [];
 	if(paramString !== "") {
 		var reParam = /\s*([A-Za-z0-9\-_]+)(?:\s*:\s*(?:"""([\s\S]*?)"""|"([^"]*)"|'([^']*)'|\[\[([^\]]*)\]\]|([^"'\s]+)))?/mg,
@@ -56,9 +56,9 @@ exports.parse = function() {
 	}
 	// Is this a multiline definition?
 	var reEnd;
-	if(this.match[4]) {
+	if(this.match[3]) {
 		// If so, the end of the body is marked with \end
-		reEnd = new RegExp("(\\r?\\n" + $tw.utils.repeat("\\\\",this.match[1].length) + "end[^\\S\\n\\r]*(?:$|\\r?\\n))","mg");
+		reEnd = new RegExp("(\\r?\\n\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[1]) + ")?(?:$|\\r?\\n))","mg");
 	} else {
 		// Otherwise, the end of the definition is marked by the end of the line
 		reEnd = /($|\r?\n)/mg;
@@ -80,7 +80,7 @@ exports.parse = function() {
 	return [{
 		type: "set",
 		attributes: {
-			name: {type: "string", value: this.match[2]},
+			name: {type: "string", value: this.match[1]},
 			value: {type: "string", value: text}
 		},
 		children: [],

--- a/editions/test/tiddlers/tests/data/macros/NestedMacros.tid
+++ b/editions/test/tiddlers/tests/data/macros/NestedMacros.tid
@@ -10,23 +10,23 @@ title: Output
 \define outer()
 \whitespace trim
 
-\\define middle()
+\define middle()
 \whitespace trim
 
-\\\\define inner()
+\define inner()
 \whitespace trim
 
 Jaguar
 
-\\\\end
+\end inner
 
 <<inner>>
 
-\\end
+\end middle
 
 <<middle>>
 
-\end
+\end outer
 
 <<outer>>
 

--- a/editions/test/tiddlers/tests/data/macros/NestedMacros.tid
+++ b/editions/test/tiddlers/tests/data/macros/NestedMacros.tid
@@ -1,0 +1,36 @@
+title: Macros/NestedMacros
+description: Nested Macros
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+
+\define outer()
+\whitespace trim
+
+\\define middle()
+\whitespace trim
+
+\\\\define inner()
+\whitespace trim
+
+Jaguar
+
+\\\\end
+
+<<inner>>
+
+\\end
+
+<<middle>>
+
+\end
+
+<<outer>>
+
++
+title: ExpectedResult
+
+<p>Jaguar</p>

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -119,22 +119,6 @@ describe("WikiText parser tests", function() {
 		);
 	});
 
-	it("should parse macro definitions with two backslashes", function() {
-		expect(parse("\\\\define myMacro()\nnothing\n\\\\end\n")).toEqual(
-
-			[ { type : 'set', attributes : { name : { type : 'string', value : 'myMacro' }, value : { type : 'string', value : 'nothing' } }, children : [  ], params : [  ], isMacroDefinition : true } ]
-
-		);
-	});
-
-	it("should parse macro definitions with four backslashes", function() {
-		expect(parse("\\\\\\\\define myMacro()\nnothing\n\\\\\\\\end\n")).toEqual(
-
-			[ { type : 'set', attributes : { name : { type : 'string', value : 'myMacro' }, value : { type : 'string', value : 'nothing' } }, children : [  ], params : [  ], isMacroDefinition : true } ]
-
-		);
-	});
-
 	it("should parse comment in pragma area. Comment will be invisible", function() {
 		expect(parse("<!-- comment in pragma area -->\n\\define aMacro()\nnothing\n\\end\n")).toEqual(
 

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -119,6 +119,22 @@ describe("WikiText parser tests", function() {
 		);
 	});
 
+	it("should parse macro definitions with two backslashes", function() {
+		expect(parse("\\\\define myMacro()\nnothing\n\\\\end\n")).toEqual(
+
+			[ { type : 'set', attributes : { name : { type : 'string', value : 'myMacro' }, value : { type : 'string', value : 'nothing' } }, children : [  ], params : [  ], isMacroDefinition : true } ]
+
+		);
+	});
+
+	it("should parse macro definitions with four backslashes", function() {
+		expect(parse("\\\\\\\\define myMacro()\nnothing\n\\\\\\\\end\n")).toEqual(
+
+			[ { type : 'set', attributes : { name : { type : 'string', value : 'myMacro' }, value : { type : 'string', value : 'nothing' } }, children : [  ], params : [  ], isMacroDefinition : true } ]
+
+		);
+	});
+
 	it("should parse comment in pragma area. Comment will be invisible", function() {
 		expect(parse("<!-- comment in pragma area -->\n\\define aMacro()\nnothing\n\\end\n")).toEqual(
 

--- a/editions/tw5.com/tiddlers/wikitext/Macro Definitions in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Macro Definitions in WikiText.tid
@@ -1,13 +1,15 @@
 caption: Macro Definitions
 created: 20150220181617000
-modified: 20180820165115455
+modified: 20221022135909352
 tags: WikiText
 title: Macro Definitions in WikiText
 type: text/vnd.tiddlywiki
 
 A [[macro|Macros]] is defined using a `\define` [[pragma|Pragma]]. Like any pragma, this can only appear at the start of a tiddler.
 
-The first line of the definition specifies the macro name and any parameters. Each parameter has a name and, optionally, a default value that is used if no value is supplied on a particular call to the macro. The lines that follow contain the text of the macro text (i.e. the snippet represented by the macro name), until `\end` appears on a line by itself:
+The first line of the definition specifies the macro name and any parameters. Each parameter has a name and, optionally, a default value that is used if no value is supplied on a particular call to the macro.
+
+The lines that follow contain the text of the macro text (i.e. the snippet represented by the macro name), until `\end` appears on a line by itself:
 
 <$codeblock code={{$:/editions/tw5.com/macro-examples/say-hi}}/>
 
@@ -16,6 +18,20 @@ Alternatively, the entire definition can be presented on a single line without a
 ```
 \define sayhi(name:"Bugs Bunny") Hi, I'm $name$.
 ```
+
+Macro definitions can be nested by specifying the name of the macro in the `\end` marker. For example:
+
+<<wikitext-example-without-html src:"""\define special-button(caption:"Click me")
+\define actions()
+<$action-sendmessage $message="tm-notify" $param="HelloThere"/>
+\end actions
+<$button actions=<<actions>>>
+$caption$
+</$button>
+\end special-button
+
+<<special-button>>
+""">>
 
 A more formal [[presentation|Macro Definition Syntax]] of this syntax is also available.
 


### PR DESCRIPTION
### Introduction

It is common for macros to require further "sub-macros" for their operation. For example, here is an outline of a macro that renders a special button that uses a further macro to contain the action string:

```
\define actions()
<$action-sendmessage ... />
\end

\define special-button()
<$button actions=<<actions>>>
Caption
</$button>
\end
```

That should work fine in most situations, but a particularly pernicious case arises when the macros are made global by being tagged `$:/tags/Macro`. The problem then is that not only does `special-button` get exposed as a global variable, so does the `actions` macro. That means that the `<<special-button>>` macro would not work correctly if it was invoked in a context where the variable `actions` has been redefined. For example:

### Proposal

It is proposed to extend the macro definition syntax to allow the macro name to be specified after the `\end` keyword. When parsing a macro, the end marker is taken to be whichever is found first of an empty `\end` marker or a matching `\end <macroname>` marker.

This makes it possible to nest macros inside one another, completely hiding the nested definitions from the outside world.

The example above could instead be written as:

```
\define special-button()
\define actions()
<$action-sendmessage ... />
\end actions
<$button actions=<<actions>>>
Caption
</$button>
\end special-button
```

Note that the following example does not nest as expected because when parsing the parent definition it will find the first `\end` marker and use that as the terminator:

```
\define parent ( )
 commands, comments, ...
 \define child ()
    ....
 \end
 ....
\end
```

In other words, when nesting macro definitions, only the innermost macro definition can omit the macro name from the `\end` marker.

### To do

- [x] Documentation