### PR TITLE
Replace Macro with Myfun when Calling Example Function

### DIFF
--- a/editions/tw5.com/tiddlers/functions/Functions.tid
+++ b/editions/tw5.com/tiddlers/functions/Functions.tid
@@ -1,5 +1,5 @@
 created: 20221009124003601
-modified: 20230419103154328
+modified: 20240619211228560
 tags: Concepts Reference
 title: Functions
 type: text/vnd.tiddlywiki
@@ -11,17 +11,17 @@ type: text/vnd.tiddlywiki
 Functions are usually defined with the [[Pragma: \function]]:
 
 ```
-\function my-function(parameter:"2")
-[<parameter>multiply[1.5]]
+\function myfun(param:"2")
+[<param>multiply[1.5]]
 \end
 ```
 
 Functions can be invoked in several ways:
 
-* Directly transclude functions with the syntax `<<myfn param:"value">>`
-* Assign functions to widget attributes with the syntax `<div class=<<myfn param:"value">>>`
-* Invoke functions via the [[function Operator]] with the syntax `[function[myfn],[value],...]`
-* Directly invoke functions whose names contain a period as custom filter operators with the syntax `[my.fn[value]]` or `[.myfn[value]]`
+* Directly transclude functions with the syntax `<<myfun param:"value">>`
+* Assign functions to widget attributes with the syntax `<div class=<<myfun param:"value">>>`
+* Invoke functions via the [[function Operator]] with the syntax `[function[myfun],[value],...]`
+* Directly invoke functions whose names contain a period as custom filter operators with the syntax `[my.fun[value]]` or `[.myfun[value]]`
 
 !! How Functions Work
 

--- a/editions/tw5.com/tiddlers/variables/Behaviour of invoked variables depends on how the variable was declared.tid
+++ b/editions/tw5.com/tiddlers/variables/Behaviour of invoked variables depends on how the variable was declared.tid
@@ -1,5 +1,5 @@
 created: 20230726145210484
-modified: 20230726145757234
+modified: 20240619211734149
 tags: [[Variable Usage]]
 title: Behaviour of invoked variables depends on how the variable was declared
 type: text/vnd.tiddlywiki
@@ -8,19 +8,19 @@ type: text/vnd.tiddlywiki
 \procedure p1(a1) $a1$ - <<__a1__>> - <<a1>>
 \function f1(a1) "$a1$" "-" [<__a1__>] ="-" [<a1>] :and[join[ ]]
 
-Invoked in normal wikitext context: `<$transclude $variable=macro/>` or `<<macro>>`
+Invoked in normal wikitext context: `<$transclude $variable=myvar/>` or `<<myvar>>`
 
 {{Behaviour of variables invoked via normal wikitext}}
 
-Invoked via widget attribute: `<div class=<<macro>>/>`
+Invoked via widget attribute: `<div class=<<myvar>>/>`
 
 {{Behaviour of variables invoked via widget attributes}}
 
-Invoked via filter operator parameter: `[<macro>]`
+Invoked via filter operator parameter: `[<myvar>]`
 
 {{Behaviour of variables invoked via filter operator parameter}}
 
-Invoked via function call in a filter expression: `[function[macro]]`
+Invoked via function call in a filter expression: `[function[.myfun]]`
 
 {{Behaviour of variables invoked via filter expression function call}}
 

--- a/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via normal wikitext.tid
+++ b/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via normal wikitext.tid
@@ -1,5 +1,5 @@
 created: 20230726142925020
-modified: 20230726150648189
+modified: 20240619211452297
 tags: [[Variable Usage]]
 title: Behaviour of variables invoked via normal wikitext
 type: text/vnd.tiddlywiki
@@ -8,4 +8,4 @@ type: text/vnd.tiddlywiki
 |!how declared|!behaviour|
 |\define|All wikitext and variable substitution and textual substitution takes place|
 |<<.wlink SetWidget>>, <<.wlink LetWidget>>, <<.wlink VarsWidget>>, \procedure, \widget|All wikitext and variable substitution takes place|
-|\function|Invoking a function in this way (`<<macro>>`) is a synonym for `<$text text={{{[function[macro]]}}}/>`. As with any filtered transclusion (i.e. triple curly braces), all results except the first are discarded|
+|\function|Invoking a function in this way (`<<.myfun>>`) is a synonym for `<$text text={{{[function[.myfun]]}}}/>`. As with any filtered transclusion (i.e. triple curly braces), all results except the first are discarded|

--- a/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via widget attributes.tid
+++ b/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via widget attributes.tid
@@ -1,5 +1,5 @@
 created: 20230726143332803
-modified: 20230726150616232
+modified: 20240619210723396
 tags: [[Variable Usage]]
 title: Behaviour of variables invoked via widget attributes
 type: text/vnd.tiddlywiki
@@ -8,4 +8,4 @@ type: text/vnd.tiddlywiki
 |!how declared|!behaviour|
 |\define|Textual substitution of parameters is performed on the body text. No further processing takes place. The result after textual substitution is used as the attribute's value|
 |<<.wlink SetWidget>>, <<.wlink LetWidget>>, <<.wlink VarsWidget>>, \procedure, \widget|Body text is retrieved as-is and used as the attribute's value.|
-|\function|When a function is invoked as `<div class=<<macro>>/>`, it is a synonym for `<div class={{{[function[macro]]}}}/>`. As with any filtered transclusion (i.e. triple curly braces), all results except the first are discarded. That first result is used as the attribute's value. Note that functions are recursively processed even when invoked in this form. In other words a filter expression in a function can invoke another function and the processing will continue|
+|\function|When a function (e.g. `.myfun`) is invoked as `<div class=<<.myfun>>/>`, it is a synonym for `<div class={{{[function[.myfun]]}}}/>`. As with any filtered transclusion (i.e. triple curly braces), all results except the first are discarded. That first result is used as the attribute's value. Note that functions are recursively processed even when invoked in this form. In other words a filter expression in a function can invoke another function and the processing will continue|


### PR DESCRIPTION
Correct the name of function in examples. Better name for variable in example is used. 