### PR TITLE
Fix server crash with newlines in server name or site title

### DIFF
--- a/core/modules/utils/transliterate.js
+++ b/core/modules/utils/transliterate.js
@@ -924,7 +924,7 @@ exports.transliterate = function(str) {
 };
 
 exports.transliterateToSafeASCII = function(str) {
-	return str.replace(/[^\x00-\x7F]/g,function(ch) {
+	return str.replace(/[^\x20-\x7F]/g,function(ch) {
 		return exports.transliterationPairs[ch] || ""
 	});
 };


### PR DESCRIPTION
Fixed by transliterating control characters.

Fixes #8338 