### PR TITLE
dumpvariables - new v5.3.x syntax

### DIFF
--- a/core/wiki/macros/dumpvariables.tid
+++ b/core/wiki/macros/dumpvariables.tid
@@ -1,14 +1,14 @@
 title: $:/core/macros/dumpvariables
 tags: $:/tags/Macro
 
-\define dumpvariables()
 \whitespace trim
+\procedure dumpvariables()
 <ul>
-<$list filter="[variables[]]" variable="varname">
-<li>
-<strong><code><$text text=<<varname>>/></code></strong>:<br/>
-<$codeblock code={{{ [<varname>getvariable[]] }}}/>
-</li>
-</$list>
+	<$list filter="[variables[]]" variable="varname">
+		<li>
+			<strong><code><$text text=<<varname>>/></code></strong>:<br/>
+			<$codeblock code={{{ [<varname>getvariable[]] }}}/>
+		</li>
+	</$list>
 </ul>
 \end


### PR DESCRIPTION
This PR changes the syntax of the dumpvariables macro.  -- 

PR  **Dumpvariables rewrite new syntax plus search** #7992  will completely rewrite it when it's finished.