### PR TITLE
Use the testcase widget for $action-createtiddler examples

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 1.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 1.tid
@@ -1,26 +1,15 @@
 created: 20200131142401129
-modified: 20211113230406823
+modified: 20240602154417754
 tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 1
 type: text/vnd.tiddlywiki
 
-\define testCreate()
-<$action-createtiddler />
-\end
-
-This example will create "New Tiddler", "New Tiddler 1", " New Tiddler 2" and so on
-
-```
-\define testCreate()
-<$action-createtiddler />
-\end
+<$testcase>
+<$data title=Description text="Default widget with no attributes"/>
+<$data title=Narrative text='The button in this example uses the $action-createtiddler widget to create "New Tiddler", "New Tiddler 1", " New Tiddler 2" and so on'/>
+<$data title=Output text="""\define testCreate() <$action-createtiddler />
 
 <$button actions=<<testCreate>> >
 Create Tiddler
-</$button>
-```
-
-<$button actions=<<testCreate>> >
-<$action-setfield $tiddler="$:/state/tab/sidebar--595412856" text="$:/core/ui/SideBar/Recent"/>
-Create Tiddler
-</$button> - Clicking this button, will also open the Right sidebar: Recent tab
+</$button>"""/>
+</$testcase>

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 1.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 1.tid
@@ -7,7 +7,7 @@ type: text/vnd.tiddlywiki
 <$testcase>
 <$data title=Description text="Default widget with no attributes"/>
 <$data title=Narrative text='The button in this example uses the $action-createtiddler widget to create "New Tiddler", "New Tiddler 1", " New Tiddler 2" and so on'/>
-<$data title=Output text="""\define testCreate() <$action-createtiddler />
+<$data title=Output text="""\procedure testCreate() <$action-createtiddler />
 
 <$button actions=<<testCreate>> >
 Create Tiddler

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 2.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 2.tid
@@ -1,28 +1,20 @@
 created: 20200131144828713
-modified: 20211113011036840
+modified: 20240602160133371
 tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 2
 type: text/vnd.tiddlywiki
 
-\define testCreate()
-<$action-createtiddler $basetitle={{$:/language/DefaultNewTiddlerTitle}} $overwrite="yes"/>
-\end
+<$testcase>
+<$data title=Description text="Transcluded base title"/>
+<$data title=Narrative text="""The $action-createtiddler widget in this example uses the base title defined in [[$:/language/DefaultNewTiddlerTitle]].
 
-This example will use the base title defined in [[$:/language/DefaultNewTiddlerTitle]]. 
-
-It will overwrite the tiddler, if the button is clicked several times.
-
-```
-\define testCreate()
+It will overwrite the tiddler if the button is clicked several times."""/>
+<$data $tiddler="$:/language/DefaultNewTiddlerTitle"/>
+<$data title=Output text="""\define testCreate()
 <$action-createtiddler $basetitle={{$:/language/DefaultNewTiddlerTitle}} $overwrite="yes"/>
 \end
 
 <$button actions=<<testCreate>> >
 Create Tiddler
-</$button>
-```
-
-<$button actions=<<testCreate>> >
-<$action-setfield $tiddler="$:/state/tab/sidebar--595412856" text="$:/core/ui/SideBar/Recent"/>
-Create Tiddler
-</$button> - Clicking this button, will also open the Right sidebar: Recent tab
+</$button>"""/>
+</$testcase>

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 2.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 2.tid
@@ -10,7 +10,7 @@ type: text/vnd.tiddlywiki
 
 It will overwrite the tiddler if the button is clicked several times."""/>
 <$data $tiddler="$:/language/DefaultNewTiddlerTitle"/>
-<$data title=Output text="""\define testCreate()
+<$data title=Output text="""\procedure testCreate()
 <$action-createtiddler $basetitle={{$:/language/DefaultNewTiddlerTitle}} $overwrite="yes"/>
 \end
 

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 3.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 3.tid
@@ -1,28 +1,21 @@
 created: 20200131145355658
-modified: 20211113011111052
+modified: 20240602155233116
 tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 3
 type: text/vnd.tiddlywiki
 
