### PR TITLE
Fixed error "Global assignment is not allowed within modules on node"

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -575,9 +575,8 @@ var globalCheck =[
 	"    configurable: true",
 	"  });",
 	"  if(Object.keys(__temp__).length){",
-	"    console.log(Object.keys(__temp__));",
+	"    console.log(\"Warning: Global assignment detected\",Object.keys(__temp__));",
 	"    delete Object.prototype.__temp__;",
-	"    throw \"Global assignment is not allowed within modules on node.\";",
 	"  }",
 	"  delete Object.prototype.__temp__;",
 ].join('\n');


### PR DESCRIPTION
This error message was introduced in #4624 as:

```
Global assignment is not allowed within modules on node
```

Since #4624 was released in v5.3.0 it has been found that the error is raised by a number of popular existing plugins when they are run under Node.js.

The initial approach to fixing it taken here is to make it a warning to the console, but I'm wondering whether it might not be more useful to entirely remove the global check.

Fixes #7585

@Arlen22 @flibbles @saqimtiaz I'd welcome your thoughts.
