### PR TITLE
Toc uses currentTiddler as "tag" default parameter if it is missing

### DIFF
--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -37,7 +37,10 @@ tags: $:/tags/Macro
 \end
 
 \define toc(tag,sort:"",itemClassFilter:"", exclude)
-<$macrocall $name="toc-body"  tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> exclude=<<__exclude__>>/>
+\whitespace trim
+<$let __tag__={{{ [<__tag__>is[blank]then<currentTiddler>else<__tag__>] }}} >
+  <$macrocall $name="toc-body"  tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> exclude=<<__exclude__>>/>
+</$let>
 \end
 
 \define toc-linked-expandable-body(tag,sort:"",itemClassFilter,exclude,path)
@@ -99,7 +102,7 @@ tags: $:/tags/Macro
 
 \define toc-expandable(tag,sort:"",itemClassFilter:"",exclude,path)
 \whitespace trim
-<$let tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> path={{{ [<__path__>addsuffix[/]addsuffix<__tag__>] }}}>
+<$let __tag__={{{ [<__tag__>is[blank]then<currentTiddler>else<__tag__>] }}} tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> path={{{ [<__path__>addsuffix[/]addsuffix<__tag__>] }}}>
   <$set name="excluded" filter="[subfilter<__exclude__>] [<__tag__>]">
     <ol class="tc-toc toc-expandable">
       <$list filter="""[all[shadows+tiddlers]tag<__tag__>!has[draft.of]$sort$] -[<__tag__>] -[subfilter<__exclude__>]""">
@@ -173,7 +176,7 @@ tags: $:/tags/Macro
 
 \define toc-selective-expandable(tag,sort:"",itemClassFilter,exclude,path)
 \whitespace trim
-<$let tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> path={{{ [<__path__>addsuffix[/]addsuffix<__tag__>] }}}>
+<$let __tag__={{{ [<__tag__>is[blank]then<currentTiddler>else<__tag__>] }}} tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> path={{{ [<__path__>addsuffix[/]addsuffix<__tag__>] }}}>
   <$set name="excluded" filter="[subfilter<__exclude__>] [<__tag__>]">
     <ol class="tc-toc toc-selective-expandable">
       <$list filter="""[all[shadows+tiddlers]tag<__tag__>!has[draft.of]$sort$] -[<__tag__>] -[subfilter<__exclude__>]""">
@@ -188,31 +191,35 @@ tags: $:/tags/Macro
 
 \define toc-tabbed-external-nav(tag,sort:"",selectedTiddler:"$:/temp/toc/selectedTiddler",unselectedText,missingText,template:"",exclude)
 \whitespace trim
-<$tiddler tiddler={{{ [<__selectedTiddler__>get[text]] }}}>
-  <div class="tc-tabbed-table-of-contents">
-    <$linkcatcher to=<<__selectedTiddler__>>>
-      <div class="tc-table-of-contents">
-        <$macrocall $name="toc-selective-expandable" tag=<<__tag__>> sort=<<__sort__>> itemClassFilter="[all[current]] -[<__selectedTiddler__>get[text]]" exclude=<<__exclude__>>/>
+<$let __tag__={{{ [<__tag__>is[blank]then<currentTiddler>else<__tag__>] }}}>
+  <$tiddler tiddler={{{ [<__selectedTiddler__>get[text]] }}}>
+    <div class="tc-tabbed-table-of-contents">
+      <$linkcatcher to=<<__selectedTiddler__>>>
+        <div class="tc-table-of-contents">
+          <$macrocall $name="toc-selective-expandable" tag=<<__tag__>> sort=<<__sort__>> itemClassFilter="[all[current]] -[<__selectedTiddler__>get[text]]" exclude=<<__exclude__>>/>
+        </div>
+      </$linkcatcher>
+      <div class="tc-tabbed-table-of-contents-content">
+        <$reveal stateTitle=<<__selectedTiddler__>> type="nomatch" text="">
+          <$transclude mode="block" tiddler=<<__template__>>>
+            <h1><<toc-caption>></h1>
+            <$transclude mode="block">$missingText$</$transclude>
+          </$transclude>
+        </$reveal>
+        <$reveal stateTitle=<<__selectedTiddler__>> type="match" text="">
+          $unselectedText$
+        </$reveal>
       </div>
