### PR TITLE
Switch off CamelCase linking by default

### DIFF
--- a/core/modules/parsers/wikiparser/rules/wikilinkprefix.js
+++ b/core/modules/parsers/wikiparser/rules/wikilinkprefix.js
@@ -1,0 +1,40 @@
+/*\
+title: $:/core/modules/parsers/wikiparser/rules/wikilinkprefix.js
+type: application/javascript
+module-type: wikirule
+
+Wiki text inline rule for suppressed wiki links. For example:
+
+```
+~SuppressedLink
+```
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.name = "wikilinkprefix";
+exports.types = {inline: true};
+
+exports.init = function(parser) {
+	this.parser = parser;
+	// Regexp to match
+	this.matchRegExp = new RegExp($tw.config.textPrimitives.unWikiLink + $tw.config.textPrimitives.wikiLink,"mg");
+};
+
+/*
+Parse the most recent match
+*/
+exports.parse = function() {
+	// Get the details of the match
+	var linkText = this.match[0];
+	// Move past the wikilink
+	this.parser.pos = this.matchRegExp.lastIndex;
+	// Return the link without unwikilink character as plain text
+	return [{type: "text", text: linkText.substr(1)}];
+};
+
+})();

--- a/core/wiki/config/wikilink.tid
+++ b/core/wiki/config/wikilink.tid
@@ -1,3 +1,3 @@
 title: $:/config/WikiParserRules/Inline/wikilink
 
-enable
+disable

--- a/editions/dev/tiddlers/system/configWikiParserRulesInlineWikilink.tid
+++ b/editions/dev/tiddlers/system/configWikiParserRulesInlineWikilink.tid
@@ -1,0 +1,3 @@
+title: $:/config/WikiParserRules/Inline/wikilink
+
+enable

--- a/editions/prerelease/tiddlers/Release 5.3.0.tid
+++ b/editions/prerelease/tiddlers/Release 5.3.0.tid
@@ -30,6 +30,10 @@ These changes lay the groundwork for macros and related features to be deprecate
 
 The new transclusion architecture is not by itself sufficient to enable us to fully deprecate macros yet. To handle the remaining use cases we propose a new backtick quoted attribute format that allows for the substitution of variable values. See https://github.com/Jermolene/TiddlyWiki5/issues/6663 for details.
 
+! Defaulting to Disabling CamelCase Links
+
+<<.link-badge-updated "https://github.com/Jermolene/TiddlyWiki5/pull/7513">> CamelCase linking is now disabled by default. (Note that this wiki has CamelCase linking explicitly enabled)
+
 ! Plugin Improvements
 
 * <<.link-badge-extended "https://github.com/Jermolene/TiddlyWiki5/pull/7260">> Dynannotate pugin to support three additional search modes

