### PR TITLE
Use testcase tiddlers for html examples

### DIFF
--- a/editions/tw5.com/tiddlers/testcases/HTML/BlockModeInHTMLTable.tid
+++ b/editions/tw5.com/tiddlers/testcases/HTML/BlockModeInHTMLTable.tid
@@ -1,0 +1,30 @@
+created: 20240713164810184
+description: Block mode for table cells
+modified: 20240713164810184
+tags: $:/tags/wiki-test-spec
+title: TestCases/HTML/BlockModeInHTMLTable
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+Unlike the table wiki syntax, the less convenient `<table>`, `<tr>`, `<td>` html tags can use a blank line
+to get block mode punctuation regognised inside of table cells.
++
+title: Output
+
+<table>
+<tr><td>
+
+* list item one
+* list item two
+</td><td>
+
+|nested|table|
+</td></tr>
+</table>
++
+title: ExpectedResult
+
+<p><table>
+<tr><td><ul><li>list item one</li><li>list item two</li></ul></td><td><table><tbody><tr class="evenRow"><td>nested</td><td>table</td></tr></tbody></table></td></tr>
+</table></p>

--- a/editions/tw5.com/tiddlers/testcases/HTML/OpenTagBlankLine.tid
+++ b/editions/tw5.com/tiddlers/testcases/HTML/OpenTagBlankLine.tid
@@ -1,0 +1,23 @@
+created: 20240622142425004
+description: Blank line after open tag
+modified: 20240622144230258
+tags: $:/tags/wiki-test-spec
+title: TestCases/HTML/OpenTagBlankLine
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+A blank line after an open html tag allows block mode punctuation to be recognised
++
+title: Output
+
+<div>
+
+* blank line after open tag allows
+* block mode punctuation (i.e. this list) to
+* be recognised
+</div>
++
+title: ExpectedResult
+
+<div><ul><li>blank line after open tag allows</li><li>block mode punctuation (i.e. this list) to</li><li>be recognised</li></ul></div>

--- a/editions/tw5.com/tiddlers/testcases/HTML/OpenTagBlankLineInBoldSyntax.tid
+++ b/editions/tw5.com/tiddlers/testcases/HTML/OpenTagBlankLineInBoldSyntax.tid
@@ -1,0 +1,22 @@
+created: 20240622144038465
+description: Blank line after open tag in bold syntax
+modified: 20240622145114506
+tags: $:/tags/wiki-test-spec
+title: TestCases/HTML/OpenTagBlankLineInBoldSyntax
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+A blank line after an open html tag allows block mode punctuation to be recognised even when the html is embedded within inline punctuation (bold here).
++
+title: Output
+
+''<div>
+
+* list item one
+* list item two
+</div>''
++
+title: ExpectedResult
+
+<p><strong><div><ul><li>list item one</li><li>list item two</li></ul></div></strong></p>

--- a/editions/tw5.com/tiddlers/testcases/HTML/OpenTagBlankLineInTableSyntax.tid
+++ b/editions/tw5.com/tiddlers/testcases/HTML/OpenTagBlankLineInTableSyntax.tid
@@ -1,0 +1,22 @@
+created: 20240622144753311
+description: Blank line after open tag in table syntax
+modified: 20240622145056299
+tags: $:/tags/wiki-test-spec
+title: TestCases/HTML/OpenTagBlankLineInTableSyntax
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+A blank line after an open html tag cannot work when used inside table syntax since each row of a table must be all on one line
++
+title: Output
+
+|For a blank line after open tag|<div>
+
+* list is recognised
+* but the surrounding table row is not
+</div>|
++
+title: ExpectedResult
+
+<p>|For a blank line after open tag|<div><ul><li>list is recognised</li><li>but the surrounding table row is not</li></ul></div>|</p>

--- a/editions/tw5.com/tiddlers/testcases/HTML/OpenTagNoBlankLine.tid
+++ b/editions/tw5.com/tiddlers/testcases/HTML/OpenTagNoBlankLine.tid
@@ -1,0 +1,34 @@
+created: 20240622143533021
+description: No blank line after open tag
+modified: 20240622145145440
+tags: $:/tags/wiki-test-spec
+title: TestCases/HTML/OpenTagNoBlankLine
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+Block mode punctuation is not recognised when HTML open tag is not followed by a blank line
++
+title: Output
+
+<div>
+* Open tag without a blank line means
+* block mode punctuation (i.e. this list) will
+* NOT be recognised.
+
+Paragraphs are only recognised in block mode. Even with blank lines, new paragraphs are not recognised.
+
+This also is not a new paragraph.
+</div>
++
+title: ExpectedResult
+
+<p><div>
+* Open tag without a blank line means
+* block mode punctuation (i.e. this list) will
+* NOT be recognised.
+
+Paragraphs are only recognised in block mode. Even with blank lines, new paragraphs are not recognised.
+
+This also is not a new paragraph.
+</div></p>

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ HTML examples.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ HTML examples.tid
@@ -1,5 +1,5 @@
 created: 20220122153235162
-modified: 20240622150508298
+modified: 20240713165558596
 tags: [[WikiText parser mode transitions]]
 title: WikiText parser mode: HTML examples
 type: text/vnd.tiddlywiki
@@ -36,15 +36,4 @@ Note that <<.wlink MacroCallWidget>> does not have a similar <<.attr mode>> attr
 
 ---
 
-The less convenient `<table>`, `<tr>`, `<td>` html tags can be used as a foolproof way to get [[block mode|Block Mode WikiText]] punctuation recognised inside of table cells.
-
-<<wikitext-example-without-html "<table>
-<tr><td>
-
-* list item one
-* list item two
-</td><td>
-
-|nested|table|
-</td></tr>
-</table>">>
+<<testcase TestCases/HTML/BlockModeInHTMLTable>>

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ HTML examples.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ HTML examples.tid
@@ -1,38 +1,20 @@
 created: 20220122153235162
-modified: 20220122180508134
+modified: 20240622150508298
 tags: [[WikiText parser mode transitions]]
 title: WikiText parser mode: HTML examples
 type: text/vnd.tiddlywiki
 
-<<wikitext-example-without-html "<div>
-
-* blank line after open tag allows
-* block mode punctuation (i.e. this list) to
-* be recognised
-</div>
-">>
+<<testcase TestCases/HTML/OpenTagBlankLine>>
 
 ---
 
 The open tag blank line "trick" also works inside of punctuation only recognised in inline mode (such as [[Formatting in WikiText]]):
 
-<<wikitext-example-without-html "''<div>
-
-* list item one
-* list item two
-</div>''">>
+<<testcase TestCases/HTML/OpenTagBlankLineInBoldSyntax>>
 
 ---
 
-<<wikitext-example-without-html "<div>
-* Open tag without a blank line means
-* block mode punctuation (i.e. this list) will
-* NOT be recognised.
-
-Paragraphs are only recognised in block mode. Even with blank lines, new paragraphs are not recognised.
-
-This also is not a new paragraph.
-</div>">>
+<<testcase TestCases/HTML/OpenTagNoBlankLine>>
 
 ---
 
@@ -42,11 +24,7 @@ Adding a blank link after an open tag within a table cell causes the row to span
 
 <<wikitext-example-without-html "|table row|all on|one line|is recognised|">>
 
-<<wikitext-example-without-html "|For a blank line after open tag|<div>
-
-* list is recognised
-* but the surrounding table row is not
-</div>|">>
+<<testcase TestCases/HTML/OpenTagBlankLineInTableSyntax>>
 
 ---
 


### PR DESCRIPTION
Change the "WikiText parser mode: HTML examples" from inline examples into testcase tiddlers.