-\define testCreate()
-<$action-createtiddler $basetitle="base" $template="ActionCreateTiddlerWidget Template"/>
-\end
+<$testcase>
+<$data title=Description text="Template and custom base title"/>
+<$data title=Narrative text="""The $action-createtiddler widget in this example uses the basetitle attribute and template: [[ActionCreateTiddlerWidget Template]].
 
-This example will uses a base-title and a template: [[ActionCreateTiddlerWidget Template]]
-
-It will create: "base", "base 1", "base 2" and so on 
-
-```
-\define testCreate()
+Clicking the button will create: "base", "base 1", "base 2" and so on
+"""/>
+<$data $tiddler="ActionCreateTiddlerWidget Template"/>
+<$data title=Output text="""\define testCreate()
 <$action-createtiddler $basetitle="base" $template="ActionCreateTiddlerWidget Template"/>
 \end
 
 <$button actions=<<testCreate>> >
 Create Tiddler
-</$button>
-```
-
-<$button actions=<<testCreate>> >
-<$action-setfield $tiddler="$:/state/tab/sidebar--595412856" text="$:/core/ui/SideBar/Recent"/>
-Create Tiddler
-</$button> - Clicking this button will also open the Right sidebar: Recent tab
+</$button>"""/>
+</$testcase>

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 3.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 3.tid
@@ -11,7 +11,7 @@ type: text/vnd.tiddlywiki
 Clicking the button will create: "base", "base 1", "base 2" and so on
 """/>
 <$data $tiddler="ActionCreateTiddlerWidget Template"/>
-<$data title=Output text="""\define testCreate()
+<$data title=Output text="""\procedure testCreate()
 <$action-createtiddler $basetitle="base" $template="ActionCreateTiddlerWidget Template"/>
 \end
 

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 4.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 4.tid
@@ -1,28 +1,21 @@
 created: 20200131150229551
-modified: 20211113011129601
+modified: 20240602154933113
 tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 4
 type: text/vnd.tiddlywiki
 
-\define testCreate()
-<$action-createtiddler $basetitle="base" $template="ActionCreateTiddlerWidget Template" aa="new field aa" bb="new field bb" />
-\end
-
-This example uses a base-title "base" and a template: [[ActionCreateTiddlerWidget Template]].
+<$testcase>
+<$data title=Description text="Template with override fields and custom base title"/>
+<$data title=Narrative text="""The $action-createtiddler widget in this example uses the basetitle attribute and template: [[ActionCreateTiddlerWidget Template]].
 
 There will be new fields "aa" and "bb" which are added to the new tiddlers.
-
-```
-\define testCreate()
+"""/>
+<$data $tiddler="ActionCreateTiddlerWidget Template"/>
+<$data title=Output text="""\define testCreate()
 <$action-createtiddler $basetitle="base" $template="ActionCreateTiddlerWidget Template" aa="new field aa" bb="new field bb" />
 \end
 
 <$button actions=<<testCreate>> >
 Create Tiddler
-</$button>
-```
-
-<$button actions=<<testCreate>> >
-<$action-setfield $tiddler="$:/state/tab/sidebar--595412856" text="$:/core/ui/SideBar/Recent"/>
-Create Tiddler
-</$button> - Clicking this button will also open the Right sidebar: Recent tab
+</$button>"""/>
+</$testcase>

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 4.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 4.tid
@@ -11,7 +11,7 @@ type: text/vnd.tiddlywiki
 There will be new fields "aa" and "bb" which are added to the new tiddlers.
 """/>
 <$data $tiddler="ActionCreateTiddlerWidget Template"/>
-<$data title=Output text="""\define testCreate()
+<$data title=Output text="""\procedure testCreate()
 <$action-createtiddler $basetitle="base" $template="ActionCreateTiddlerWidget Template" aa="new field aa" bb="new field bb" />
 \end
 

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 5.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 5.tid
@@ -8,7 +8,7 @@ type: text/vnd.tiddlywiki
 <$data title=Description text="Child action widget uses the created tiddler title"/>
 <$data title=Narrative text="""The $action-createtiddler widget in this example uses the <<.var createTiddler-title>> variable to navigate to the created tiddler"""/>
 <$data $tiddler="ActionCreateTiddlerWidget Template"/>
-<$data title=Output text="""\define testCreate()
+<$data title=Output text="""\procedure testCreate()
 <$action-createtiddler  $basetitle="base" $template="ActionCreateTiddlerWidget Template">
 	<$action-navigate $to=<<createTiddler-title>>/>
 </$action-createtiddler>

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 5.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 5.tid
@@ -1,32 +1,20 @@
 created: 20200131144828713
-modified: 20230111220933412
+modified: 20240602155008453
 tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 5
 type: text/vnd.tiddlywiki
 
