### PR TITLE
feat: allow tags have its ViewTemplate tag and cascade

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -235,3 +235,7 @@ ViewTemplateBody/Caption: View Template Body
 ViewTemplateBody/Hint: This rule cascade is used by the default view template to dynamically choose the template for displaying the body of a tiddler.
 ViewTemplateTitle/Caption: View Template Title
 ViewTemplateTitle/Hint: This rule cascade is used by the default view template to dynamically choose the template for displaying the title of a tiddler.
+ViewTemplateSubtitle/Caption: View Template Subtitle
+ViewTemplateSubtitle/Hint: This rule cascade is used by the default view template to dynamically choose the template for displaying the subtitle of a tiddler.
+ViewTemplateTags/Caption: View Template Tags
+ViewTemplateTags/Hint: This rule cascade is used by the default view template to dynamically choose the template for displaying the tags area of a tiddler.

--- a/core/ui/ControlPanel/Cascades/ViewTemplateSubtitle.tid
+++ b/core/ui/ControlPanel/Cascades/ViewTemplateSubtitle.tid
@@ -1,0 +1,9 @@
+title: $:/core/ui/ControlPanel/ViewTemplateSubtitle
+tags: $:/tags/ControlPanel/Cascades
+caption: {{$:/language/ControlPanel/ViewTemplateSubtitle/Caption}}
+
+\define lingo-base() $:/language/ControlPanel/ViewTemplateSubtitle/
+
+<<lingo Hint>>
+
+{{$:/tags/ViewTemplateSubtitleFilter||$:/snippets/ListTaggedCascade}}

--- a/core/ui/ControlPanel/Cascades/ViewTemplateTags.tid
+++ b/core/ui/ControlPanel/Cascades/ViewTemplateTags.tid
@@ -1,0 +1,9 @@
+title: $:/core/ui/ControlPanel/ViewTemplateTags
+tags: $:/tags/ControlPanel/Cascades
+caption: {{$:/language/ControlPanel/ViewTemplateTags/Caption}}
+
+\define lingo-base() $:/language/ControlPanel/ViewTemplateTags/
+
+<<lingo Hint>>
+
+{{$:/tags/ViewTemplateTagsFilter||$:/snippets/ListTaggedCascade}}

--- a/core/ui/ViewTemplate/subtitle.tid
+++ b/core/ui/ViewTemplate/subtitle.tid
@@ -2,10 +2,4 @@ title: $:/core/ui/ViewTemplate/subtitle
 tags: $:/tags/ViewTemplate
 
 \whitespace trim
-<$reveal type="nomatch" stateTitle=<<folded-state>> text="hide" tag="div" retain="yes" animate="yes">
-<div class="tc-subtitle">
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewTemplate/Subtitle]!has[draft.of]]" variable="subtitleTiddler">
-<$transclude tiddler=<<subtitleTiddler>> mode="inline"/><$list-join>&nbsp;</$list-join>
-</$list>
-</div>
-</$reveal>
+<$transclude tiddler={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/ViewTemplateSubtitleFilter]!is[draft]get[text]] :and[!is[blank]else[$:/core/ui/ViewTemplate/subtitle/default]] }}} />

--- a/core/ui/ViewTemplate/subtitle/default.tid
+++ b/core/ui/ViewTemplate/subtitle/default.tid
@@ -1,0 +1,10 @@
+title: $:/core/ui/ViewTemplate/subtitle/default
+
+\whitespace trim
+<$reveal type="nomatch" stateTitle=<<folded-state>> text="hide" tag="div" retain="yes" animate="yes">
+<div class="tc-subtitle">
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewTemplate/Subtitle]!has[draft.of]]" variable="subtitleTiddler">
+<$transclude tiddler=<<subtitleTiddler>> mode="inline"/><$list-join>&nbsp;</$list-join>
+</$list>
+</div>
+</$reveal>

--- a/core/ui/ViewTemplate/tags.tid
+++ b/core/ui/ViewTemplate/tags.tid
@@ -2,6 +2,4 @@ title: $:/core/ui/ViewTemplate/tags
 tags: $:/tags/ViewTemplate
 
 \whitespace trim
-<$reveal type="nomatch" stateTitle=<<folded-state>> text="hide" tag="div" retain="yes" animate="yes">
-<div class="tc-tags-wrapper"><$list filter="[all[current]tags[]sort[title]]" template="$:/core/ui/TagTemplate" storyview="pop"/></div>
-</$reveal>
+<$transclude tiddler={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/ViewTemplateTagsFilter]!is[draft]get[text]] :and[!is[blank]else[$:/core/ui/ViewTemplate/tags/default]] }}} />

