### PR TITLE
Show wikitext formatting buttons for compound tiddlers

### DIFF
--- a/core/ui/EditorToolbar/bold.tid
+++ b/core/ui/EditorToolbar/bold.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/bold
 caption: {{$:/language/Buttons/Bold/Caption}}
 description: {{$:/language/Buttons/Bold/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((bold))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/excise.tid
+++ b/core/ui/EditorToolbar/excise.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/excise
 caption: {{$:/language/Buttons/Excise/Caption}}
 description: {{$:/language/Buttons/Excise/Hint}}
-condition: [<targetTiddler>type[]] [<targetTiddler>type[text/vnd.tiddlywiki]] +[first[]]
+condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]] +[first[]]
 shortcuts: ((excise))
 dropdown: $:/core/ui/EditorToolbar/excise-dropdown
 

--- a/core/ui/EditorToolbar/heading-1.tid
+++ b/core/ui/EditorToolbar/heading-1.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/heading-1
 caption: {{$:/language/Buttons/Heading1/Caption}}
 description: {{$:/language/Buttons/Heading1/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 button-classes: tc-text-editor-toolbar-item-start-group
 shortcuts: ((heading-1))
 

--- a/core/ui/EditorToolbar/heading-2.tid
+++ b/core/ui/EditorToolbar/heading-2.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/heading-2
 caption: {{$:/language/Buttons/Heading2/Caption}}
 description: {{$:/language/Buttons/Heading2/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((heading-2))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/heading-3.tid
+++ b/core/ui/EditorToolbar/heading-3.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/heading-3
 caption: {{$:/language/Buttons/Heading3/Caption}}
 description: {{$:/language/Buttons/Heading3/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((heading-3))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/heading-4.tid
+++ b/core/ui/EditorToolbar/heading-4.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/heading-4
 caption: {{$:/language/Buttons/Heading4/Caption}}
 description: {{$:/language/Buttons/Heading4/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((heading-4))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/heading-5.tid
+++ b/core/ui/EditorToolbar/heading-5.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/heading-5
 caption: {{$:/language/Buttons/Heading5/Caption}}
 description: {{$:/language/Buttons/Heading5/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((heading-5))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/heading-6.tid
+++ b/core/ui/EditorToolbar/heading-6.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/heading-6
 caption: {{$:/language/Buttons/Heading6/Caption}}
 description: {{$:/language/Buttons/Heading6/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((heading-6))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/italic.tid
+++ b/core/ui/EditorToolbar/italic.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/italic
 caption: {{$:/language/Buttons/Italic/Caption}}
 description: {{$:/language/Buttons/Italic/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((italic))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/link.tid
+++ b/core/ui/EditorToolbar/link.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/link
 caption: {{$:/language/Buttons/Link/Caption}}
 description: {{$:/language/Buttons/Link/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 button-classes: tc-text-editor-toolbar-item-start-group
 shortcuts: ((link))
 dropdown: $:/core/ui/EditorToolbar/link-dropdown

--- a/core/ui/EditorToolbar/linkify.tid
+++ b/core/ui/EditorToolbar/linkify.tid
@@ -1,5 +1,5 @@
 caption: {{$:/language/Buttons/Linkify/Caption}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 description: {{$:/language/Buttons/Linkify/Hint}}
 icon: $:/core/images/linkify
 list-before: $:/core/ui/EditorToolbar/mono-block

--- a/core/ui/EditorToolbar/list-bullet.tid
+++ b/core/ui/EditorToolbar/list-bullet.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/list-bullet
 caption: {{$:/language/Buttons/ListBullet/Caption}}
 description: {{$:/language/Buttons/ListBullet/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((list-bullet))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/list-number.tid
+++ b/core/ui/EditorToolbar/list-number.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/list-number
 caption: {{$:/language/Buttons/ListNumber/Caption}}
 description: {{$:/language/Buttons/ListNumber/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((list-number))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/mono-block.tid
+++ b/core/ui/EditorToolbar/mono-block.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/mono-block
 caption: {{$:/language/Buttons/MonoBlock/Caption}}
 description: {{$:/language/Buttons/MonoBlock/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 button-classes: tc-text-editor-toolbar-item-start-group
 shortcuts: ((mono-block))
 

--- a/core/ui/EditorToolbar/mono-line.tid
+++ b/core/ui/EditorToolbar/mono-line.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/mono-line
 caption: {{$:/language/Buttons/MonoLine/Caption}}
 description: {{$:/language/Buttons/MonoLine/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((mono-line))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/picture.tid
+++ b/core/ui/EditorToolbar/picture.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/picture
 caption: {{$:/language/Buttons/Picture/Caption}}
 description: {{$:/language/Buttons/Picture/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((picture))
 dropdown: $:/core/ui/EditorToolbar/picture-dropdown
 

--- a/core/ui/EditorToolbar/quote.tid
+++ b/core/ui/EditorToolbar/quote.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/quote
 caption: {{$:/language/Buttons/Quote/Caption}}
 description: {{$:/language/Buttons/Quote/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((quote))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/strikethrough.tid
+++ b/core/ui/EditorToolbar/strikethrough.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/strikethrough
 caption: {{$:/language/Buttons/Strikethrough/Caption}}
 description: {{$:/language/Buttons/Strikethrough/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((strikethrough))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/subscript.tid
+++ b/core/ui/EditorToolbar/subscript.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/subscript
 caption: {{$:/language/Buttons/Subscript/Caption}}
 description: {{$:/language/Buttons/Subscript/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((subscript))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/superscript.tid
+++ b/core/ui/EditorToolbar/superscript.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/superscript
 caption: {{$:/language/Buttons/Superscript/Caption}}
 description: {{$:/language/Buttons/Superscript/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((superscript))
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/transcludify.tid
+++ b/core/ui/EditorToolbar/transcludify.tid
@@ -1,5 +1,5 @@
 caption: {{$:/language/Buttons/Transcludify/Caption}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 description: {{$:/language/Buttons/Transcludify/Hint}}
 icon: $:/core/images/transcludify
 list-before: $:/core/ui/EditorToolbar/mono-block

--- a/core/ui/EditorToolbar/underline.tid
+++ b/core/ui/EditorToolbar/underline.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/underline
 caption: {{$:/language/Buttons/Underline/Caption}}
 description: {{$:/language/Buttons/Underline/Hint}}
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>!has[type]] [<targetTiddler>get[type]prefix[text/vnd.tiddlywiki]]
 shortcuts: ((underline))
 
 <$action-sendmessage


### PR DESCRIPTION
This PR fixes #8448: **[BUG] type: text/vnd.tiddlywiki-multiple - tiddlers only show the basic buttons** 

- It uses a **prefix** `...prefix[text/vnd.tiddlywiki]]` instead of an exact match, which is relatively permissive

I did use a prefix for the button-condition, because I think every type prefixed with `text/vnd.tiddlywiki` should be allowed to use TW wikitext syntax. IMO that's the whole point of this type. -- But I'm open to change it to an exact match

@Jermolene -- What do you think?

