### PR TITLE
Add list links horizontal draggable procedure

### DIFF
--- a/core/wiki/macros/list-links-horizontal-draggable.tid
+++ b/core/wiki/macros/list-links-horizontal-draggable.tid
@@ -57,7 +57,6 @@ tags: $:/tags/Macro $:/tags/Global
 					<$droppable
 						actions=<<list-links-draggable-drop-actions>>
 						tag="span"
-						enable=<<_enable>>
 					>
 						<span class="tc-horizontal-draggable-placeholder tc-horizontal-draggable-placeholder-last"></span>
 					</$droppable>

--- a/core/wiki/macros/list-links-horizontal-draggable.tid
+++ b/core/wiki/macros/list-links-horizontal-draggable.tid
@@ -1,0 +1,69 @@
+title: $:/core/macros/list-links-horizontal-draggable
+tags: $:/tags/Macro $:/tags/Global
+
+\whitespace trim
+\procedure list-links-horizontal-draggable-caption()
+<$let tv-wikilinks="no">
+	<span class="tc-small-gap-right">
+		<$transclude field="caption">
+			<$view field="title"/>
+		</$transclude>
+	</span>
+</$let>
+\end
+
+\procedure list-links-horizontal-draggable(tiddler,field:"list",emptyMessage,type:"span",subtype:"span",class:"",itemTemplate,dragHandle:"yes",enable:"yes")
+	\procedure customSort() [<tiddler>get<field>enlist-input[]] :sort:alphanumeric:caseinsensitive[subfilter{$:/config/Tags/CustomSort/subfilter}]
+
+<span class="tc-horizontal-draggable tc-tiny-gap-right">
+	<$let targetTiddler=<<tiddler>>
+		targetField=<<field>>
+		_enable={{{ [<tv-enable-drag-and-drop>!match[no]then<enable>else[yes]] }}}
+		_dragHandle={{{ [<_enable>match[yes]then<dragHandle>else[no]] }}}
+	>
+	<$log/>
+		<$genesis $type=<<type>> class=<<class>>>
+			<$list filter=<<customSort>> emptyMessage=<<emptyMessage>>>
+				<$droppable
+					actions=<<list-links-draggable-drop-actions>>
+					tag=<<subtype>>
+					enable=<<_enable>>
+				>
+					<span class="tc-horizontal-draggable-placeholder"/>
+					<% if [<_dragHandle>match[yes]] %>
+						<$draggable tiddler={{!!title}} tag="span"
+							class="tc-draggable-handle"
+						/>
+					<% endif %>
+					<$draggable tiddler={{!!title}} tag="span"
+						enable={{{ [<_dragHandle>!match[yes]then<_enable>else[no]]  }}}
+						class="tc-horizontal-draggable-item"
+					>
+						<span class="tc-draggable-item"/>
+						<% if [<itemTemplate>is[variable]] %>
+							<$transclude $variable=<<itemTemplate>>>
+								<<list-links-horizontal-draggable-caption>>
+							</$transclude>
+						<% else %>
+							<$transclude $tiddler=<<itemTemplate>>>
+								<<list-links-horizontal-draggable-caption>>
+							</$transclude>
+						<% endif %>
+					</$draggable>
+				</$droppable>
+			</$list>
+			<% if [<_enable>match[yes]] %>
+				<$tiddler tiddler="">
+					<$droppable
+						actions=<<list-links-draggable-drop-actions>>
+						tag="span"
+						enable=<<_enable>>
+					>
+						<span class="tc-horizontal-draggable-placeholder tc-horizontal-draggable-placeholder-last"></span>
+					</$droppable>
+				</$tiddler>
+			<% endif %>
+		</$genesis>
+	</$let>
+</span>
+\end

--- a/core/wiki/macros/list-links-horizontal-draggable.tid
+++ b/core/wiki/macros/list-links-horizontal-draggable.tid
@@ -12,14 +12,14 @@ tags: $:/tags/Macro $:/tags/Global
 </$let>
 \end
 
-\procedure list-links-horizontal-draggable(tiddler,field:"list",emptyMessage,type:"span",subtype:"span",class:"",itemTemplate,dragHandle:"yes",enable:"yes")
+\procedure list-links-horizontal-draggable(tiddler,field:"list",emptyMessage,type:"span",subtype:"span",class:"",itemTemplate,dragHandle:"⠿",enable:"yes")
 	\procedure customSort() [<tiddler>get<field>enlist-input[]] :sort:alphanumeric:caseinsensitive[subfilter{$:/config/Tags/CustomSort/subfilter}]
 
 <span class="tc-horizontal-draggable tc-tiny-gap-right">
 	<$let targetTiddler=<<tiddler>>
 		targetField=<<field>>
 		_enable={{{ [<tv-enable-drag-and-drop>!match[no]then<enable>else[yes]] }}}
