### PR TITLE
eslint force double-quotes for strings -- avoidEscape:true

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -231,7 +231,10 @@ rules:
   prefer-spread: 'off'
   prefer-template: 'off'
   quote-props: 'off'
-  quotes: 'off'
+  quotes:
+    - error
+    - double
+    - avoidEscape: true
   radix: 'off'
   require-atomic-updates: error
   require-await: error


### PR DESCRIPTION
eslint force double-quotes for strings -- avoidEscape:true

See: https://eslint.org/docs/latest/rules/quotes#avoidescape