### PR TITLE
Fix $:/core/ui/testcases/DefaultTemplate so narrative can use wikitext formatting

### DIFF
--- a/core/ui/TestCases/DefaultTemplate.tid
+++ b/core/ui/TestCases/DefaultTemplate.tid
@@ -1,4 +1,5 @@
 title: $:/core/ui/testcases/DefaultTemplate
+code-body: yes
 
 \whitespace trim
 \procedure linkcatcherActions()
@@ -46,7 +47,7 @@ title: $:/core/ui/testcases/DefaultTemplate
 								<$list filter="[all[shadows+tiddlers]tag[$:/tags/TestCase/Actions]!has[draft.of]]"
 									variable="listItem"
 								>
-									<$transclude tiddler=<<listItem>> mode="inline"/>
+									<$transclude $tiddler=<<listItem>> $mode="inline"/>
 								</$list>
 							</div>
 						</$reveal>
@@ -56,7 +57,7 @@ title: $:/core/ui/testcases/DefaultTemplate
 		</div>
 		<%if [[Narrative]is[tiddler]] %>
 			<div class="tc-test-case-narrative">
-				<$transclude $tiddler="Narrative" mode="block"/>
+				<$transclude $tiddler="Narrative" $mode="block"/>
 			</div>
 		<%endif%>
 		<%if [<testResult>match[fail]] %>


### PR DESCRIPTION
This PR fixes: `$:/core/ui/testcases/DefaultTemplate` so narrative can use wikitext formatting. 

- transclusion **mode** parameter has to be **$mode** if `$tiddler` is uses
- set `code-body: yes`