### PR TITLE
Enable pasting (dropping) images for markdown tiddlers.

### DIFF
--- a/core/wiki/config/EditorEnableImportFilter.tid
+++ b/core/wiki/config/EditorEnableImportFilter.tid
@@ -1,4 +1,4 @@
 title: $:/config/Editor/EnableImportFilter
 type: text/vnd.tiddlywiki
 
-[all[current]type[text/vnd.tiddlywiki]] [all[current]!has[type]]
+[all[current]type[text/vnd.tiddlywiki]] [all[current]!has[type]] [all[current]type[text/markdown]] [all[current]type[text/x-markdown]]

--- a/plugins/tiddlywiki/markdown/EditorToolbar/file-import.tid
+++ b/plugins/tiddlywiki/markdown/EditorToolbar/file-import.tid
@@ -1,0 +1,47 @@
+title: $:/plugins/tiddlywiki/markdown/EditorToolbar/file-import
+tags: $:/tags/EditorTools
+condition: [<targetTiddler>type[text/x-markdown]] [<targetTiddler>type[text/markdown]]
+
+\define lingo-base() $:/language/Import/
+
+\define closePopupActions()
+<$action-deletetiddler $filter="[title<importState>] [title<importTitle>]"/>
+\end
+
+\define replacement-text-image() ![](<#$title$>)
+
+\define replacement-text-file() [](<#$title$>)
+
+\define replacement-regexp() [()<>\\]
+
+\define postImportActions()
+\whitespace trim
+<$list filter="[<importTitle>links[]search-replace:g:regexp<replacement-regexp>,[\$&]] :reduce[get[type]prefix[image]then<replacement-text-image>else<replacement-text-file>search-replace[$title$],<currentTiddler>addprefix<accumulator>]" variable="imageTitle">
+<$action-sendmessage
+	$message="tm-edit-text-operation"
+	$param="insert-text"
+	text=<<imageTitle>>
+/>
+</$list>
+<<closePopupActions>>
+\end
+
+\define buttons()
+\whitespace trim
+<$button class="tc-btn-invisible" actions=<<closePopupActions>> ><<lingo Listing/Cancel/Caption>></$button>
+&#32;
+<$button class="tc-btn-invisible" message="tm-perform-import" param=<<importTitle>> actions=<<postImportActions>> ><<lingo Listing/Import/Caption>></$button>
+\end
+
+\whitespace trim
+<$reveal type="popup" state=<<importState>> tag="div" class="tc-editor-importpopup">
+<div class="tc-editor-import">
+<$list filter="[<importTitle>field:plugin-type[import]]">
+<h2><<lingo Editor/Import/Heading>></h2>
+<$tiddler tiddler=<<importTitle>>>
+{{||$:/core/ui/ImportListing}}
+<<buttons>>
+</$tiddler>
+</$list>
+</div>
+</$reveal>

--- a/plugins/tiddlywiki/markdown/EditorToolbar/file-import.tid
+++ b/plugins/tiddlywiki/markdown/EditorToolbar/file-import.tid
@@ -16,12 +16,16 @@ condition: [<targetTiddler>type[text/x-markdown]] [<targetTiddler>type[text/mark
 
 \define postImportActions()
 \whitespace trim
-<$list filter="[<importTitle>links[]search-replace:g:regexp<replacement-regexp>,[\$&]] :reduce[get[type]prefix[image]then<replacement-text-image>else<replacement-text-file>search-replace[$title$],<currentTiddler>addprefix<accumulator>]" variable="imageTitle">
+<$list filter="[<importTitle>links[]]">
+<$let escaped-title={{{ [<currentTiddler>search-replace:g:regexp<replacement-regexp>,[\$&]] }}}>
+<$let insertText={{{ [get[type]prefix[image]then<replacement-text-image>else<replacement-text-file>search-replace[$title$],<escaped-title>] }}}>
 <$action-sendmessage
 	$message="tm-edit-text-operation"
 	$param="insert-text"
-	text=<<imageTitle>>
+	text=<<insertText>>
 />
+</$let>
+</$let>
 </$list>
 <<closePopupActions>>
 \end

--- a/plugins/tiddlywiki/markdown/EditorToolbar/file-import.tid
+++ b/plugins/tiddlywiki/markdown/EditorToolbar/file-import.tid
@@ -2,19 +2,19 @@ title: $:/plugins/tiddlywiki/markdown/EditorToolbar/file-import
 tags: $:/tags/EditorTools
 condition: [<targetTiddler>type[text/x-markdown]] [<targetTiddler>type[text/markdown]]
 
-\define lingo-base() $:/language/Import/
+\procedure lingo-base() $:/language/Import/
 
-\define closePopupActions()
+\procedure closePopupActions()
 <$action-deletetiddler $filter="[title<importState>] [title<importTitle>]"/>
 \end
 
-\define replacement-text-image() ![](<#$title$>)
+\procedure replacement-text-image() ![](<#$title$>)
 
-\define replacement-text-file() [](<#$title$>)
+\procedure replacement-text-file() [](<#$title$>)
 
-\define replacement-regexp() [()<>\\]
+\procedure replacement-regexp() [()<>\\]
 
-\define postImportActions()
+\procedure postImportActions()
 \whitespace trim
 <$list filter="[<importTitle>links[]]">
 <$let escaped-title={{{ [<currentTiddler>search-replace:g:regexp<replacement-regexp>,[\$&]] }}}>
@@ -30,7 +30,7 @@ condition: [<targetTiddler>type[text/x-markdown]] [<targetTiddler>type[text/mark
 <<closePopupActions>>
 \end
 
-\define buttons()
+\procedure buttons()
 \whitespace trim
 <$button class="tc-btn-invisible" actions=<<closePopupActions>> ><<lingo Listing/Cancel/Caption>></$button>
 &#32;

--- a/plugins/tiddlywiki/markdown/EditorToolbar/file-import.tid
+++ b/plugins/tiddlywiki/markdown/EditorToolbar/file-import.tid
@@ -2,6 +2,8 @@ title: $:/plugins/tiddlywiki/markdown/EditorToolbar/file-import
 tags: $:/tags/EditorTools
 condition: [<targetTiddler>type[text/x-markdown]] [<targetTiddler>type[text/markdown]]
 
+\whitespace trim
+
 \procedure lingo-base() $:/language/Import/
 
 \procedure closePopupActions()
@@ -15,29 +17,25 @@ condition: [<targetTiddler>type[text/x-markdown]] [<targetTiddler>type[text/mark
 \procedure replacement-regexp() [()<>\\]
 
 \procedure postImportActions()
-\whitespace trim
 <$list filter="[<importTitle>links[]]">
-<$let escaped-title={{{ [<currentTiddler>search-replace:g:regexp<replacement-regexp>,[\$&]] }}}>
-<$let insertText={{{ [get[type]prefix[image]then<replacement-text-image>else<replacement-text-file>search-replace[$title$],<escaped-title>] }}}>
-<$action-sendmessage
-	$message="tm-edit-text-operation"
-	$param="insert-text"
-	text=<<insertText>>
-/>
-</$let>
-</$let>
+	<$let escaped-title={{{ [<currentTiddler>search-replace:g:regexp<replacement-regexp>,[\$&]] }}}>
+		<$let insertText={{{ [get[type]prefix[image]then<replacement-text-image>else<replacement-text-file>search-replace[$title$],<escaped-title>] }}}>
+			<$action-sendmessage
+				$message="tm-edit-text-operation"
+				$param="insert-text"
+				text=<<insertText>>
+			/>
+		</$let>
+	</$let>
 </$list>
 <<closePopupActions>>
 \end
 
 \procedure buttons()
-\whitespace trim
-<$button class="tc-btn-invisible" actions=<<closePopupActions>> ><<lingo Listing/Cancel/Caption>></$button>
-&#32;
+<$button class="tc-btn-invisible tc-small-gap-right" actions=<<closePopupActions>> ><<lingo Listing/Cancel/Caption>></$button>
 <$button class="tc-btn-invisible" message="tm-perform-import" param=<<importTitle>> actions=<<postImportActions>> ><<lingo Listing/Import/Caption>></$button>
 \end
 
-\whitespace trim
 <$reveal type="popup" state=<<importState>> tag="div" class="tc-editor-importpopup">
 <div class="tc-editor-import">
 <$list filter="[<importTitle>field:plugin-type[import]]">


### PR DESCRIPTION
This PR closes #8388.

Add support for copying & pasting (dragging & dropping) images in mardown tiddlers.

To enable it out-of-box, the tiddler `$:/config/Editor/EnableImportFilter` is also modified.