--- a/core/ui/ViewTemplate/tags/default.tid
+++ b/core/ui/ViewTemplate/tags/default.tid
@@ -1,0 +1,11 @@
+title: $:/core/ui/ViewTemplate/tags/default
+
+\whitespace trim
+<$reveal type="nomatch" stateTitle=<<folded-state>> text="hide" tag="div" retain="yes" animate="yes">
+  <div class="tc-tags-wrapper">
+    <$list filter="[all[current]tags[]sort[title]]" template="$:/core/ui/TagTemplate" storyview="pop"/>
+    <$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewTemplate/Tags]!has[draft.of]]">
+      <$transclude mode="inline"/>
+    </$list>
+  </div>
+</$reveal>

--- a/languages/zh-Hans/ControlPanel.multids
+++ b/languages/zh-Hans/ControlPanel.multids
@@ -236,7 +236,7 @@ ViewTemplateBody/Caption: 查看模板主体
 ViewTemplateBody/Hint: 默认的查看模板使用此规则级联，动态选择模板以显示条目的主体。
 ViewTemplateTitle/Caption: 查看模板标题
 ViewTemplateTitle/Hint: 默认的查看模板使用此规则级联，动态选择模板以显示条目的标题。
-ViewTemplateTitle/Caption: 查看模板副标题
-ViewTemplateTitle/Hint: 默认的查看模板使用此规则级联，动态选择模板以显示条目的副标题。
-ViewTemplateTitle/Caption: 查看模板标签区
-ViewTemplateTitle/Hint: 默认的查看模板使用此规则级联，动态选择模板以显示条目的标签区域。
+ViewTemplateSubtitle/Caption: 查看模板副标题
+ViewTemplateSubtitle/Hint: 默认的查看模板使用此规则级联，动态选择模板以显示条目的副标题。
+ViewTemplateTags/Caption: 查看模板标签区
+ViewTemplateTags/Hint: 默认的查看模板使用此规则级联，动态选择模板以显示条目的标签区域。

--- a/languages/zh-Hans/ControlPanel.multids
+++ b/languages/zh-Hans/ControlPanel.multids
@@ -236,3 +236,7 @@ ViewTemplateBody/Caption: 查看模板主体
 ViewTemplateBody/Hint: 默认的查看模板使用此规则级联，动态选择模板以显示条目的主体。
 ViewTemplateTitle/Caption: 查看模板标题
 ViewTemplateTitle/Hint: 默认的查看模板使用此规则级联，动态选择模板以显示条目的标题。
+ViewTemplateTitle/Caption: 查看模板副标题
+ViewTemplateTitle/Hint: 默认的查看模板使用此规则级联，动态选择模板以显示条目的副标题。
+ViewTemplateTitle/Caption: 查看模板标签区
+ViewTemplateTitle/Hint: 默认的查看模板使用此规则级联，动态选择模板以显示条目的标签区域。

--- a/languages/zh-Hant/ControlPanel.multids
+++ b/languages/zh-Hant/ControlPanel.multids
@@ -236,3 +236,7 @@ ViewTemplateBody/Caption: 檢視範本主體
 ViewTemplateBody/Hint: 預設的檢視範本使用此規則級聯，動態選擇範本以顯示條目的主體。
 ViewTemplateTitle/Caption: 檢視範本標題
 ViewTemplateTitle/Hint: 預設的檢視範本使用此規則級聯，動態選擇範本以顯示條目的標題。
+ViewTemplateSubtitle/Caption: 檢視範本副標題
+ViewTemplateSubtitle/Hint: 預設的檢視範本使用此規則級聯，動態選擇範本以顯示條目的副標題。
+ViewTemplateTags/Caption: 檢視範本標籤
+ViewTemplateTags/Hint: 預設的檢視範本使用此規則級聯，動態選擇範本以顯示條目的標籤。


### PR DESCRIPTION
Title and subtitle and body all have their ViewTemplate tag and cascade, now it's tag's turn.

I will need this to build https://saqimtiaz.github.io/sq-tw/sandbox.html#%24%3A%2Fcore%2Fui%2FViewTemplate%2Ftags that is not shadowing anything.

@pmario @saqimtiaz 