-\define testCreate()
+<$testcase>
+<$data title=Description text="Child action widget uses the created tiddler title"/>
+<$data title=Narrative text="""The $action-createtiddler widget in this example uses the <<.var createTiddler-title>> variable to navigate to the created tiddler"""/>
+<$data $tiddler="ActionCreateTiddlerWidget Template"/>
+<$data title=Output text="""\define testCreate()
 <$action-createtiddler  $basetitle="base" $template="ActionCreateTiddlerWidget Template">
-	<$action-sendmessage $message="tm-edit-tiddler" $param=<<createTiddler-title>>/>
-</$action-createtiddler>
-\end
-
-This example will use the base title defined in [[ActionCreateTiddlerWidget Template]].
-
-It will create: "base", "base 1", "base 2" and so on, and navigate to this tiddler in draft mode.
-
-```
-\define testCreate()
-<$action-createtiddler $basetitle="base" $template="ActionCreateTiddlerWidget Template">
-	<$action-sendmessage $message="tm-edit-tiddler" $param=<<createTiddler-title>>/>
+	<$action-navigate $to=<<createTiddler-title>>/>
 </$action-createtiddler>
 \end
 
 <$button actions=<<testCreate>> >
 Create Tiddler
-</$button>
-```
-
-<$button actions=<<testCreate>> >
-<$action-setfield $tiddler="$:/state/tab/sidebar--595412856" text="$:/core/ui/SideBar/Recent"/>
-Create Tiddler
-</$button> - Clicking this button, will also open the Right sidebar: Recent tab
+</$button>"""/>
+</$testcase>

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget.tid
@@ -1,6 +1,6 @@
 caption: action-createtiddler
 created: 20161020152745942
-modified: 20230115084716196
+modified: 20240602153213986
 tags: Widgets ActionWidgets
 title: ActionCreateTiddlerWidget
 type: text/vnd.tiddlywiki
@@ -37,37 +37,6 @@ The ''action-createtiddler'' widget is invisible.
 
 ! Examples
 
-<<<
-<$macrocall $name='wikitext-example-without-html' src={{ActionCreateTiddlerWidget Example}}/>
-<<<
-
----
-
-<<<
-<$transclude tiddler="ActionCreateTiddlerWidget Example 1" mode=block/>
-<<<
-
----
-
-<<<
-{{ActionCreateTiddlerWidget Example 2}}
-<<<
-
----
-
-<<<
-{{ActionCreateTiddlerWidget Example 3}}
-<<<
-
----
-
-<<<
-{{ActionCreateTiddlerWidget Example 4}}
-<<<
-
----
-
-<<<
-{{ActionCreateTiddlerWidget Example 5}}
-<<<
-
+<$list filter="[prefix[ActionCreateTiddlerWidget Example]]">
+<$transclude/>
+</$list>

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget_Example.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget_Example.tid
@@ -1,14 +1,24 @@
 created: 20161020153426686
-modified: 20211113011019510
+modified: 20240602160452171
 tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example
 type: text/vnd.tiddlywiki
 
+<$testcase>
+<$data title=Description text="Create a new page control button"/>
+<$data title=Narrative text="""Use the $action-createtiddler widget to create and open a new, non-functional page control button tiddler"""/>
+<$data title=Output text="""\define testCreate()
+<$action-createtiddler $basetitle="Homemade Button" tags="$:/tags/PageControls" text={{$:/state/new-button-caption}}>
+	<$action-navigate $to=<<createTiddler-title>>/>
+</$action-createtiddler>
+\end
+
+{{$:/core/ui/SideBarSegments/page-controls}}
+
 Caption for new button: <$edit-text tiddler="$:/state/new-button-caption" tag="input" default=""/>
 
-<$button>
-<$action-createtiddler $basetitle="Homemade Button" tags="$:/tags/PageControls" text={{$:/state/new-button-caption}}>
-<$action-navigate $to=<<createTiddler-title>>/>
-</$action-createtiddler>
-Create a new non-functional page control button and open the tiddler
-</$button>
+<$button actions=<<testCreate>> >
+Create Tiddler
+</$button>"""/>
+<$data title="$:/state/new-button-caption" text="button text "/>
+</$testcase>

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget_Example.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget_Example.tid
@@ -7,7 +7,7 @@ type: text/vnd.tiddlywiki
 <$testcase>
 <$data title=Description text="Create a new page control button"/>
 <$data title=Narrative text="""Use the $action-createtiddler widget to create and open a new, non-functional page control button tiddler"""/>
-<$data title=Output text="""\define testCreate()
+<$data title=Output text="""\procedure testCreate()
 <$action-createtiddler $basetitle="Homemade Button" tags="$:/tags/PageControls" text={{$:/state/new-button-caption}}>
 	<$action-navigate $to=<<createTiddler-title>>/>
 </$action-createtiddler>


### PR DESCRIPTION
Translate the `$action-createtiddler` examples to use the `$testcase` widget.

Directly used the `$testcase` widget rather than test case tiddlers so the user can interactively click the buttons to see the behavior.

Converted macro `\define` to `\procedure` in the examples.