### PR TITLE
Add image toolbar dropdown to markdown plugin

### DIFF
--- a/plugins/tiddlywiki/markdown/EditorToolbar/picture-dropdown.tid
+++ b/plugins/tiddlywiki/markdown/EditorToolbar/picture-dropdown.tid
@@ -1,13 +1,16 @@
 title: $:/plugins/tiddlywiki/markdown/EditorToolbar/picture-dropdown
 
 \define replacement-text()
-![](<#$(imageTitle)$>)
+![](<#$(escaped-text)$>)
 \end
+
+\define escapetitle() [()<>\\]
 
 ''{{$:/language/Buttons/Picture/Hint}}''
 
 <$macrocall $name="image-picker" actions="""
 
+<$let escaped-text={{{ [<imageTitle>search-replace:g:regexp<escapetitle>,[\$&]] }}}>
 <$action-sendmessage
 	$message="tm-edit-text-operation"
 	$param="replace-selection"
@@ -17,5 +20,5 @@ title: $:/plugins/tiddlywiki/markdown/EditorToolbar/picture-dropdown
 <$action-deletetiddler
 	$tiddler=<<dropdown-state>>
 />
-
+</$let>
 """/>

--- a/plugins/tiddlywiki/markdown/EditorToolbar/picture-dropdown.tid
+++ b/plugins/tiddlywiki/markdown/EditorToolbar/picture-dropdown.tid
@@ -1,0 +1,21 @@
+title: $:/plugins/tiddlywiki/markdown/EditorToolbar/picture-dropdown
+
+\define replacement-text()
+![](<#$(imageTitle)$>)
+\end
+
+''{{$:/language/Buttons/Picture/Hint}}''
+
+<$macrocall $name="image-picker" actions="""
+
+<$action-sendmessage
+	$message="tm-edit-text-operation"
+	$param="replace-selection"
+	text=<<replacement-text>>
+/>
+
+<$action-deletetiddler
+	$tiddler=<<dropdown-state>>
+/>
+
+"""/>

--- a/plugins/tiddlywiki/markdown/EditorToolbar/picture.tid
+++ b/plugins/tiddlywiki/markdown/EditorToolbar/picture.tid
@@ -1,0 +1,10 @@
+title: $:/plugins/tiddlywiki/markdown/EditorToolbar/picture
+list-after: $:/core/ui/EditorToolbar/picture
+tags: $:/tags/EditorToolbar
+icon: $:/core/images/picture
+caption: {{$:/language/Buttons/Picture/Caption}} (Markdown)
+description: {{$:/language/Buttons/Picture/Hint}}
+condition: [<targetTiddler>type[text/x-markdown]] [<targetTiddler>type[text/markdown]]
+shortcuts: ((picture))
+dropdown: $:/plugins/tiddlywiki/markdown/EditorToolbar/picture-dropdown
+


### PR DESCRIPTION
Add image toolbar dropdown to markdown plugin which enables picking imported images.

![图片](https://github.com/user-attachments/assets/29c5bbc8-c850-4ed7-81d8-3382a76db597)
