### PR TITLE
Make pluginlibrary edition consistent with all other editions

### DIFF
--- a/editions/pluginlibrary/tiddlers/GettingStarted.tid
+++ b/editions/pluginlibrary/tiddlers/GettingStarted.tid
@@ -16,7 +16,7 @@ The following commands will create the library files and start a test server at 
 
 ```
 cd /your/path/to/TiddlyWiki5
-node .\tiddlywiki.js ./editions/pluginlibrary --build test-server
+node ./tiddlywiki.js ./editions/pluginlibrary --build test-server
 ```
 
 !! Test the Library with a Single File Wiki

--- a/editions/pluginlibrary/tiddlers/GettingStarted.tid
+++ b/editions/pluginlibrary/tiddlers/GettingStarted.tid
@@ -16,7 +16,7 @@ The following commands will create the library files and start a test server at 
 
 ```
 cd /your/path/to/TiddlyWiki5
-tiddlywiki ./editions/pluginlibrary --build test-server
+node .\tiddlywiki.js ./editions/pluginlibrary --build test-server
 ```
 
 !! Test the Library with a Single File Wiki

--- a/editions/pluginlibrary/tiddlers/GettingStarted.tid
+++ b/editions/pluginlibrary/tiddlers/GettingStarted.tid
@@ -15,8 +15,8 @@ Import the configuration tiddler: $:/config/LocalPluginLibrary to your "test wik
 The following commands will create the library files and start a test server at http://localhost:8888
 
 ```
-cd /your/path/to/TiddlyWiki5/editions/pluginlibrary
-tiddlywiki --build test-server
+cd /your/path/to/TiddlyWiki5
+tiddlywiki ./editions/pluginlibrary --build test-server
 ```
 
 !! Test the Library with a Single File Wiki

--- a/editions/pluginlibrary/tiddlywiki.info
+++ b/editions/pluginlibrary/tiddlywiki.info
@@ -11,7 +11,7 @@
 	],
 	"build": {
 		"test-server": [
-			"--output", "./files/local/library/tmp",
+			"--output", "./editions/pluginlibrary/files/local/library/tmp",
 			"--build", "library",
 			"--listen", "port=8888"
 		],


### PR DESCRIPTION
Make pluginlibrary edition consistent with all other editions.

Usually TW commands are run from the TW directory. The initial configuration was wrong and error-prone. This PR fixes that.

