### PR TITLE
Fix extra state tab when exporting testcase tiddlers

### DIFF
--- a/core/ui/TestCases/DefaultTemplate.tid
+++ b/core/ui/TestCases/DefaultTemplate.tid
@@ -72,7 +72,7 @@ code-body: yes
 		<%endif%>
 		<div class="tc-test-case-panes">
 			<div class="tc-test-case-source">
-				<$macrocall $name="tabs" tabsList="[all[tiddlers]sort[]] -[prefix<state>] -[prefix[$:/state/popup/export]] -Description -Narrative -Output Output +[putfirst[]] -[has[plugin-type]]" state=<<state>> default="Output" template="$:/core/ui/testcases/DefaultTemplate/SourceTabs"/>
+				<$macrocall $name="tabs" tabsList="[all[tiddlers]sort[]] Output +[putfirst[]] -[prefix<state>] -[prefix[$:/state/popup/export]] -Description -Narrative -[has[plugin-type]]" state=<<state>> default="Output" template="$:/core/ui/testcases/DefaultTemplate/SourceTabs"/>
 			</div>
 			<div class="tc-test-case-divider">
 			</div>

--- a/core/ui/TestCases/DefaultTemplate.tid
+++ b/core/ui/TestCases/DefaultTemplate.tid
@@ -72,7 +72,7 @@ code-body: yes
 		<%endif%>
 		<div class="tc-test-case-panes">
 			<div class="tc-test-case-source">
-				<$macrocall $name="tabs" tabsList="[all[tiddlers]sort[]] -[prefix<state>] -Description -Narrative -Output Output +[putfirst[]] -[has[plugin-type]]" state=<<state>> default="Output" template="$:/core/ui/testcases/DefaultTemplate/SourceTabs"/>
+				<$macrocall $name="tabs" tabsList="[all[tiddlers]sort[]] -[prefix[$:/state/]] -Description -Narrative -Output Output +[putfirst[]] -[has[plugin-type]]" state=<<state>> default="Output" template="$:/core/ui/testcases/DefaultTemplate/SourceTabs"/>
 			</div>
 			<div class="tc-test-case-divider">
 			</div>

--- a/core/ui/TestCases/DefaultTemplate.tid
+++ b/core/ui/TestCases/DefaultTemplate.tid
@@ -72,7 +72,7 @@ code-body: yes
 		<%endif%>
 		<div class="tc-test-case-panes">
 			<div class="tc-test-case-source">
-				<$macrocall $name="tabs" tabsList="[all[tiddlers]sort[]] -[prefix[$:/state/]] -Description -Narrative -Output Output +[putfirst[]] -[has[plugin-type]]" state=<<state>> default="Output" template="$:/core/ui/testcases/DefaultTemplate/SourceTabs"/>
+				<$macrocall $name="tabs" tabsList="[all[tiddlers]sort[]] -[prefix<state>] -[prefix[$:/state/popup/export]] -Description -Narrative -Output Output +[putfirst[]] -[has[plugin-type]]" state=<<state>> default="Output" template="$:/core/ui/testcases/DefaultTemplate/SourceTabs"/>
 			</div>
 			<div class="tc-test-case-divider">
 			</div>


### PR DESCRIPTION
Fix the apperance of extra state tab when exporting testcase tiddlers.

![图片](https://github.com/user-attachments/assets/5e757c53-1ae9-4cce-bddd-bf7a21b2e9cb)
 