### PR TITLE
Add Copy to Clipboard Button to Code Template

### DIFF
--- a/core/ui/ViewTemplate/body/code.tid
+++ b/core/ui/ViewTemplate/body/code.tid
@@ -1,3 +1,4 @@
 title: $:/core/ui/ViewTemplate/body/code
 
+<$transclude $variable="copy-to-clipboard-above-right" src={{{ [<currentTiddler>get[text]] }}} />
 <$codeblock code={{{ [<currentTiddler>get[text]] }}} language={{{ [<currentTiddler>get[type]else[text/vnd.tiddlywiki]] }}}/>


### PR DESCRIPTION

The `$:/core/ui/ViewTemplate/body/code` is used in several places. See for example

https://tiddlywiki.com/prerelease/#%24%3A%2Fcore%2Fui%2FControlPanel%2FViewTemplateBody

Which implements Cascades for `view template body`.

This PR adds a copy to clipboard button on the top right of revealed code, allow users to simply copy the code of tiddler.