### PR TITLE
Prevent geospatial plugin exception when geomap contains empty geolayer widget

### DIFF
--- a/plugins/tiddlywiki/geospatial/tests/widgets/geomap-empty-layer.tid
+++ b/plugins/tiddlywiki/geospatial/tests/widgets/geomap-empty-layer.tid
@@ -1,0 +1,12 @@
+title: $:/plugins/tiddlywiki/geospatial/tests/widgets/geomap-empty-layer
+
+<$testcase testOutput="Output" testExpectedResult="ExpectedResult">
+<$data title="Description" text="Map using geolayer without json and lat/long attributes"/>
+<$data title="Narrative" text="Verify exception reported in [[8452|https://github.com/TiddlyWiki/TiddlyWiki5/issues/8452]] is not thrown when the geolayer widget has no attributes"/>
+<$data title="Output" text="""<$geomap startPosition="bounds">
+<$geolayer/>
+</$geomap>"""/>
+<$data title="ExpectedResult" text="""<p><div style="width:100%;height:600px;"></div></p>"""/>
+<!-- Without this, "infinite bounds exception" will be thrown -->
+<$data $tiddler="$:/plugins/tiddlywiki/geospatial"/>
+</$testcase>

--- a/plugins/tiddlywiki/geospatial/tests/widgets/geomap-empty-layer.tid
+++ b/plugins/tiddlywiki/geospatial/tests/widgets/geomap-empty-layer.tid
@@ -1,12 +1,19 @@
 title: $:/plugins/tiddlywiki/geospatial/tests/widgets/geomap-empty-layer
+description: Map using geolayer without json and lat/long attributes
+import: $:/plugins/tiddlywiki/geospatial
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
 
-<$testcase testOutput="Output" testExpectedResult="ExpectedResult">
-<$data title="Description" text="Map using geolayer without json and lat/long attributes"/>
-<$data title="Narrative" text="Verify exception reported in [[8452|https://github.com/TiddlyWiki/TiddlyWiki5/issues/8452]] is not thrown when the geolayer widget has no attributes"/>
-<$data title="Output" text="""<$geomap startPosition="bounds">
+title: Narrative
+
+Verify exception reported in [[8452|https://github.com/TiddlyWiki/TiddlyWiki5/issues/8452]] is not thrown when the geolayer widget has no attributes
++
+title: Output
+
+<$geomap startPosition="bounds">
 <$geolayer/>
-</$geomap>"""/>
-<$data title="ExpectedResult" text="""<p><div style="width:100%;height:600px;"></div></p>"""/>
-<!-- Without this, "infinite bounds exception" will be thrown -->
-<$data $tiddler="$:/plugins/tiddlywiki/geospatial"/>
-</$testcase>
+</$geomap>
++
+title: ExpectedResult
+
+<p><div style="width:100%;height:600px;"></div></p>

--- a/plugins/tiddlywiki/geospatial/widgets/geomap.js
+++ b/plugins/tiddlywiki/geospatial/widgets/geomap.js
@@ -262,10 +262,12 @@ GeomapWidget.prototype.refreshMap = function() {
 				var bounds = null;
 				$tw.utils.each(this.renderedLayers,function(layer) {
 					var featureBounds = layer.layer.getBounds();
-					if(bounds) {
-						bounds.extend(featureBounds);
-					} else {
-						bounds = featureBounds;
+					if(featureBounds.isValid()) {
+						if(bounds) {
+							bounds.extend(featureBounds);
+						} else {
+							bounds = featureBounds;
+						}
 					}
 				});
 				if(bounds) {


### PR DESCRIPTION
When startPosition is bounds with an empty geolayer widget, a javascript exception "Bounds are not valid" was being thrown.

Fixes #8452. 