### PR TITLE
Fix missing closing tag, and update erroneous docs

### DIFF
--- a/core/templates/tiddlywiki5.html.tid
+++ b/core/templates/tiddlywiki5.html.tid
@@ -57,3 +57,4 @@ title: $:/core/templates/tiddlywiki5.html
 `{{{ [enlist<saveTiddlerAndShadowsFilter>tag[$:/tags/RawMarkupWikified/BottomBody]] ||$:/core/templates/raw-static-tiddler}}}`
 </body>
 </html>`
+</$set>

--- a/core/wiki/macros/tag.tid
+++ b/core/wiki/macros/tag.tid
@@ -7,7 +7,7 @@ fill:$(foregroundColor)$;
 color:$(foregroundColor)$;
 \end
 
-<!-- This has no whitespace trim to avoid modifying $actions$. Closing tags omitted for brevity. -->
+<!-- This has no whitespace trim to avoid modifying $actions$ -->
 \define tag-pill-inner(tag,icon,colour,fallbackTarget,colourA,colourB,element-tag,element-attributes,actions)
 \whitespace trim
 <$let


### PR DESCRIPTION
Fixes a missing closing tag in the template `$:/core/templates/tiddlywiki5.html`, and removes an obsolete comment

See https://talk.tiddlywiki.org/t/closing-set-nested-setwidgets/10100/10 for background