### PR TITLE
[DOCS] Fix empty-tag-node-template. removing redundant DOM elements if no list is shown

### DIFF
--- a/editions/tw5.com/tiddlers/empty-tag-node-template.tid
+++ b/editions/tw5.com/tiddlers/empty-tag-node-template.tid
@@ -5,7 +5,8 @@ tags: $:/tags/ViewTemplate
 title: $:/editions/tw5.com/empty-tag-node-template
 type: 
 
-<$list filter='[<storyTiddler>!has[text]!has[tags]] :filter[tagging[]]'>
+<% if [<storyTiddler>!has[text]!has[tags]tagging[]] %>
 The following tiddlers are tagged with <<tag>>:
-</$list>
+
 <<list-links filter:"[<storyTiddler>!has[text]!has[tags]tagging[]]" class:"multi-columns">>
+<% endif %>


### PR DESCRIPTION
This doc-only PR fixes: https://github.com/TiddlyWiki/TiddlyWiki5/discussions/8429

Fix empty-tag-node-template. removing redundant DOM elements if no list is shown