--- a/editions/prerelease/tiddlers/system/configWikiParserRulesInlineWikilink.tid
+++ b/editions/prerelease/tiddlers/system/configWikiParserRulesInlineWikilink.tid
@@ -1,0 +1,3 @@
+title: $:/config/WikiParserRules/Inline/wikilink
+
+enable

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -99,14 +99,14 @@ Tests the filtering mechanism.
 				},
 				"TiddlerSix": {
 					title: "TiddlerSix",
-					text: "Missing inaction from TiddlerOne",
+					text: "Missing inaction from [[TiddlerOne]]",
 					filter: "[[one]] [[a a]] [subfilter{hasList!!list}]",
 					tags: []
 				},
 				"TiddlerSeventh": {
 					title: "TiddlerSeventh",
 					text: "",
-					list: "TiddlerOne [[Tiddler Three]] [[a fourth tiddler]] MissingTiddler",
+					list: "[[TiddlerOne]] [[Tiddler Three]] [[a fourth tiddler]] [[MissingTiddler]]",
 					tags: ["one"]
 				},
 				"Tiddler8": {
@@ -144,7 +144,7 @@ Tests the filtering mechanism.
 			modified: "201304152211"
 		},{
 			title: "Tiddler Three",
-			text: "The speed of sound in light\n\nThere is no TiddlerZero but TiddlerSix",
+			text: "The speed of sound in light\n\nThere is no [[TiddlerZero]] but [[TiddlerSix]]",
 			tags: ["one","two"],
 			cost: "56",
 			value: "80",
@@ -252,9 +252,9 @@ Tests the filtering mechanism.
 		});
 	
 		it("should handle the lookup operator", function() {
-			expect(wiki.filterTiddlers("Six Seventh 8 +[lookup[Tiddler]]").join(",")).toBe("Missing inaction from TiddlerOne,,Tidd");
-			expect(wiki.filterTiddlers("Six Seventh 8 +[lookup:8[Tiddler]]").join(",")).toBe("Missing inaction from TiddlerOne,8,Tidd");
-			expect(wiki.filterTiddlers("Six Seventh 8 +[lookup:8[Tiddler],[text]]").join(",")).toBe("Missing inaction from TiddlerOne,8,Tidd");
+			expect(wiki.filterTiddlers("Six Seventh 8 +[lookup[Tiddler]]").join(",")).toBe("Missing inaction from [[TiddlerOne]],,Tidd");
+			expect(wiki.filterTiddlers("Six Seventh 8 +[lookup:8[Tiddler]]").join(",")).toBe("Missing inaction from [[TiddlerOne]],8,Tidd");
+			expect(wiki.filterTiddlers("Six Seventh 8 +[lookup:8[Tiddler],[text]]").join(",")).toBe("Missing inaction from [[TiddlerOne]],8,Tidd");
 			expect(wiki.filterTiddlers("Six Seventh 8 +[lookup[Tiddler],[tags]]").join(",")).toBe(",one,one");
 		});
 	
@@ -990,10 +990,10 @@ Tests the filtering mechanism.
 			expect(wiki.filterTiddlers("[!sortsub:number<sort1>]",anchorWidget).join(",")).toBe("filter regexp test,a fourth tiddler,$:/ShadowPlugin,$:/TiddlerTwo,Tiddler Three,has filter,TiddlerOne,hasList,one");
 			expect(wiki.filterTiddlers("[sortsub:string<sort1>]",anchorWidget).join(",")).toBe("has filter,TiddlerOne,$:/TiddlerTwo,Tiddler Three,$:/ShadowPlugin,a fourth tiddler,filter regexp test,one,hasList");
 			expect(wiki.filterTiddlers("[!sortsub:string<sort1>]",anchorWidget).join(",")).toBe("hasList,one,filter regexp test,a fourth tiddler,$:/ShadowPlugin,$:/TiddlerTwo,Tiddler Three,has filter,TiddlerOne");