-		_dragHandle={{{ [<_enable>match[yes]then<dragHandle>else[no]] }}}
+		_dragHandle={{{ [<_enable>match[yes]then<dragHandle>else[]] }}}
 	>
 	<$log/>
 		<$genesis $type=<<type>> class=<<class>>>
@@ -30,16 +30,15 @@ tags: $:/tags/Macro $:/tags/Global
 					enable=<<_enable>>
 				>
 					<span class="tc-horizontal-draggable-placeholder"/>
-					<% if [<_dragHandle>match[yes]] %>
-						<$draggable tiddler={{!!title}} tag="span"
-							class="tc-draggable-handle"
-						/>
-					<% endif %>
 					<$draggable tiddler={{!!title}} tag="span"
-						enable={{{ [<_dragHandle>!match[yes]then<_enable>else[no]]  }}}
+						enable=<<_enable>>
 						class="tc-horizontal-draggable-item"
 					>
-						<span class="tc-draggable-item"/>
+						<% if [<_dragHandle>!is[blank]] %>
+							<span class="tc-draggable-handle tc-tiny-gap-right">
+								<<_dragHandle>>
+							</span>
+						<% endif %>
 						<% if [<itemTemplate>is[variable]] %>
 							<$transclude $variable=<<itemTemplate>>>
 								<<list-links-horizontal-draggable-caption>>

--- a/core/wiki/macros/list-links-horizontal-draggable.tid
+++ b/core/wiki/macros/list-links-horizontal-draggable.tid
@@ -13,7 +13,9 @@ tags: $:/tags/Macro $:/tags/Global
 \end
 
 \procedure list-links-horizontal-draggable(tiddler,field:"list",emptyMessage,type:"span",subtype:"span",class:"",itemTemplate,dragHandle:"⠿",enable:"yes")
-	\procedure customSort() [<tiddler>get<field>enlist-input[]] :sort:alphanumeric:caseinsensitive[subfilter{$:/config/Tags/CustomSort/subfilter}]
+	\procedure tagSort() [<tiddler>get<field>enlist-input[]] :sort:alphanumeric:caseinsensitive[subfilter{$:/config/Tags/CustomSort/subfilter}]
+	\procedure defaultSort() [<tiddler>get<field>enlist-input[]]
+	\function tf.customSort() [<field>match[tags]then<tagSort>else<defaultSort>]
 
 <span class="tc-horizontal-draggable tc-tiny-gap-right">
 	<$let targetTiddler=<<tiddler>>
@@ -21,9 +23,8 @@ tags: $:/tags/Macro $:/tags/Global
 		_enable={{{ [<tv-enable-drag-and-drop>!match[no]then<enable>else[yes]] }}}
 		_dragHandle={{{ [<_enable>match[yes]then<dragHandle>else[]] }}}
 	>
-	<$log/>
 		<$genesis $type=<<type>> class=<<class>>>
-			<$list filter=<<customSort>> emptyMessage=<<emptyMessage>>>
+			<$list filter=<<tf.customSort>> emptyMessage=<<emptyMessage>>>
 				<$droppable
 					actions=<<list-links-draggable-drop-actions>>
 					tag=<<subtype>>

--- a/editions/tw5.com/tiddlers/demonstrations/Weekdays/Days of the Week.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/Weekdays/Days of the Week.tid
@@ -1,6 +1,6 @@
 created: 20150117192110000
 list: Monday Tuesday Wednesday Thursday Friday Saturday Sunday
-modified: 20240716222620082
+modified: 20211116221246915
 my-special-list: [[listed Operator (Examples)]]
 short: Mon Tue Wed Thu Fri Sat Sun
 tags: [[Operator Examples]]

--- a/editions/tw5.com/tiddlers/demonstrations/Weekdays/Days of the Week.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/Weekdays/Days of the Week.tid
@@ -1,6 +1,6 @@
 created: 20150117192110000
 list: Monday Tuesday Wednesday Thursday Friday Saturday Sunday
-modified: 20211116221246915
+modified: 20240716222620082
 my-special-list: [[listed Operator (Examples)]]
 short: Mon Tue Wed Thu Fri Sat Sun
 tags: [[Operator Examples]]

--- a/editions/tw5.com/tiddlers/macros/examples/list-links-horizontal-draggable Macro (Examples).tid
+++ b/editions/tw5.com/tiddlers/macros/examples/list-links-horizontal-draggable Macro (Examples).tid
@@ -1,6 +1,12 @@
 created: 20240712134945885
