### PR TITLE
bootprefix: Tighten browser check to include the document global

### DIFF
--- a/boot/bootprefix.js
+++ b/boot/bootprefix.js
@@ -21,7 +21,7 @@ $tw.boot = $tw.boot || Object.create(null);
 
 // Detect platforms
 if(!("browser" in $tw)) {
-	$tw.browser = typeof(window) !== "undefined" ? {} : null;
+	$tw.browser = typeof(window) !== "undefined" && typeof(document) !== "undefined" ? {} : null;
 }
 if(!("node" in $tw)) {
 	$tw.node = typeof(process) === "object" ? {} : null;


### PR DESCRIPTION
[Deno](https://deno.com/)'s node emulation can run TiddlyWiki now that it supports the VM isolates API, but the `window` global exists in that environment, so both browser and node were being detected, causing the autoboot to trip up on nonexistent `argv`, as the boot was happening in the constructor right before `argv` was set.

Ref: https://github.com/denoland/deno/issues/19286
Ref: https://github.com/flexdinesh/browser-or-node