### PR TITLE
add suffix:ordered to tags-operator to be 100% backwards compatibility

### DIFF
--- a/core/modules/filters/tags.js
+++ b/core/modules/filters/tags.js
@@ -16,15 +16,35 @@ Filter operator returning all the tags of the selected tiddlers
 Export our filter function
 */
 exports.tags = function(source,operator,options) {
-	var tags = {};
+	var tags = {},
+		tagArray = [],
+		orderedTags= [],
+		cnt = 0;
 	source(function(tiddler,title) {
 		var t, length;
 		if(tiddler && tiddler.fields.tags) {
 			for(t=0, length=tiddler.fields.tags.length; t<length; t++) {
-				tags[tiddler.fields.tags[t]] = true;
+				tags[tiddler.fields.tags[t]] = cnt++;
 			}
 		}
 	});
+	if(operator.suffix === "ordered") {
+		// Convert 'tags' into an array of {key:value} objects
+		$tw.utils.each(tags,function(cnt,tag) {
+			tagArray.push({tag:tag, cnt:cnt})
+		})
+
+		// Sort the array by 'cnt' in ascending order
+		tagArray.sort(function(a,b) {
+			return a.cnt - b.cnt;
+		});
+
+		// Convert to simple array
+		$tw.utils.each(tagArray,function(item) {
+			orderedTags.push(item.tag)
+		})
+		return orderedTags;
+	}
 	return Object.keys(tags);
 };
 

--- a/editions/tw5.com/tiddlers/filters/tags.tid
+++ b/editions/tw5.com/tiddlers/filters/tags.tid
@@ -1,14 +1,18 @@
+caption: tags
 created: 20140410103123179
-modified: 20150203191657000
+modified: 20240725124555323
+op-input: a [[selection of titles|Title Selection]]
+op-output: all the tags carried by the input tiddlers
+op-parameter: none
+op-purpose: select all tags of the input tiddlers
+op-suffix: `ordered` guarantees the sort order even if tags are numbers. <<.from-version "5.3.6">>
+op-suffix-name: S
 tags: [[Filter Operators]] [[Tag Operators]]
 title: tags Operator
 type: text/vnd.tiddlywiki
-caption: tags
-op-purpose: select all tags of the input tiddlers
-op-input: a [[selection of titles|Title Selection]]
-op-parameter: none
-op-output: all the tags carried by the input tiddlers
 
 Each input title is processed in turn. The corresponding tiddler's tags are retrieved (in order of appearance in the <<.field tags>> field) and then [[dominantly appended|Dominant Append]] to the operator's output.
+
+<<.from-version "5.3.6">> If the <<.param suffix>> <<.place S>> is set to  `ordered`, numerical and unicode tags are also listed in order of creation.
 
 <<.operator-examples "tags">>


### PR DESCRIPTION
This PR is related to: #8352

- This is the first step to allow us to sort tags in the order they are created
- This PR should be 100% backwards compatible, since it does not change the default behaviour
- If the `suffix:ordered` is used, we now return the list of tags in the order, they are created, and in the order as described in the docs
  - even if tags are numbers, which `Object.keys()` always lists at the beginning of the list
- Change tags-operator doc tiddler



