### PR TITLE
Disable importing $:/build tiddler when upgrading

### DIFF
--- a/core/modules/upgraders/system.js
+++ b/core/modules/upgraders/system.js
@@ -12,7 +12,7 @@ Upgrader module that suppresses certain system tiddlers that shouldn't be import
 /*global $tw: false */
 "use strict";
 
-var DONT_IMPORT_LIST = ["$:/Import"],
+var DONT_IMPORT_LIST = ["$:/Import", "$:/build"],
 	UNSELECT_PREFIX_LIST = ["$:/temp/","$:/state/","$:/StoryList","$:/HistoryList"],
 	WARN_IMPORT_PREFIX_LIST = ["$:/core/modules/"];
 


### PR DESCRIPTION
The tiddler `$:/build` contains information of the commit of the current version, which shouldn't be overridden by the older one, but the upgrader selects the tiddler on default.

![图片](https://github.com/user-attachments/assets/ad3ec222-7ea8-4e03-8310-2707e421968a)

This PR fixes that by blocking the `$:/build` tiddler on import.