### PR TITLE
Remove Redundant Filter in ViewTemplateBodyFilters

### DIFF
--- a/core/wiki/config/ViewTemplateBodyFilters.multids
+++ b/core/wiki/config/ViewTemplateBodyFilters.multids
@@ -4,7 +4,7 @@ tags: $:/tags/ViewTemplateBodyFilter
 testcase: [tag[$:/tags/wiki-test-spec]type[text/vnd.tiddlywiki-multiple]then[$:/core/ui/TestCaseTemplate]] [tag[$:/tags/wiki-test-spec-failing]type[text/vnd.tiddlywiki-multiple]then[$:/core/ui/TestCaseTemplate]]
 stylesheet: [tag[$:/tags/Stylesheet]then[$:/core/ui/ViewTemplate/body/rendered-plain-text]]
 core-ui-tags: [tag[$:/tags/PageTemplate]] [tag[$:/tags/EditTemplate]] [tag[$:/tags/ViewTemplate]] [tag[$:/tags/KeyboardShortcut]] [tag[$:/tags/ImportPreview]] [tag[$:/tags/EditPreview]][tag[$:/tags/EditorToolbar]] [tag[$:/tags/Actions]] :then[[$:/core/ui/ViewTemplate/body/code]]
-system: [prefix[$:/boot/]][prefix[$:/core/macros]][prefix[$:/core/save/]][prefix[$:/core/templates/]] [prefix[$:/config/]][prefix[$:/info/]][prefix[$:/language/]][prefix[$:/languages/]][prefix[$:/snippets/]] [prefix[$:/info/]][prefix[$:/state/]][prefix[$:/status/]][prefix[$:/temp/]]:and[!is[image]] :then[[$:/core/ui/ViewTemplate/body/code]]
+system: [prefix[$:/boot/]] [prefix[$:/core/macros]] [prefix[$:/core/save/]] [prefix[$:/core/templates/]]  [prefix[$:/config/]] [prefix[$:/info/]] [prefix[$:/language/]] [prefix[$:/languages/]] [prefix[$:/snippets/]]  [prefix[$:/info/]] [prefix[$:/state/]] [prefix[$:/status/]] [prefix[$:/temp/]] :and[!is[image]]  :then[[$:/core/ui/ViewTemplate/body/code]]
 code-body: [field:code-body[yes]then[$:/core/ui/ViewTemplate/body/code]]
 import: [field:plugin-type[import]then[$:/core/ui/ViewTemplate/body/import]]
 plugin: [has[plugin-type]then[$:/core/ui/ViewTemplate/body/plugin]]

--- a/core/wiki/config/ViewTemplateBodyFilters.multids
+++ b/core/wiki/config/ViewTemplateBodyFilters.multids
@@ -4,7 +4,7 @@ tags: $:/tags/ViewTemplateBodyFilter
 testcase: [tag[$:/tags/wiki-test-spec]type[text/vnd.tiddlywiki-multiple]then[$:/core/ui/TestCaseTemplate]] [tag[$:/tags/wiki-test-spec-failing]type[text/vnd.tiddlywiki-multiple]then[$:/core/ui/TestCaseTemplate]]
 stylesheet: [tag[$:/tags/Stylesheet]then[$:/core/ui/ViewTemplate/body/rendered-plain-text]]
 core-ui-tags: [tag[$:/tags/PageTemplate]] [tag[$:/tags/EditTemplate]] [tag[$:/tags/ViewTemplate]] [tag[$:/tags/KeyboardShortcut]] [tag[$:/tags/ImportPreview]] [tag[$:/tags/EditPreview]][tag[$:/tags/EditorToolbar]] [tag[$:/tags/Actions]] :then[[$:/core/ui/ViewTemplate/body/code]]
-system: [prefix[$:/boot/]] [prefix[$:/config/]] [prefix[$:/core/macros]] [prefix[$:/core/save/]] [prefix[$:/core/templates/]]  [prefix[$:/info/]] [prefix[$:/language/]] [prefix[$:/languages/]] [prefix[$:/snippets/]] [prefix[$:/state/]] [prefix[$:/status/]] [prefix[$:/info/]] [prefix[$:/temp/]] +[!is[image]limit[1]then[$:/core/ui/ViewTemplate/body/code]]
+system: [prefix[$:/boot/]][prefix[$:/core/macros]][prefix[$:/core/save/]][prefix[$:/core/templates/]] [prefix[$:/config/]][prefix[$:/info/]][prefix[$:/language/]][prefix[$:/languages/]][prefix[$:/snippets/]] [prefix[$:/info/]][prefix[$:/state/]][prefix[$:/status/]][prefix[$:/temp/]]:and[!is[image]] :then[[$:/core/ui/ViewTemplate/body/code]]
 code-body: [field:code-body[yes]then[$:/core/ui/ViewTemplate/body/code]]
 import: [field:plugin-type[import]then[$:/core/ui/ViewTemplate/body/import]]
 plugin: [has[plugin-type]then[$:/core/ui/ViewTemplate/body/plugin]]


### PR DESCRIPTION
This PR closes #8426

- The filters are given in a more semantic way
- The redundant filter `[prefix[$:/info]]` was removed
- The `limit[1]` was removed as the whole filter wont returns more than one result
- The `:then` was used which is more meaningful here with multi filters like [$:/config/ViewTemplateBodyFilters/core-ui-tags](https://tiddlywiki.com/prerelease/#%24%3A%2Fconfig%2FViewTemplateBodyFilters%2Fcore-ui-tags)

