### PR TITLE
View Widget View handler

### DIFF
--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -75,6 +75,7 @@ ViewHandler.prototype.createFakeWidget = function() {
 		field: this.widget.viewField,
 		index: this.widget.viewIndex,
 		parseAsInline: this.widget.viewMode !== "block",
+		mode: this.widget.viewMode === "block" ? "block" : "inline",
 		parentWidget: this.widget,
 		subTiddler: this.widget.viewSubTiddler
 	});

--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -38,8 +38,8 @@ ViewHandler.prototype.render = function(parent,nextSibling) {
 Base ViewHandler render method for wikified views
 */
 ViewHandler.prototype.renderWikified = function(parent,nextSibling) {
-	this.text = this.getValue(this.widget.viewMode);
 	this.createFakeWidget();
+	this.text = this.getValue();
 	this.createWikifiedTextNode(parent,nextSibling);
 };
 
@@ -186,17 +186,14 @@ ViewWidget.prototype.initialiseHTMLWikifiedView = function(View) {
 		this.renderWikified(parent,nextSibling);
 	};
 
-	View.prototype.getValue = function(mode) {
-		return self.wiki.renderText("text/html","text/vnd.tiddlywiki",self.getValueAsText(),{
-			parseAsInline: mode !== "block",
-			parentWidget: self
-		});
+	View.prototype.getValue = function() {
+		return this.fakeNode.innerHTML;
 	};
 
 	View.prototype.refresh = function(changedTiddlers) {
 		var refreshed = this.fakeWidget.refresh(changedTiddlers);
 		if(refreshed) {
-			var newText = this.fakeNode.innerHTML;
+			var newText = this.getValue();
 			if(newText !== this.text) {
 				self.domNodes[0].textContent = newText;
 				this.text = newText;
@@ -217,17 +214,14 @@ ViewWidget.prototype.initialisePlainWikifiedView = function(View) {
 		this.renderWikified(parent,nextSibling);
 	};
 
-	View.prototype.getValue = function(mode) {
-		return self.wiki.renderText("text/plain","text/vnd.tiddlywiki",self.getValueAsText(),{
-			parseAsInline: mode !== "block",
-			parentWidget: self
-		});
+	View.prototype.getValue = function() {
+		return this.fakeNode.textContent;
 	};
 
 	View.prototype.refresh = function(changedTiddlers) {
 		var refreshed = this.fakeWidget.refresh(changedTiddlers);
 		if(refreshed) {
-			var newText = this.fakeNode.textContent;
+			var newText = this.getValue();
 			if(newText !== this.text) {
 				self.domNodes[0].textContent = newText;
 				this.text = newText;
@@ -248,17 +242,14 @@ ViewWidget.prototype.initialiseHTMLEncodedPlainWikifiedView = function(View) {
 		this.renderWikified(parent,nextSibling);
 	};
 
-	View.prototype.getValue = function(mode) {
-		return $tw.utils.htmlEncode(self.wiki.renderText("text/plain","text/vnd.tiddlywiki",self.getValueAsText(),{
-			parseAsInline: mode !== "block",
-			parentWidget: self
-		}));
+	View.prototype.getValue = function() {
+		return $tw.utils.htmlEncode(this.fakeNode.textContent);
 	};
 
 	View.prototype.refresh = function(changedTiddlers) {
 		var refreshed = this.fakeWidget.refresh(changedTiddlers);
 		if(refreshed) {
-			var newText = $tw.utils.htmlEncode(this.fakeNode.textContent);
+			var newText = this.getValue();
 			if(newText !== this.text) {
 				self.domNodes[0].textContent = newText;
 				this.text = newText;

--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -18,6 +18,8 @@ var ViewWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
+var ViewHandler = function() {};
+
 /*
 Inherit from the base widget class
 */

--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -192,7 +192,6 @@ ViewWidget.prototype.initialiseView = function() {
 Initialise HTML wikified view methods
 */
 ViewWidget.prototype.initialiseHTMLWikifiedView = function(View) {
-	var self = this;
 
 	View.prototype.render = function(parent,nextSibling) {
 		this.renderWikified(parent,nextSibling);
@@ -212,7 +211,6 @@ ViewWidget.prototype.initialiseHTMLWikifiedView = function(View) {
 Initialise plain wikified view methods
 */
 ViewWidget.prototype.initialisePlainWikifiedView = function(View) {
-	var self = this;
 
 	View.prototype.render = function(parent,nextSibling) {
 		this.renderWikified(parent,nextSibling);
@@ -232,7 +230,6 @@ ViewWidget.prototype.initialisePlainWikifiedView = function(View) {
 Initialise HTML encoded plain wikified methods
 */
 ViewWidget.prototype.initialiseHTMLEncodedPlainWikifiedView = function(View) {
-	var self = this;
 	
 	View.prototype.render = function(parent,nextSibling) {
 		this.renderWikified(parent,nextSibling);

--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -83,6 +83,18 @@ ViewHandler.prototype.createFakeWidget = function() {
 	this.fakeWidget.renderChildren(this.fakeNode,null);
 };
 
+ViewHandler.prototype.refreshWikified = function(changedTiddlers) {
+	var refreshed = this.fakeWidget.refresh(changedTiddlers);
+	if(refreshed) {
+		var newText = this.getValue();
+		if(newText !== this.text) {
+			this.widget.domNodes[0].textContent = newText;
+			this.text = newText;
+		}
+	}
+	return refreshed;
+};
+
 /*
 Base ViewHandler refresh method
 */
@@ -191,15 +203,7 @@ ViewWidget.prototype.initialiseHTMLWikifiedView = function(View) {
 	};
 
 	View.prototype.refresh = function(changedTiddlers) {
-		var refreshed = this.fakeWidget.refresh(changedTiddlers);
-		if(refreshed) {
-			var newText = this.getValue();
-			if(newText !== this.text) {
-				self.domNodes[0].textContent = newText;
-				this.text = newText;
-			}
-		}
-		return refreshed;
+		return this.refreshWikified(changedTiddlers);
 	};
 	return View;
 };
@@ -219,15 +223,7 @@ ViewWidget.prototype.initialisePlainWikifiedView = function(View) {
 	};
 
 	View.prototype.refresh = function(changedTiddlers) {
-		var refreshed = this.fakeWidget.refresh(changedTiddlers);
-		if(refreshed) {
-			var newText = this.getValue();
-			if(newText !== this.text) {
-				self.domNodes[0].textContent = newText;
-				this.text = newText;
-			}
-		}
-		return refreshed;
+		return this.refreshWikified(changedTiddlers);
 	};
 	return View;
 };
@@ -247,15 +243,7 @@ ViewWidget.prototype.initialiseHTMLEncodedPlainWikifiedView = function(View) {
 	};
 
 	View.prototype.refresh = function(changedTiddlers) {
-		var refreshed = this.fakeWidget.refresh(changedTiddlers);
-		if(refreshed) {
-			var newText = this.getValue();
-			if(newText !== this.text) {
-				self.domNodes[0].textContent = newText;
-				this.text = newText;
-			}
-		}
-		return refreshed;
+		return this.refreshWikified(changedTiddlers);
 	};
 	return View;
 };

--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -81,7 +81,7 @@ ViewHandler.prototype.createFakeWidget = function() {
 	});
 	this.fakeNode = $tw.fakeDocument.createElement("div");
 	this.fakeWidget.makeChildWidgets();
-	this.fakeWidget.renderChildren(this.fakeNode,null);
+	this.fakeWidget.render(this.fakeNode,null);
 };
 
 ViewHandler.prototype.refreshWikified = function(changedTiddlers) {

--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -24,8 +24,6 @@ var ViewHandler = function(widget) {
 	this.document = widget.document;
 };
 
-ViewHandler.prototype = {};
-
 /*
 Base ViewHandler render method
 */

--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -35,6 +35,15 @@ ViewHandler.prototype.render = function(parent,nextSibling) {
 };
 
 /*
+Base ViewHandler render method for wikified views
+*/
+ViewHandler.prototype.renderWikified = function(parent,nextSibling) {
+	this.text = this.getValue(this.widget.viewMode);
+	this.createFakeWidget();
+	this.createWikifiedTextNode(parent,nextSibling);
+};
+
+/*
 ViewHandler method to create a simple text node
 */
 ViewHandler.prototype.createTextNode = function(parent,nextSibling) {
@@ -172,10 +181,9 @@ Initialise HTML wikified view methods
 */
 ViewWidget.prototype.initialiseHTMLWikifiedView = function(View) {
 	var self = this;
+
 	View.prototype.render = function(parent,nextSibling) {
-		this.text = this.getValue(self.viewMode);
-		this.createFakeWidget();
-		this.createWikifiedTextNode(parent,nextSibling);
+		this.renderWikified(parent,nextSibling);
 	};
 
 	View.prototype.getValue = function(mode) {
@@ -204,10 +212,9 @@ Initialise plain wikified view methods
 */
 ViewWidget.prototype.initialisePlainWikifiedView = function(View) {
 	var self = this;
+
 	View.prototype.render = function(parent,nextSibling) {
-		this.text = this.getValue(self.viewMode);
-		this.createFakeWidget();
-		this.createWikifiedTextNode(parent,nextSibling);
+		this.renderWikified(parent,nextSibling);
 	};
 
 	View.prototype.getValue = function(mode) {
@@ -236,10 +243,9 @@ Initialise HTML encoded plain wikified methods
 */
 ViewWidget.prototype.initialiseHTMLEncodedPlainWikifiedView = function(View) {
 	var self = this;
+	
 	View.prototype.render = function(parent,nextSibling) {
-		this.text = this.getValue(self.viewMode);
-		this.createFakeWidget();
-		this.createWikifiedTextNode(parent,nextSibling);
+		this.renderWikified(parent,nextSibling);
 	};
 
 	View.prototype.getValue = function(mode) {


### PR DESCRIPTION
This PR adds a `ViewHandler` base class to the `view` widget and `subclasses` for each of the different views

The `ViewHandler` has methods `render`, `renderWikified`, `createTextNode`, `createWikifiedTextNode`, `createFakeWidget` and `refresh` - EDIT: and now also `refreshWikified`
These methods are used by more than one of the different subclasses.

The subclasses are initialised if they're needed.
There's still a big `switch` statement in the `ViewWidget`'s `getView` method to find the view and initialise the correct subclass, maybe there's a better method to do so but I haven't found one.

Each subclass has its own `getValue` method.
The wikified views also have dedicated `render` and `refresh` methods.

I hope I got this right this time :smile_cat: 

Please review and test and leave me some comments if this is the right approach and what could be simplified.
I had to read about subclassing for this and am not 100% sure if I got it right.