### PR TITLE
Data widget add compound filter parameter

### DIFF
--- a/core/modules/widgets/data.js
+++ b/core/modules/widgets/data.js
@@ -75,7 +75,9 @@ DataWidget.prototype.computeDataTiddlerValues = function() {
 		}
 	});
 	// Deal with $tiddler, $filter or $compound-tiddler attributes
-	var tiddlers = [],title;
+	var tiddlers = [],
+		compoundTiddlers,
+		title;
 	if(this.hasAttribute("$tiddler")) {
 		title = this.getAttribute("$tiddler");
 		if(title) {
@@ -103,8 +105,17 @@ DataWidget.prototype.computeDataTiddlerValues = function() {
 			tiddlers.push.apply(tiddlers,this.extractCompoundTiddler(title));
 		}
 	}
+	if(this.hasAttribute("$compound-filter")) {
+		filter = this.getAttribute("$compound-filter");
+		if(filter) {
+			compoundTiddlers = this.wiki.filterTiddlers(filter);
+			$tw.utils.each(compoundTiddlers, function(title){
+				tiddlers.push.apply(tiddlers,self.extractCompoundTiddler(title));
+			});
+		}
+	}
 	// Return the literal item if none of the special attributes were used
-	if(!this.hasAttribute("$tiddler") && !this.hasAttribute("$filter") && !this.hasAttribute("$compound-tiddler")) {
+	if(!this.hasAttribute("$tiddler") && !this.hasAttribute("$filter") && !this.hasAttribute("$compound-tiddler") && !this.hasAttribute("$compound-filter")) {
 		if(Object.keys(item).length > 0 && !!item.title) {
 			return [new $tw.Tiddler(item)];
 		} else {

--- a/core/ui/TestCaseTemplate.tid
+++ b/core/ui/TestCaseTemplate.tid
@@ -13,7 +13,8 @@ title: $:/core/ui/TestCaseTemplate
 		testActions="Actions"
 		testHideIfPass=<<hideIfPass>>
 	>
+		<$data $compound-filter={{!!import-compound}}/>
 		<$data $compound-tiddler=<<currentTiddler>>/>
-		<$data title="Description" text={{!!description}}/>
+		<%if [{!!description}!is[blank]] %><$data title="Description" text={{!!description}}/><%endif%>
 	</$testcase>
 </$let>

--- a/editions/tw5.com/tiddlers/concepts/CompoundTiddlers.tid
+++ b/editions/tw5.com/tiddlers/concepts/CompoundTiddlers.tid
@@ -1,7 +1,8 @@
-title: CompoundTiddlers
-modified: 20240507221902644
 created: 20240507221902644
+modified: 20240729082610287
 tags: Concepts
+title: CompoundTiddlers
+type: text/vnd.tiddlywiki
 
 Compound tiddlers are a special type of tiddler that can store one or more payload tiddlers. The tiddlers within a compound tiddler are only accessible via special operations, typically with the TestCaseWidget.
 
@@ -29,3 +30,5 @@ tags: five six
 
 This is the third tiddler
 ```
+
+Also see: [[TestCaseTiddlers]]

--- a/editions/tw5.com/tiddlers/concepts/TestCaseTiddlers.tid
+++ b/editions/tw5.com/tiddlers/concepts/TestCaseTiddlers.tid
@@ -1,26 +1,30 @@
-title: TestCaseTiddlers
-modified: 20240507221902644
 created: 20240507221902644
+modified: 20240729083054531
 tags: Concepts
+title: TestCaseTiddlers
+type: text/vnd.tiddlywiki
 
-Test case tiddlers encapsulate one or more tiddlers that can be displayed as a [[test case|TestCaseWidget]]: an independent embedded wiki that can be used for testing or learning purposes.
+Test case tiddlers encapsulate one or more tiddlers that can be displayed as a <<.wlink TestCaseWidget>>: an independent embedded wiki that can be used for testing or learning purposes.
 
 Test case tiddlers are formatted as CompoundTiddlers, allowing them to contain multiple tiddlers packed into one.
 
-Test case tiddlers have the following fields:
+Test case tiddlers have the following ''fields'':
 
 |!Field |!Description |
-|<<.field type>> | Should be set to `text/vnd.tiddlywiki-multiple` |
-|<<.field tags>> | Test cases are tagged [[$:/tags/wiki-test-spec]]. Test cases that intentionally fail are tagged [[$:/tags/wiki-test-spec-failing]] |
+|<<.field type>> |Needs to be set to `text/vnd.tiddlywiki-multiple` |
+|<<.field tags>> |Test cases are tagged [[$:/tags/wiki-test-spec]]. Test cases that intentionally fail are tagged [[$:/tags/wiki-test-spec-failing]] |
 |<<.field description>> |Descriptive heading for the test, intended to make it easy to identify the test |
 |<<.field display-format>> |Optional, defaults to `wikitext`. Set to `plaintext` to cause the output to be rended as plain text |
+|<<.field import-compound>> |<<.from-version "5.3.6">> A filter string, that defines a list of compound tiddlers, that should be imported. See: <<.wlink DataWidget>> widget |
 
-Test case tiddlers with the appropriate tag are shown in $:/ControlPanel
+Test case tiddlers with the appropriate tag are shown in the $:/ControlPanel ''-> Advanced -> Test Cases ''
 
-Some payload tiddlers are set aside for special purposes:
+Some ''payload ''tiddlers are set aside for special purposes:
 
 |!Tiddler |!Description |
 |''Narrative'' |Narrative description of the test, intended to explain the purpose and operation of the test |
 |''Output'' |The tiddler that produces the test output |
 |''~ExpectedResult'' |HTML of expected result of rendering the ''Output'' tiddler |
-|''Description'' |Set to the text of the <<.field description>> field |
+|''Description'' |Set to the text of the <<.field description>> field, if the field exists |
+
+Also see: TestCaseWidget, DataWidget

--- a/editions/tw5.com/tiddlers/widgets/DataWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/DataWidget.tid
@@ -1,6 +1,6 @@
 caption: data
 created: 20240507221902644
-modified: 20240507221902644
+modified: 20240729084028713
 tags: Widgets
 title: DataWidget
 type: text/vnd.tiddlywiki
@@ -17,6 +17,7 @@ The content of the data widget is ignored. It supports the following attributes:
 |<<.attr $tiddler>> |Optional title of a tiddler to be used as a payload tiddler (optional) |
 |<<.attr $filter>> |Optional filter string identifying tiddlers to be used as payload tiddlers (optional) |
 |<<.attr $compound-tiddler>> |Optional title of a tiddler containing payload tiddlers in `text/vnd.tiddlywiki-multiple` format (see below) |
+|<<.attr $compound-filter>> |<<.from-version "5.3.6">> Optional filter, to create a list of tiddlers that contain compound tiddlers. <<.infoBox """Tiddlers will be imported in order. Existing testcase tiddlers will be overwritten, so the currentTiddler wins""">>|
 |//any attribute<br>not starting<br>with $// |Field values to be assigned to the payload tiddler(s) |
 
 The data widget is not rendered when used within the <<.wlink TestCaseWidget>> widget or the [[Innerwiki Plugin]] but for ease of testing, when used elsewhere it renders a JSON representation of the payload tiddlers.


### PR DESCRIPTION
@Jermolene -- As discussed at **Using testcase-widget for documentation** #8415, this PR 

- adds a $compound-filter to the $data-widget, which lets us simplify TestCaseTiddlers
- Testcase tiddlers now can use an `import-compound` **field**, which expects a **filter** run
  - Typically this filter will contain a TitleList, because order is important
  - The currentTiddler wins
- The PR also contains docs changes

This PR is an important one, since it highly simplifies the creation of TestCaseTiddlers that are used for documentation. It avoids a lot of duplicated text.