### PR TITLE
Fixes for JSON operators

### DIFF
--- a/editions/prerelease/tiddlers/Release 5.2.4.tid
+++ b/editions/prerelease/tiddlers/Release 5.2.4.tid
@@ -19,7 +19,7 @@ New [ext[Twitter Archivist|./editions/twitter-archivist]] plugin to import the t
 
 <<.link-badge-added "https://github.com/Jermolene/TiddlyWiki5/pull/6961">> new GenesisWidget that allows the dynamic construction of another widget, where the name and attributes of the new widget can be dynamically determined, without needing to be known in advance
 
-<<.link-badge-added "https://github.com/Jermolene/TiddlyWiki5/pull/6936">> new operators for reading and formatting JSON data: [[jsonget Operator]], [[jsonindexes Operator]], [[jsontype Operator]] and [[format Operator]]
+<<.link-badge-added "https://github.com/Jermolene/TiddlyWiki5/pull/6936">> new operators for reading and formatting JSON data: [[jsonget Operator]], [[jsonindexes Operator]], [[jsontype Operator]], [[jsonextract Operator]] and [[format Operator]]
 
 ! Translation improvement
 

--- a/editions/test/tiddlers/tests/test-json-filters.js
+++ b/editions/test/tiddlers/tests/test-json-filters.js
@@ -23,7 +23,7 @@ describe("json filter tests", function() {
 		type: "application/json"
 	},{
 		title: "Second",
-		text: '["une","deux","trois"]',
+		text: '["une","deux","trois",["quatre","cinq"]]',
 		type: "application/json"
 	},{
 		title: "Third",
@@ -38,14 +38,14 @@ describe("json filter tests", function() {
 
 	it("should support the jsonget operator", function() {
 		expect(wiki.filterTiddlers("[{Third}jsonget[]]")).toEqual(["This is not JSON"]);
-		expect(wiki.filterTiddlers("[{First}jsonget[]]")).toEqual(['{"a":"one","b":"","c":1.618,"d":{"e":"four","f":["five","six",true,false,null]}}']);
+		expect(wiki.filterTiddlers("[{Second}jsonget[]]")).toEqual(["une","deux","trois","quatre","cinq"]);
+		expect(wiki.filterTiddlers("[{First}jsonget[]]")).toEqual(["one","","1.618","four","five","six","true","false","null"]);
 		expect(wiki.filterTiddlers("[{First}jsonget[a]]")).toEqual(["one"]);
 		expect(wiki.filterTiddlers("[{First}jsonget[b]]")).toEqual([""]);
 		expect(wiki.filterTiddlers("[{First}jsonget[missing-property]]")).toEqual([]);
-		expect(wiki.filterTiddlers("[{First}jsonget[d]]")).toEqual(['{"e":"four","f":["five","six",true,false,null]}']);
-		expect(wiki.filterTiddlers("[{First}jsonget[d]jsonget[f]]")).toEqual(['["five","six",true,false,null]']);
+		expect(wiki.filterTiddlers("[{First}jsonget[d]]")).toEqual(["four","five","six","true","false","null"]);
 		expect(wiki.filterTiddlers("[{First}jsonget[d],[e]]")).toEqual(["four"]);
-		expect(wiki.filterTiddlers("[{First}jsonget[d],[f]]")).toEqual(['["five","six",true,false,null]']);
+		expect(wiki.filterTiddlers("[{First}jsonget[d],[f]]")).toEqual(["five","six","true","false","null"]);
 		expect(wiki.filterTiddlers("[{First}jsonget[d],[f],[0]]")).toEqual(["five"]);
 		expect(wiki.filterTiddlers("[{First}jsonget[d],[f],[1]]")).toEqual(["six"]);
 		expect(wiki.filterTiddlers("[{First}jsonget[d],[f],[2]]")).toEqual(["true"]);
@@ -53,8 +53,25 @@ describe("json filter tests", function() {
 		expect(wiki.filterTiddlers("[{First}jsonget[d],[f],[4]]")).toEqual(["null"]);
 	});
 
+	it("should support the jsonextract operator", function() {
+		expect(wiki.filterTiddlers("[{Third}jsonextract[]]")).toEqual(['"This is not JSON"']);
+		expect(wiki.filterTiddlers("[{First}jsonextract[]]")).toEqual(['{"a":"one","b":"","c":1.618,"d":{"e":"four","f":["five","six",true,false,null]}}']);
+		expect(wiki.filterTiddlers("[{First}jsonextract[a]]")).toEqual(['"one"']);
+		expect(wiki.filterTiddlers("[{First}jsonextract[b]]")).toEqual(['""']);
+		expect(wiki.filterTiddlers("[{First}jsonextract[missing-property]]")).toEqual([]);
+		expect(wiki.filterTiddlers("[{First}jsonextract[d]]")).toEqual(['{"e":"four","f":["five","six",true,false,null]}']);
+		expect(wiki.filterTiddlers("[{First}jsonextract[d]jsonextract[f]]")).toEqual(['["five","six",true,false,null]']);
+		expect(wiki.filterTiddlers("[{First}jsonextract[d],[e]]")).toEqual(['"four"']);
+		expect(wiki.filterTiddlers("[{First}jsonextract[d],[f]]")).toEqual(['["five","six",true,false,null]']);
+		expect(wiki.filterTiddlers("[{First}jsonextract[d],[f],[0]]")).toEqual(['"five"']);
+		expect(wiki.filterTiddlers("[{First}jsonextract[d],[f],[1]]")).toEqual(['"six"']);
+		expect(wiki.filterTiddlers("[{First}jsonextract[d],[f],[2]]")).toEqual(["true"]);
+		expect(wiki.filterTiddlers("[{First}jsonextract[d],[f],[3]]")).toEqual(["false"]);
+		expect(wiki.filterTiddlers("[{First}jsonextract[d],[f],[4]]")).toEqual(["null"]);
+	});
+
 	it("should support the jsonindexes operator", function() {
-		expect(wiki.filterTiddlers("[{Second}jsonindexes[]]")).toEqual(["0","1","2"]);
+		expect(wiki.filterTiddlers("[{Second}jsonindexes[]]")).toEqual(["0","1","2","3"]);
 		expect(wiki.filterTiddlers("[{First}jsonindexes[]]")).toEqual(["a","b","c","d"]);
 		expect(wiki.filterTiddlers("[{First}jsonindexes[a]]")).toEqual([]);
 		expect(wiki.filterTiddlers("[{First}jsonindexes[b]]")).toEqual([]);

--- a/editions/tw5.com/tiddlers/features/JSON in TiddlyWiki.tid
+++ b/editions/tw5.com/tiddlers/features/JSON in TiddlyWiki.tid
@@ -2,7 +2,7 @@ title: JSON in TiddlyWiki
 tags: Features
 type: text/vnd.tiddlywiki
 created: 20220427174702859
-modified: 20220427174702859
+modified: 20220611104737314
 
 !! Introduction
 

--- a/editions/tw5.com/tiddlers/filters/jsonextract.tid
+++ b/editions/tw5.com/tiddlers/filters/jsonextract.tid
@@ -1,20 +1,20 @@
 created: 20220611104737314
 modified: 20220611104737314
 tags: [[Filter Operators]] [[JSON Operators]]
-title: jsonindexes Operator
-caption: jsonindexes
-op-purpose: retrieve the value of a property from JSON strings
+title: jsonextract Operator
+caption: jsonextract
+op-purpose: retrieve the JSON string of a property from JSON strings
 op-input: a selection of JSON strings
 op-parameter: one or more indexes of the property to retrieve
-op-output: the values of each of the retrieved properties
+op-output: the JSON string values of each of the retrieved properties
 
 <<.from-version "5.2.4">> See [[JSON in TiddlyWiki]] for background.
 
-The <<.op jsonindexes>> operator is used to retrieve the property names of JSON objects or the index names of JSON arrays. See also the following related operators:
+The <<.op jsonextract>> operator is used to retrieve values from JSON data as JSON substrings. See also the following related operators:
 
 * <<.olink jsonget>> to retrieve the values of a property in JSON data
 * <<.olink jsontype>> to retrieve the type of a JSON value
-* <<.olink jsonextract>> to retrieve a JSON value as a string of JSON
+* <<.olink jsonindexes>> to retrieve the names of the fields of a JSON object, or the indexes of a JSON array
 
 Properties within a JSON object are identified by a sequence of indexes. In the following example, the value at `[a]` is `one`, and the value at `[d][f][0]` is `five`.
 
@@ -43,23 +43,24 @@ Properties within a JSON object are identified by a sequence of indexes. In the 
 
 The following examples assume that this JSON data is contained in a variable called `jsondata`.
 
-The <<.op jsonindexes>> operator uses multiple operands to specify the indexes of the property to retrieve:
+The <<.op jsonextract>> operator uses multiple operands to specify the indexes of the property to retrieve. Values are returned as literal JSON strings:
 
 ```
-[<jsondata>jsonindexes[d],[f]] --> "0", "1", "2", "3", "4"
-[<jsondata>jsonindexes[d],[g]] --> "x", "y", "z"
+[<jsondata>jsonextract[a]] --> "one"
+[<jsondata>jsonextract[d],[e]] --> "four"
+[<jsondata>jsonextract[d],[f],[0]] --> "five"
+[<jsondata>jsonextract[d],[f]] --> ["five","six",true,false,null]
+[<jsondata>jsonextract[d],[g]] --> {"x":"max","y":"may","z":"maize"}
 ```
 
 Indexes can be dynamically composed from variables and transclusions:
 
 ```
-[<jsondata>jsonindexes<variable>,{!!field}]
+[<jsondata>jsonextract<variable>,{!!field},[0]]
 ```
-
-Retrieving the indexes of JSON properties that are not objects or arrays will return nothing.
 
 A subtlety is that the special case of a single blank operand is used to identify the root object. Thus:
 
 ```
-[<jsondata>jsonindexes[]] --> "a", "b", "c", "d"
+[<jsondata>jsonextract[]] --> {"a":"one","b":"","c":"three","d":{"e":"four","f":["five","six",true,false,null],"g":{"x":"max","y":"may","z":"maize"}}}
 ```

--- a/editions/tw5.com/tiddlers/filters/jsonget.tid
+++ b/editions/tw5.com/tiddlers/filters/jsonget.tid
@@ -10,10 +10,11 @@ op-output: the values of each of the retrieved properties
 
 <<.from-version "5.2.4">> See [[JSON in TiddlyWiki]] for background.
 
-The <<.op jsonget>> operator is used to retrieve values from JSON data. See also the following related operators:
+The <<.op jsonget>> operator is used to retrieve values from JSON data as strings. See also the following related operators:
 
 * <<.olink jsontype>> to retrieve the type of a JSON value
 * <<.olink jsonindexes>> to retrieve the names of the fields of a JSON object, or the indexes of a JSON array
+* <<.olink jsonextract>> to retrieve a JSON value as a string of JSON
 
 Properties within a JSON object are identified by a sequence of indexes. In the following example, the value at `[a]` is `one`, and the value at `[d][f][0]` is `five`.
 
@@ -65,11 +66,11 @@ Boolean values and null are returned as normal strings. The <<.olink jsontype>> 
 [<jsondata>jsontype[d],[f],[2]] --> "boolean"
 ```
 
-Using the <<.op jsonget>> operator to retrieve an object or an array returns a JSON string of the values. For example:
+Using the <<.op jsonget>> operator to retrieve an object or an array returns a list of the values. For example:
 
 ```
-[<jsondata>jsonget[d],[f]] --> `["five","six",true,false,null]`
-[<jsondata>jsonget[d],[g]] --> `{"x": "max","y": "may","z": "maize"}`
+[<jsondata>jsonget[d],[f]] --> "five","six","true","false","null"
+[<jsondata>jsonget[d],[g]] --> "max","may","maize"
 ```
 
 The <<.olink jsonindexes>> operator retrieves the corresponding indexes:
@@ -77,6 +78,12 @@ The <<.olink jsonindexes>> operator retrieves the corresponding indexes:
 ```
 [<jsondata>jsonindexes[d],[f]] --> "0", "1", "2", "3", "4"
 [<jsondata>jsonindexes[d],[g]] --> "x", "y", "z"
+```
+
+If the object or array contains nested child objects or arrays then the values are retrieved recursively and returned flattened into a list. For example:
+
+```
+[<jsondata>jsonget[d]] --> "four","five","six","true","false","null","max","may","maize"
 ```
 
 A subtlety is that the special case of a single blank operand is used to identify the root object. Thus:

--- a/editions/tw5.com/tiddlers/filters/jsontype.tid
+++ b/editions/tw5.com/tiddlers/filters/jsontype.tid
@@ -14,6 +14,7 @@ The <<.op jsontype>> operator is used to retrieve the type of a property in JSON
 
 * <<.olink jsonget>> to retrieve the values of a property in JSON data
 * <<.olink jsonindexes>> to retrieve the names of the fields of a JSON object, or the indexes of a JSON array
+* <<.olink jsonextract>> to retrieve a JSON value as a string of JSON
 
 JSON supports the following data types:
 

--- a/editions/tw5.com/tiddlers/howtos/Reading data from JSON tiddlers.tid
+++ b/editions/tw5.com/tiddlers/howtos/Reading data from JSON tiddlers.tid
@@ -1,10 +1,19 @@
 created: 20220427174702859
-modified: 20220427171449102
+modified: 20220611104737314
 tags: [[JSON in TiddlyWiki]] Learning
 title: Reading data from JSON tiddlers
 type: text/vnd.tiddlywiki
 
 See [[JSON in TiddlyWiki]] for an overview of using JSON in TiddlyWiki.
+
+!! Filter Operators for Accessing JSON Data
+
+The following filter operators allow values to be read from JSON data:
+
+* <<.olink jsonget>> to retrieve the values of a property in JSON data
+* <<.olink jsontype>> to retrieve the type of a JSON value
+* <<.olink jsonindexes>> to retrieve the names of the fields of a JSON object, or the indexes of a JSON array
+* <<.olink jsonextract>> to retrieve a JSON value as a string of JSON
 
 !! Text References for Accessing JSON Data
 


### PR DESCRIPTION
This PR fixes an issue with the `jsonget` operator where previously it was inconsistent whether the operator returned JSON substrings or usable strings. With this PR, the new `jsonextract` operator is used for extracting JSON substrings and the `jsonget` operator is reserved for returning usable strings.
