### PR TITLE
Add disable parameter to keyboard widget

### DIFF
--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -43,9 +43,11 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 	this.domNode = domNode;
 	this.assignDomNodeClasses();
 	// Add a keyboard event handler
-	$tw.utils.addEventListeners(domNode,[
-		{name: "keydown", handlerObject: this, handlerMethod: "handleChangeEvent"}
-	]);
+	if(this.disabled !== "yes") {
+		$tw.utils.addEventListeners(domNode,[
+			{name: "keydown", handlerObject: this, handlerMethod: "handleChangeEvent"}
+		]);
+	}
 	// Insert element
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);
@@ -53,10 +55,9 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 };
 
 KeyboardWidget.prototype.handleChangeEvent = function(event) {
-	if ($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
+	if($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
 		return true;
 	}
-
 	var keyInfo = $tw.keyboardManager.getMatchingKeyDescriptor(event,this.keyInfoArray);
 	if(keyInfo) {
 		var handled = this.invokeActions(this,event);
@@ -96,6 +97,7 @@ KeyboardWidget.prototype.execute = function() {
 	this.param = this.getAttribute("param","");
 	this.key = this.getAttribute("key","");
 	this.tag = this.getAttribute("tag","");
+	this.disabled = this.getAttribute("disabled","no");
 	this.keyInfoArray = $tw.keyboardManager.parseKeyDescriptors(this.key);
 	if(this.key.substr(0,2) === "((" && this.key.substr(-2,2) === "))") {
 		this.shortcutTiddlers = [];
@@ -111,6 +113,9 @@ KeyboardWidget.prototype.execute = function() {
 KeyboardWidget.prototype.assignDomNodeClasses = function() {
 	var classes = this.getAttribute("class","").split(" ");
 	classes.push("tc-keyboard");
+	if(this.disabled === "yes") {
+		classes.push("tc-disabled");
+	}
 	this.domNode.className = classes.join(" ");
 };
 
@@ -119,7 +124,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 KeyboardWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.message || changedAttributes.param || changedAttributes.key || changedAttributes.tag) {
+	if(changedAttributes.message || changedAttributes.param || changedAttributes.key || changedAttributes.tag || changedAttributes.disabled) {
 		this.refreshSelf();
 		return true;
 	} else if(changedAttributes["class"]) {

--- a/editions/tw5.com/tiddlers/widgets/KeyboardWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/KeyboardWidget.tid
@@ -1,6 +1,6 @@
 caption: keyboard
 created: 20140302192136805
-modified: 20211009121239821
+modified: 20240517131307923
 tags: Widgets TriggeringWidgets
 title: KeyboardWidget
 type: text/vnd.tiddlywiki
@@ -19,7 +19,8 @@ The content of the `<$keyboard>` widget is rendered normally. The keyboard short
 |param |The parameter to be passed with the [[WidgetMessage|Messages]] |
 |key |Key string identifying the key(s) to be trapped (see below) |
 |class |A CSS class to be assigned to the generated HTML DIV element |
-|tag|<<.from-version "5.1.14">> The html element the widget creates to capture the keyboard event, defaults to:<br>» `span` when parsed in inline-mode<br>» `div` when parsed in block-mode|
+|tag |<<.from-version "5.1.14">> The html element the widget creates to capture the keyboard event, defaults to:<br>» `span` when parsed in inline-mode<br>» `div` when parsed in block-mode|
+|disabled |<<.from-version "5.3.4">> Optional. If set to "yes" the keyboard actions are not activated. Defaults to "no" |
 
 ! Variables
 


### PR DESCRIPTION
This PR is related to PR: **use a textarea in advanced-search-filter** tab #8194 which should be implemented differently in wikitext. 

To be able to implement #8194 functionality as a plugin the core needs to support a "disabled" parameter for the keyboard-widget, which this PR implements. 

- "disabled" defaults to "no"
- If set to "yes" the keyboard widget event-handler will not be created in the DOM.
- If disabled a `tc-disabled` class is assigned to the HTML element, so it can be used for styling if needed.