-    </$linkcatcher>
-    <div class="tc-tabbed-table-of-contents-content">
-      <$reveal stateTitle=<<__selectedTiddler__>> type="nomatch" text="">
-        <$transclude mode="block" tiddler=<<__template__>>>
-          <h1><<toc-caption>></h1>
-          <$transclude mode="block">$missingText$</$transclude>
-        </$transclude>
-      </$reveal>
-      <$reveal stateTitle=<<__selectedTiddler__>> type="match" text="">
-        $unselectedText$
-      </$reveal>
     </div>
-  </div>
-</$tiddler>
+  </$tiddler>
+</$let>
 \end
 
 \define toc-tabbed-internal-nav(tag,sort:"",selectedTiddler:"$:/temp/toc/selectedTiddler",unselectedText,missingText,template:"",exclude)
 \whitespace trim
-<$linkcatcher to=<<__selectedTiddler__>>>
-  <$macrocall $name="toc-tabbed-external-nav" tag=<<__tag__>> sort=<<__sort__>> selectedTiddler=<<__selectedTiddler__>> unselectedText=<<__unselectedText__>> missingText=<<__missingText__>> template=<<__template__>> exclude=<<__exclude__>> />
-</$linkcatcher>
+<$let __tag__={{{ [<__tag__>is[blank]then<currentTiddler>else<__tag__>] }}}>
+  <$linkcatcher to=<<__selectedTiddler__>>>
+    <$macrocall $name="toc-tabbed-external-nav" tag=<<__tag__>> sort=<<__sort__>> selectedTiddler=<<__selectedTiddler__>> unselectedText=<<__unselectedText__>> missingText=<<__missingText__>> template=<<__template__>> exclude=<<__exclude__>> />
+  </$linkcatcher>
+</$let>
 \end

--- a/editions/tw5.com/tiddlers/macros/TableOfContentsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TableOfContentsMacro.tid
@@ -1,27 +1,31 @@
 created: 20140919155729620
-modified: 20230427125500432
+modified: 20240624102502089
 tags: Macros [[Core Macros]]
 title: Table-of-Contents Macros
 type: text/vnd.tiddlywiki
 
 ~TiddlyWiki provides several macros for generating a tree of tiddler links by analysing [[tags|Tagging]]:
 
-;<<.var toc>>
+; <<.var toc>>
 : A simple tree
-;<<.var toc-expandable>>
+
+; <<.var toc-expandable>>
 : A tree in which all the branches can be expanded and collapsed
-;<<.var toc-selective-expandable>>
+
+; <<.var toc-selective-expandable>>
 : A tree in which the non-empty branches can be expanded and collapsed
-;<<.var toc-tabbed-internal-nav>> and <<.var toc-tabbed-external-nav>>
+
+; <<.var toc-tabbed-internal-nav>> and <<.var toc-tabbed-external-nav>>
 : A two-panel browser:
 :* on the left, a selectively expandable tree that behaves like a set of vertical tabs
 :* on the right, the content of whichever tiddler the user selects in the tree
 
 The difference between the last two has to do with what happens when the user clicks a link in the right-hand panel:
 
-;<<.var toc-tabbed-internal-nav>>
+; <<.var toc-tabbed-internal-nav>>
 : The target tiddler appears in the right-hand panel, replacing the tiddler that contained the link
-;<<.var toc-tabbed-external-nav>>
+
+; <<.var toc-tabbed-external-nav>>
 : The target tiddler appears in the normal way (which depends on the user's configured storyview)
 
 !! Structure
@@ -42,9 +46,11 @@ To make a table of contents appear in the sidebar, see [[How to add a new tab to
 
 !! Parameters
 
-;tag
+; tag
 : The root tag that identifies the top level of the tree
-;sort
+: <<.from-version "5.3.5">> If the <<.param tag>> parameter is "missing" or "an empty" string, the <<.var curretTiddler>> variable is used
+
+; sort
 : An optional extra [[filter step|Filter Step]], e.g. `sort[title]`
 
 These two parameters are combined into a single [[filter expression|Filter Expression]] like this:


### PR DESCRIPTION
This PR fixes #8289

- #8289

- The Toc uses currentTiddler as "tag" default parameter if it is missing.
- A little bit of docs changes.

@springerspandrel can you please test the prview, once it's built.