### PR TITLE
Add initial TiddlyWiki Dockerfile and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Adapted from: https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile
+
+ARG NODE_LTS_VERSION=18
+
+FROM node:${NODE_LTS_VERSION}-alpine
+
+ARG TIDDLYWIKI_VERSION=5.2.7
+ARG TIDDLYWIKI_DATA_DIR=/tiddlywiki
+ARG TIDDLYWIKI_PORT=8080
+
+# https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#handling-kernel-signals
+RUN apk add --no-cache tini
+RUN npm install -g tiddlywiki@${TIDDLYWIKI_VERSION}
+
+EXPOSE ${TIDDLYWIKI_PORT}
+
+VOLUME ${TIDDLYWIKI_DATA_DIR}
+WORKDIR ${TIDDLYWIKI_DATA_DIR}
+
+ENTRYPOINT ["/sbin/tini", "--", "tiddlywiki"]
+CMD ["--help"]

--- a/editions/tw5.com/tiddlers/docker/Using TiddlyWiki with Docker.tid
+++ b/editions/tw5.com/tiddlers/docker/Using TiddlyWiki with Docker.tid
@@ -1,0 +1,39 @@
+created: 20230403211230516
+modified: 20230403211230516
+tags: [[TiddlyWiki with Docker]]
+title: Using TiddlyWiki with Docker
+type: text/vnd.tiddlywiki
+
+~TiddlyWiki5 can also be run using Docker. See the [[Dockerfile]] for details.
+
+The image can be built using the following command in the root of the TiddlyWiki git repo:
+```
+docker build --tag tiddlywiki .
+```
+
+It can be run like so:
+```
+# Create a data directory
+mkdir ~/tiddlywiki
+
+# Initialize the data directory
+docker run \
+    --rm \
+    --name tiddlywiki \
+    --volume ~/tiddlywiki:/tiddlywiki \
+    tiddlywiki \
+    mynewwiki --init server
+
+# Start the server with custom arguments
+docker run \
+    --rm \
+    --name tiddlywiki \
+    --volume ~/tiddlywiki:/tiddlywiki \
+    --publish 8080:8080 \
+    tiddlywiki \
+    mynewwiki --listen host=0.0.0.0 port=8080 "readers=(anon)" "writers=(authenticated)" admin=noah username=noah password=noah
+```
+
+If you'd prefer a pre-built image, there is a community-maintained image on Docker Hub: https://hub.docker.com/r/elasticdog/tiddlywiki/
+
+See [[Commands]] for a full listing of the available commands.

--- a/editions/tw5.com/tiddlers/readme/ReadMe.tid
+++ b/editions/tw5.com/tiddlers/readme/ReadMe.tid
@@ -32,6 +32,10 @@ Developer documentation is in progress at https://tiddlywiki.com/dev/
 
 {{Upgrading TiddlyWiki on Node.js}}
 
+! Using TiddlyWiki with Docker
+
+{{Using TiddlyWiki with Docker}}
+
 ! Also see
 
 <<list-links "[tag[TiddlyWiki on Node.js]] -[[Installing TiddlyWiki on Node.js]] -[[Using TiddlyWiki on Node.js]] -[[Upgrading TiddlyWiki on Node.js]]">>


### PR DESCRIPTION
Resolves https://github.com/Jermolene/TiddlyWiki5/issues/7387

I'm still not super familiar with TiddlyWiki (especially the documentation format and how to run it securely with auth), so let me know if I need to update the docs I wrote. 😅 

One other question for you Jeremy: Do you want to publish this to Docker Hub under an "official" TiddlyWiki org? Similar to https://hub.docker.com/r/elasticdog/tiddlywiki. I wouldn't be able to do those parts, but I could guide you through them if needed.

The other option is to just require users to build their own images for TiddlyWiki.

Let me know what you think. 😄 