### PR TITLE
Fix unwrapped oveflowed code blocks not showing scroll bars when setting "Wrap long lines in code blocks" to "No" in "Theme tweaks"

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -157,6 +157,7 @@ code {
 	color: <<colour code-foreground>>;
 	background-color: <<colour code-background>>;
 	border: 1px solid <<colour code-border>>;
+	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
 	padding: 0 3px 2px;
 	border-radius: 3px;
 	font-family: {{$:/themes/tiddlywiki/vanilla/settings/codefontfamily}};
@@ -288,7 +289,6 @@ Markdown likes putting code elements inside pre elements
 */
 pre > code {
 	display: block;
-	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
 	padding: 0.5em;
 	border: none;
 	background-color: inherit;

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -157,7 +157,6 @@ code {
 	color: <<colour code-foreground>>;
 	background-color: <<colour code-background>>;
 	border: 1px solid <<colour code-border>>;
-	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
 	padding: 0 3px 2px;
 	border-radius: 3px;
 	font-family: {{$:/themes/tiddlywiki/vanilla/settings/codefontfamily}};
@@ -289,6 +288,7 @@ Markdown likes putting code elements inside pre elements
 */
 pre > code {
 	display: block;
+	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
 	padding: 0.5em;
 	border: none;
 	background-color: inherit;

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -157,7 +157,7 @@ code {
 	color: <<colour code-foreground>>;
 	background-color: <<colour code-background>>;
 	border: 1px solid <<colour code-border>>;
-	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
+	white-space: pre-wrap;
 	padding: 0 3px 2px;
 	border-radius: 3px;
 	font-family: {{$:/themes/tiddlywiki/vanilla/settings/codefontfamily}};
@@ -291,6 +291,7 @@ pre > code {
 	display: block;
 	padding: 0.5em;
 	border: none;
+	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
 	background-color: inherit;
 	color: inherit;
 	overflow-x: auto;

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -288,10 +288,12 @@ form.tc-form-inline {
 Markdown likes putting code elements inside pre elements
 */
 pre > code {
-	padding: 0;
+	display: block;
+	padding: 0.5em;
 	border: none;
 	background-color: inherit;
 	color: inherit;
+	overflow-x: auto;
 }
 
 /*


### PR DESCRIPTION
This PR fixes #8278 

![图片](https://github.com/user-attachments/assets/35e35977-be8d-435f-ba1b-a8a2de0be940)
