### PR TITLE
Fix tiddler icon size

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1173,8 +1173,8 @@ button.tc-btn-invisible.tc-remove-tag-button {
 }
 
 .tc-tiddler-title-icon svg {
-	width: 0.75em;
-	height: 0.75em;
+	width: 0.9em;
+	height: 0.9em;
 }
 
 .tc-system-title-prefix {

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1172,6 +1172,11 @@ button.tc-btn-invisible.tc-remove-tag-button {
 	margin-right: .1em;
 }
 
+.tc-tiddler-title-icon svg {
+	width: 0.75em;
+	height: 0.75em;
+}
+
 .tc-system-title-prefix {
 	color: <<colour muted-foreground>>;
 }


### PR DESCRIPTION
As reported [in the forum](https://talk.tiddlywiki.org/t/tiddler-icon-in-viewtemplate-has-fixed-size-not-relative-to-text-size/7612):

> This observation is nitpicky and of low priority if considered a bug at all, but looks like an overlook, so I decided to ask.

> The icon displayed in front of the tiddler title in the ViewTemplate has fixed, not relative, size. It stays the same size regardless of the title font size.

> This is not visible at all on the default font size `$:/themes/tiddlywiki/vanilla/metrics/fontsize` of 14px, because the fixed size happens to be the same or very similar to the view toolbar icons. It is also not very apparent on small changes of the font size. Bigger changes of the font size, as in screenshots below, demonstrate the problem:

