### PR TITLE
 Shorter Title of Compound Tiddler in Type Field Dropdown Menu

### DIFF
--- a/core/language/en-GB/Types/text_vnd.tiddlywiki_multiple.tid
+++ b/core/language/en-GB/Types/text_vnd.tiddlywiki_multiple.tid
@@ -1,5 +1,5 @@
 title: $:/language/Docs/Types/text/vnd.tiddlywiki-multiple
-description: TiddlyWiki 5 compound tiddler
+description: Compound tiddler
 name: text/vnd.tiddlywiki-multiple
 group: Developer
 group-sort: 2

--- a/languages/de-DE/Types/text_vnd.tiddlywiki_multiple.tid
+++ b/languages/de-DE/Types/text_vnd.tiddlywiki_multiple.tid
@@ -1,5 +1,5 @@
 title: $:/language/Docs/Types/text/vnd.tiddlywiki-multiple
-description: TW5 - TiddlyWiki Wikitext Verbund Tiddler
+description: Verbund Tiddler
 name: text/vnd.tiddlywiki-multiple
 group: Entwickler
 group-sort: 2


### PR DESCRIPTION
This PR implements the idea in #8465 

It modifies the description for compound tiddler in dropdown as added in https://github.com/TiddlyWiki/TiddlyWiki5/pull/8450

@pmario: I checked the #8450 and noted de-DE has been changed. I tried to use the same term for both languages.