### PR TITLE
add filter run prefix :comment or // or # for testing

### DIFF
--- a/core/modules/filterrunprefixes/comment.js
+++ b/core/modules/filterrunprefixes/comment.js
@@ -1,0 +1,23 @@
+/*\
+title: $:/core/modules/filterrunprefixes/comment.js
+type: application/javascript
+module-type: filterrunprefix
+
+Intersection of sets.
+Equivalent to + filter run prefix.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter prefix function
+*/
+exports.comment = function(operationSubFunction,options) {
+	return function(results,source,widget) {};
+};
+
+})();

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -70,7 +70,7 @@ function parseFilterOperation(operators,filterString,p) {
 		operator.operands = [];
 		var parseOperand = function(bracketType) {
 			var operand = {};
-			switch (bracketType) {
+			switch(bracketType) {
 				case "{": // Curly brackets
 					operand.indirect = true;
 					nextBracketPos = filterString.indexOf("}",p);
@@ -144,7 +144,7 @@ exports.parseFilter = function(filterString) {
 		p = 0, // Current position in the filter string
 		match;
 	var whitespaceRegExp = /(\s+)/mg,
-		operandRegExp = /((?:\+|\-|~|=|\:(\w+)(?:\:([\w\:, ]*))?)?)(?:(\[)|(?:"([^"]*)")|(?:'([^']*)')|([^\s\[\]]+))/mg;
+		operandRegExp = /((?:\+|\-|~|=|\/\/|#|\:(\w+)(?:\:([\w\:, ]*))?)?)(?:(\[)|(?:"([^"]*)")|(?:'([^']*)')|([^\s\[\]]+))/mg;
 	while(p < filterString.length) {
 		// Skip any whitespace
 		whitespaceRegExp.lastIndex = p;
@@ -171,7 +171,7 @@ exports.parseFilter = function(filterString) {
 				}
 				if(match[3]) {
 					operation.suffixes = [];
-					 $tw.utils.each(match[3].split(":"),function(subsuffix) {
+					$tw.utils.each(match[3].split(":"),function(subsuffix) {
 						operation.suffixes.push([]);
 						$tw.utils.each(subsuffix.split(","),function(entry) {
 							entry = $tw.utils.trim(entry);
@@ -179,7 +179,7 @@ exports.parseFilter = function(filterString) {
 								operation.suffixes[operation.suffixes.length -1].push(entry);
 							}
 						});
-					 });
+					});
 				}
 			}
 			if(match[4]) { // Opening square bracket
@@ -322,7 +322,10 @@ exports.compileFilter = function(filterString) {
 					return filterRunPrefixes["and"](operationSubFunction, options);
 				case "~": // This operation is unioned into the result only if the main result so far is empty
 					return filterRunPrefixes["else"](operationSubFunction, options);
-				default: 
+				case "#": // Filter comment (fallthrough is intentional)
+				case "//": // This operation is ignored and passes through all results
+					return filterRunPrefixes["comment"](operationSubFunction, options);
+				default:
 					if(operation.namedPrefix && filterRunPrefixes[operation.namedPrefix]) {
 						return filterRunPrefixes[operation.namedPrefix](operationSubFunction, options);
 					} else {


### PR DESCRIPTION
related to: **Add support for comments within filters** #6847

This PR adds 

- a verbose `:comment` filter run prefix and 
- 2 shortcuts: `#` and `//` 

There should be only 1 shortcut in the final version, that's why this is a draft PR

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/bfb1dcbc-acf1-44bd-b9dc-5b8ba7c03062)

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/31cfcedc-6913-459b-943e-89c10e044a5c)

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/dae75868-51c0-4734-aa63-e07eda6e78d8)

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/653befd2-6df3-4a99-830e-639f82b39cf3)