-modified: 20240712135014913
+modified: 20240716222408892
 title: list-links-horizontal-draggable Macro (Examples)
 type: text/vnd.tiddlywiki
 
 <$macrocall $name=".example" n="1" eg="""<<list-links-horizontal-draggable tiddler:"Days of the Week">>"""/>
+
+<$macrocall $name=".example" n="2" eg="""<<list-links-horizontal-draggable tiddler:"Days of the Week" dragHandle:"">>"""/>
+
+<$macrocall $name=".example" n="3" eg="""<<list-links-horizontal-draggable tiddler:"Days of the Week" dragHandle:{{$:/core/images/close-others-button|11px}}>>"""/>
+
+<$macrocall $name=".example" n="4" eg="""<<list-links-horizontal-draggable tiddler:"Days of the Week" enable:"no">>"""/>

--- a/editions/tw5.com/tiddlers/macros/examples/list-links-horizontal-draggable Macro (Examples).tid
+++ b/editions/tw5.com/tiddlers/macros/examples/list-links-horizontal-draggable Macro (Examples).tid
@@ -1,0 +1,6 @@
+created: 20240712134945885
+modified: 20240712135014913
+title: list-links-horizontal-draggable Macro (Examples)
+type: text/vnd.tiddlywiki
+
+<$macrocall $name=".example" n="1" eg="""<<list-links-horizontal-draggable tiddler:"Days of the Week">>"""/>

--- a/editions/tw5.com/tiddlers/macros/list-links-horizontal-draggable Procedure.tid
+++ b/editions/tw5.com/tiddlers/macros/list-links-horizontal-draggable Procedure.tid
@@ -1,6 +1,6 @@
 caption: list-links-horizontal-draggable
 created: 20240712134619467
-modified: 20240716135427247
+modified: 20240716221918196
 tags: Macros [[Core Macros]]
 title: list-links-horizontal-draggable Procedure
 type: text/vnd.tiddlywiki
@@ -33,7 +33,7 @@ The <<.def list-links-horizontal-draggable>> [[procedure|Procedures]] renders th
 : Optional title of a tiddler to use as the template for rendering list items
 
 ; dragHandle
-: Defaults to: ''yes''. If shows a drag handle: `⠿` in front of every item. If set to ''no'' the handle is removed
+: Defaults to: `⠿`. It shows ⠿ in front of every item. If set to an ''empty string'' the handle is removed
 
 ; enable
 : Defaults to: ''yes''. If set to ''no'' the draggability function and the handles are removed

--- a/editions/tw5.com/tiddlers/macros/list-links-horizontal-draggable Procedure.tid
+++ b/editions/tw5.com/tiddlers/macros/list-links-horizontal-draggable Procedure.tid
@@ -1,11 +1,11 @@
 caption: list-links-horizontal-draggable
 created: 20240712134619467
-modified: 20240716221918196
+modified: 20240717095358843
 tags: Macros [[Core Macros]]
 title: list-links-horizontal-draggable Procedure
 type: text/vnd.tiddlywiki
 
-<<.from-version "5.3.7">>
+<<.from-version "5.3.6">>
 
 The <<.def list-links-horizontal-draggable>> [[procedure|Procedures]] renders the ListField of a tiddler as a list that can be reordered via [[drag and drop|Drag and Drop]].
 

--- a/editions/tw5.com/tiddlers/macros/list-links-horizontal-draggable Procedure.tid
+++ b/editions/tw5.com/tiddlers/macros/list-links-horizontal-draggable Procedure.tid
@@ -1,0 +1,45 @@
+caption: list-links-horizontal-draggable
+created: 20240712134619467
+modified: 20240716135427247
+tags: Macros [[Core Macros]]
+title: list-links-horizontal-draggable Procedure
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.3.7">>
+
+The <<.def list-links-horizontal-draggable>> [[procedure|Procedures]] renders the ListField of a tiddler as a list that can be reordered via [[drag and drop|Drag and Drop]].
+
+!! Parameters
+
+; tiddler
+: The title of the tiddler containing the list
+
+; field
+: The name of the field containing the list (defaults to `list`)
+
+; emptyMessage
+: Optional wikitext to display if there is no output (tiddler is not existed, field is not existed or empty)
+
+; type
+: The element tag to use for the list wrapper (defaults to `span`)
+
+; subtype
+: The element tag to use for the list items (defaults to `span`)
+
+; class
+: Optional space separated classes to add to the wrapper element
+
+; itemTemplate
+: Optional title of a tiddler to use as the template for rendering list items
+
+; dragHandle
+: Defaults to: ''yes''. If shows a drag handle: `⠿` in front of every item. If set to ''no'' the handle is removed
+
+; enable
+: Defaults to: ''yes''. If set to ''no'' the draggability function and the handles are removed
+
+If the `itemTemplate` parameter is not provided then the list items are rendered as simple text. Within the `itemTemplate`, the [[currentTiddler Variable]] refers to the current list item.
+
+<<.warning """Be ware, that the macro internally respects the global variable `tv-enable-drag-and-drop`.<br>See: [[Hidden Setting: Disable Drag and Drop]]""">>
+
+<<.macro-examples "list-links-horizontal-draggable">>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -543,8 +543,7 @@ a.tc-tiddlylink-external:hover {
 }
 
 /* content: braille pattern 283F */
