### PR TITLE
Add a configurable `$messagecatcher` to the PageTemplate and go back in history upon close/delete

### DIFF
--- a/core/ui/PageTemplate.tid
+++ b/core/ui/PageTemplate.tid
@@ -19,6 +19,10 @@ icon: $:/core/images/layout-button
 
 <$navigator story="$:/StoryList" history="$:/HistoryList" openLinkFromInsideRiver={{$:/config/Navigation/openLinkFromInsideRiver}} openLinkFromOutsideRiver={{$:/config/Navigation/openLinkFromOutsideRiver}} relinkOnRename={{$:/config/RelinkOnRename}}>
 
+<$genesis $type="$messagecatcher" 
+          $names="[all[shadows+tiddlers]tag[$:/tags/PageTemplateMessageHandler]!is[draft]has[message]get[message]addprefix[$]]"
+          $values="[all[shadows+tiddlers]tag[$:/tags/PageTemplateMessageHandler]!is[draft]has[message]get[text]]">
+
 <$dropzone enable=<<tv-enable-drag-and-drop>>>
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/PageTemplate]!has[draft.of]]" variable="listItem">
@@ -28,6 +32,8 @@ icon: $:/core/images/layout-button
 </$list>
 
 </$dropzone>
+
+</$genesis>
 
 </$navigator>
 

--- a/core/ui/PageTemplate/MessageHandler/tm-close-tiddler.tid
+++ b/core/ui/PageTemplate/MessageHandler/tm-close-tiddler.tid
@@ -1,0 +1,18 @@
+message: tm-close-tiddler
+tags: $:/tags/PageTemplateMessageHandler
+title: $:/core/ui/PageTemplate/MessageHandler/tm-close-tiddler
+
+\define navigate-and-forward()
+<$let targetTiddler={{{ [<event-param>!is[blank]else<event-tiddlerTitle>] }}} history={{{ [<tv-history-list>get[text]] }}}>
+	<$list filter="[<tv-history-list>get[current-tiddler]match<targetTiddler>]" variable="void">
+		<!-- go the the last tiddler in history which is also currently open, and if none are found then to the previous / next tiddler in the story -->
+		<$let previousItem={{{ [<history>jsonindexes[]] :map[<history>jsonget<currentTiddler>,[title]] :intersection[list<tv-story-list>] +[!match<targetTiddler>reverse[]first[]] :else[list<tv-story-list>before<targetTiddler>] :else[list<tv-story-list>after<targetTiddler>] }}}>
+			<$action-navigate $to=<<previousItem>> />
+		</$let>
+	</$list>
+	<!-- forward the original message -->
+	<$action-sendmessage $message=<<event-type>> $param=<<targetTiddler>> />
+</$let>
+\end
+
+<<navigate-and-forward>>

--- a/core/ui/PageTemplate/MessageHandler/tm-delete-tiddler.tid
+++ b/core/ui/PageTemplate/MessageHandler/tm-delete-tiddler.tid
@@ -1,0 +1,7 @@
+message: tm-delete-tiddler
+tags: $:/tags/PageTemplateMessageHandler
+title: $:/core/ui/PageTemplate/MessageHandler/tm-delete-tiddler
+
+\import [[$:/core/ui/PageTemplate/MessageHandler/tm-close-tiddler]]
+
+<<navigate-and-forward>>

--- a/core/ui/PageTemplate/MessageHandler/tm-delete-tiddler.tid
+++ b/core/ui/PageTemplate/MessageHandler/tm-delete-tiddler.tid
@@ -2,6 +2,21 @@ message: tm-delete-tiddler
 tags: $:/tags/PageTemplateMessageHandler
 title: $:/core/ui/PageTemplate/MessageHandler/tm-delete-tiddler
 
-\import [[$:/core/ui/PageTemplate/MessageHandler/tm-close-tiddler]]
+\define navigate-and-forward()
+\define tv-action-refresh-policy() always
+<$let targetTiddler={{{ [<event-param>!is[blank]else<event-tiddlerTitle>] }}} history={{{ [<tv-history-list>get[text]] }}}>
+    <!-- forward the original message -->
+    <$action-sendmessage $message=<<event-type>> $param=<<targetTiddler>> />
+    <!-- only go back to previous tiddler if delete was not canceled -->
+    <$list filter="[<targetTiddler>!is[tiddler]]" variable="void">
+        <$list filter="[<tv-history-list>get[current-tiddler]match<targetTiddler>]" variable="void">
+            <!-- go the the last tiddler in history which is also currently open, and if none are found then to the previous / next tiddler in the story -->
+            <$let previousItem={{{ [<history>jsonindexes[]] :map[<history>jsonget<currentTiddler>,[title]] :intersection[list<tv-story-list>] +[!match<targetTiddler>reverse[]first[]] :else[list<tv-story-list>before<targetTiddler>] :else[list<tv-story-list>after<targetTiddler>] }}}>
+                <$action-navigate $to=<<previousItem>> />
+            </$let>
+        </$list>
+	  </$list>
+</$let>
+\end
 
 <<navigate-and-forward>>


### PR DESCRIPTION
I want to use the vercel preview of this draft PR to see how it feels with classic storyview and in general.

This PR will add a conditional `$messagecatcher` just inside the `$navigator` in the PageTemplate. Only if any tiddlers with the tag `$:/tags/PageTemplateMessageHandler` exist, the catcher is generated by `$genesis` and assigns the actions in those tiddlers to the messages they correspond to (via the `message` field). Otherwise there will be no difference to a vanilla TW.

I have also added two such message handlers for `tm-close-tiddler` and `tm-delete-tiddler`, which navigate to the last tiddler in the HistoryList that is also currently in the StoryList. If none are found, the preceding tiddler in the story is navigated to, and if there is none then the succeeding tiddler. These last two navigation actions are needed in a single-tiddler story view (which is based on the `current-tiddler` field of the HistoryList) to keep the `current-tiddler` field current.

The action of these handler tiddlers would later be controlled via a ControlPanel setting, which allows to switch between the back-in-history or current (default) behavior. I'm not sure how this would be best implemented, though.

Resolves #7262 