-			expect(wiki.filterTiddlers("[sortsub:number<sort2>]",anchorWidget).join(",")).toBe("one,TiddlerOne,hasList,has filter,a fourth tiddler,Tiddler Three,$:/TiddlerTwo,filter regexp test,$:/ShadowPlugin");
-			expect(wiki.filterTiddlers("[!sortsub:number<sort2>]",anchorWidget).join(",")).toBe("$:/ShadowPlugin,filter regexp test,$:/TiddlerTwo,Tiddler Three,a fourth tiddler,has filter,hasList,TiddlerOne,one");
-			expect(wiki.filterTiddlers("[sortsub:string<sort2>]",anchorWidget).join(",")).toBe("one,TiddlerOne,hasList,has filter,$:/ShadowPlugin,a fourth tiddler,Tiddler Three,$:/TiddlerTwo,filter regexp test");
-			expect(wiki.filterTiddlers("[!sortsub:string<sort2>]",anchorWidget).join(",")).toBe("filter regexp test,$:/TiddlerTwo,Tiddler Three,a fourth tiddler,$:/ShadowPlugin,has filter,hasList,TiddlerOne,one");
+			expect(wiki.filterTiddlers("[sortsub:number<sort2>]",anchorWidget).join(",")).toBe("one,TiddlerOne,hasList,has filter,a fourth tiddler,$:/TiddlerTwo,Tiddler Three,filter regexp test,$:/ShadowPlugin");
+			expect(wiki.filterTiddlers("[!sortsub:number<sort2>]",anchorWidget).join(",")).toBe("$:/ShadowPlugin,filter regexp test,Tiddler Three,$:/TiddlerTwo,a fourth tiddler,has filter,hasList,TiddlerOne,one");
+			expect(wiki.filterTiddlers("[sortsub:string<sort2>]",anchorWidget).join(",")).toBe("one,TiddlerOne,hasList,has filter,$:/ShadowPlugin,a fourth tiddler,$:/TiddlerTwo,Tiddler Three,filter regexp test");
+			expect(wiki.filterTiddlers("[!sortsub:string<sort2>]",anchorWidget).join(",")).toBe("filter regexp test,Tiddler Three,$:/TiddlerTwo,a fourth tiddler,$:/ShadowPlugin,has filter,hasList,TiddlerOne,one");
 			expect(wiki.filterTiddlers("[[TiddlerOne]] [[$:/TiddlerTwo]] [[Tiddler Three]] [[a fourth tiddler]] +[!sortsub:number<sort3>]",anchorWidget).join(",")).toBe("$:/TiddlerTwo,Tiddler Three,TiddlerOne,a fourth tiddler");
 			expect(wiki.filterTiddlers("a1 a10 a2 a3 b10 b3 b1 c9 c11 c1 +[sortsub:alphanumeric<sort4>]",anchorWidget).join(",")).toBe("a1,a2,a3,a10,b1,b3,b10,c1,c9,c11");
 			// #7155. The order of the output is the same as the input when an undefined variable is used in the subfitler

--- a/editions/test/tiddlers/tests/test-wikitext.js
+++ b/editions/test/tiddlers/tests/test-wikitext.js
@@ -45,16 +45,6 @@ describe("WikiText tests", function() {
 	it("should support attributes specified as macro invocations", function() {
 		expect(wiki.renderTiddler("text/html","TiddlerFour")).toBe("<p><a class=\"tc-tiddlylink tc-tiddlylink-missing\" href=\"#This%20is%20my%20%27%27amazingly%27%27%20groovy%20macro%21\">This is a link</a></p>");
 	});
-	it("should identify wikiwords to automatically link", function() {
-		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","No wikilinks here").indexOf("<a") !== -1).toBe(false);
-		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","One WikiLink here").indexOf("<a") !== -1).toBe(true);
-		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","No Wiki-Link here").indexOf("<a") !== -1).toBe(false);
-		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","No Wiki×Link here").indexOf("<a") !== -1).toBe(false);
-		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","No Wiki÷Link here").indexOf("<a") !== -1).toBe(false);
-		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","No xWikiLink here").indexOf("<a") !== -1).toBe(false);
-		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","No -WikiLink here").indexOf("<a") !== -1).toBe(false);
-		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","No _WikiLink here").indexOf("<a") !== -1).toBe(false);
-	});
 	it("handles style wikitext notation", function() {
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@.myclass\n!header\n@@")).toBe("<h1 class=\"myclass\">header</h1>");
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@.myclass\n<div>\n\nContent</div>\n@@")).toBe("<div class=\"myclass\"><p>Content</p></div>");

--- a/editions/tw5.com/tiddlers/system/configWikiParserRulesInlineWikilink.tid
+++ b/editions/tw5.com/tiddlers/system/configWikiParserRulesInlineWikilink.tid
@@ -1,0 +1,3 @@
+title: $:/config/WikiParserRules/Inline/wikilink
+
+enable


### PR DESCRIPTION
It is proposed to switch CamelCase linking off by default for v5.3.0. The rationale is that CamelCase linking is confusing for new users and is not widely used.

As well as disabling the CamelCase parse rule by default, this PR includes a new parse rule that matches suppressed CamelCase links (eg `~TiddlyWiki`), and renders them as plain text without the tilde character.

Note that for backwards compatibility CamelCase linking is currently explicitly switched on for the documentation editions such as `tw5.com` and `dev`. 