-.tc-draggable-handle::before {
-	content: '⠿';
+.tc-draggable-handle {
 	cursor: ew-resize;
 	display: inline-block;
 }
@@ -574,11 +573,6 @@ a.tc-tiddlylink-external:hover {
 	.tc-droppable.tc-dragover > .tc-horizontal-draggable-placeholder-last {
 		display: block;
 		min-height: 2em;
-	}
-	.tc-draggable-handle::before {
-		content: '⠿';
-		padding-left: 10px;
-		padding-right: 7px;
 	}
 }
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -528,9 +528,60 @@ a.tc-tiddlylink-external:hover {
 	border: 2px dashed <<colour dropzone-background>>;
 }
 
+.tc-droppable.tc-dragover .tc-horizontal-draggable-placeholder {
+	outline: 2px dashed <<colour dropzone-background>>;
+}
+
+.tc-horizontal-draggable-placeholder {
+	display: inline;
+}
+
+.tc-horizontal-draggable-placeholder-last {
+	display: inline-block;
+	min-width: 1em;
+	min-height: 1em;
+}
+
+/* content: braille pattern 283F */
+.tc-draggable-handle::before {
+	content: '⠿';
+	cursor: ew-resize;
+	display: inline-block;
+}
+
 .tc-draggable {
 	cursor: move;
 }
+
+.tc-horizontal-draggable .tc-draggable {
+	cursor: ew-resize;
+}
+
+@media (max-width: <<sidebarbreakpoint-minus-one>>) {
+	.tc-droppable.tc-dragover > .tc-horizontal-draggable-placeholder-last,
+	.tc-droppable.tc-dragover > .tc-horizontal-draggable-placeholder {
+		display: inline-block;
+		min-width: 4em;
+		min-height: 1em;
+	}
+
+	.tc-horizontal-draggable-placeholder-last {
+		outline: 1px dashed <<colour foreground>>;
+		display: block;
+		min-height: 2em;
+	}
+
+	.tc-droppable.tc-dragover > .tc-horizontal-draggable-placeholder-last {
+		display: block;
+		min-height: 2em;
+	}
+	.tc-draggable-handle::before {
+		content: '⠿';
+		padding-left: 10px;
+		padding-right: 7px;
+	}
+}
+
 
 .tc-sidebar-tab-open .tc-droppable-placeholder, .tc-tagged-draggable-list .tc-droppable-placeholder,
 .tc-links-draggable-list .tc-droppable-placeholder {
@@ -1581,7 +1632,15 @@ html body.tc-body.tc-single-tiddler-window {
 }
 
 .tc-remove-tag-button {
-	padding-left: 4px;
+	padding-left: 6px;
+	margin-left: 4px;
+}
+
+@media (max-width: <<sidebarbreakpoint-minus-one>>) {
+	.tc-remove-tag-button {
+		padding-left: 14px;
+		margin-left: 6px;
+	}
 }
 
 .tc-tiddler-editor {


### PR DESCRIPTION
This PR adds a new `list-links-horizontal-draggable` procedure, which can be used to:

- "drag and drop" sort **tags** and **list-like** fields.
- It should be able to use it to dnd sort tabs within the tabs macro (once it will be rewritten)
- This PR is related to #8352

For larger screens it looks like this: 

![image](https://github.com/user-attachments/assets/25944b84-8ddf-45a5-98f3-100a2b53afac)

For mobile screens:

- The last position drop area is now below the list, so it should be easy to move an item to the end of the list
- The standard drop positions are much larger then for PC screens. So the can be seen below fingers. 
   - At least it works for me

![image](https://github.com/user-attachments/assets/ff30caf1-d2bc-4179-a010-b59da41f4a77)
