### PR TITLE
Update the editor file import UI to support markdown tiddlers

### DIFF
--- a/core/ui/EditorToolbar/file-import.tid
+++ b/core/ui/EditorToolbar/file-import.tid
@@ -1,6 +1,6 @@
 title: $:/core/ui/EditorToolbar/file-import
 tags: $:/tags/EditorTools
-condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
+condition: [<targetTiddler>filter{$:/config/Editor/EnableImportFilter}]
 
 \procedure lingo-base() $:/language/Import/
 

--- a/core/ui/EditorToolbar/file-import.tid
+++ b/core/ui/EditorToolbar/file-import.tid
@@ -14,9 +14,11 @@ condition: [<targetTiddler>filter{$:/config/Editor/EnableImportFilter}]
 \procedure markdown-ImageTemplate() ![]($1$)
 \procedure mardkown-FileTempalte() []($1$)
 
-\function getImageTemplate() [<storyTiddler>type[text/x-markdown]then<markdown-ImageTemplate>else<tw5-ImageTemplate>]
-\function getFileTemplate() [<storyTiddler>type[text/x-markdown]then<mardkown-FileTemplate>else<tw5-FileTemplate>]
+\function is.Markdown.Tiddler() [all[]type[text/x-markdown]] [all[]type[text/markdown]]
+\function getImageTemplate() [<storyTiddler>is.Markdown.Tiddler[]then<markdown-ImageTemplate>else<tw5-ImageTemplate>]
+\function getFileTemplate() [<storyTiddler>is.Markdown.Tiddler[]then<mardkown-FileTemplate>else<tw5-FileTemplate>]
 \function getReplacementTemplate() [get[type]prefix[image]then<getImageTemplate>else<getFileTemplate>]
+
 
 \procedure postImportActions()
 \whitespace trim

--- a/core/ui/EditorToolbar/file-import.tid
+++ b/core/ui/EditorToolbar/file-import.tid
@@ -8,13 +8,19 @@ condition: [<targetTiddler>filter{$:/config/Editor/EnableImportFilter}]
 <$action-deletetiddler $filter="[title<importState>] [title<importTitle>]"/>
 \end
 
-\procedure replacement-text-image() [img[$1$]]
+\procedure tw5-ImageTemplate() [img[$1$]]
+\procedure tw5-FileTemplate() [[$1$]]
 
-\procedure replacement-text-file() [[$1$]]
+\procedure markdown-ImageTemplate() ![]($1$)
+\procedure mardkown-FileTempalte() []($1$)
+
+\function getImageTemplate() [<storyTiddler>type[text/x-markdown]then<markdown-ImageTemplate>else<tw5-ImageTemplate>]
+\function getFileTemplate() [<storyTiddler>type[text/x-markdown]then<mardkown-FileTemplate>else<tw5-FileTemplate>]
+\function getReplacementTemplate() [get[type]prefix[image]then<getImageTemplate>else<getFileTemplate>]
 
 \procedure postImportActions()
 \whitespace trim
-<$list filter="[<importTitle>links[]] :reduce[get[type]prefix[image]then<replacement-text-image>else<replacement-text-file>substitute<currentTiddler>addprefix<accumulator>]" variable="imageTitle">
+<$list filter="[<importTitle>links[]] :reduce[<getReplacementTemplate>substitute<currentTiddler>addprefix<accumulator>]" variable="imageTitle">
 <$action-sendmessage
 	$message="tm-edit-text-operation"
 	$param="insert-text"

--- a/core/ui/EditorToolbar/file-import.tid
+++ b/core/ui/EditorToolbar/file-import.tid
@@ -11,8 +11,8 @@ condition: [<targetTiddler>filter{$:/config/Editor/EnableImportFilter}]
 \procedure tw5-ImageTemplate() [img[$(currentTiddler)$]]
 \procedure tw5-FileTemplate() [[$(currentTiddler)$]]
 
-\procedure escape-regexp() [()<>\\]
-\function escape.title() [search-replace:g:regexp<escape-regexp>,[\$&]]
+<!-- The following characters must be escaped in markdown: <>()\ -->
+\function escape.title() [search-replace:g:regexp[\(|\)|<|>|\\],[\$&]]
 \procedure markdown-ImageTemplate() ![](<#${ [<currentTiddler>escape.title[]] }$>)
 \procedure markdown-FileTemplate() [](<#${ [<currentTiddler>escape.title[]] }$>)
 

--- a/core/ui/EditorToolbar/file-import.tid
+++ b/core/ui/EditorToolbar/file-import.tid
@@ -6,23 +6,24 @@ condition: [<targetTiddler>filter{$:/config/Editor/EnableImportFilter}]
 
 \procedure closePopupActions()
 <$action-deletetiddler $filter="[title<importState>] [title<importTitle>]"/>
-\end
+\end closePopupActions
 
-\procedure tw5-ImageTemplate() [img[$1$]]
-\procedure tw5-FileTemplate() [[$1$]]
+\procedure tw5-ImageTemplate() [img[$(currentTiddler)$]]
+\procedure tw5-FileTemplate() [[$(currentTiddler)$]]
 
-\procedure markdown-ImageTemplate() ![]($1$)
-\procedure mardkown-FileTempalte() []($1$)
+\procedure markdown-ImageTemplate() ![](<#${ [<currentTiddler>encodeuri[]] }$>)
+\procedure markdown-FileTemplate() [](<#${ [<currentTiddler>encodeuri[]] }$>)
 
-\function is.Markdown.Tiddler() [all[]type[text/x-markdown]] [all[]type[text/markdown]]
-\function getImageTemplate() [<storyTiddler>is.Markdown.Tiddler[]then<markdown-ImageTemplate>else<tw5-ImageTemplate>]
-\function getFileTemplate() [<storyTiddler>is.Markdown.Tiddler[]then<mardkown-FileTemplate>else<tw5-FileTemplate>]
-\function getReplacementTemplate() [get[type]prefix[image]then<getImageTemplate>else<getFileTemplate>]
-
+\function is.markdown.tiddler() [all[]type[text/x-markdown]] [all[]type[text/markdown]]
+\function is.image() [get[type]prefix[image]]
+\function get.markdown.link() [is.image[]then<markdown-ImageTemplate>else<markdown-FileTemplate>]
+\function get.tw5.link() [is.image[]then<tw5-ImageTemplate>else<tw5-FileTemplate>] 
+\function get.link.template() [<storyTiddler>is.markdown.tiddler[]then<get.markdown.link>else<get.tw5.link>]
 
 \procedure postImportActions()
 \whitespace trim
-<$list filter="[<importTitle>links[]] :reduce[<getReplacementTemplate>substitute<currentTiddler>addprefix<accumulator>]" variable="imageTitle">
+<$list filter="[<importTitle>links[]] :reduce[get.link.template[]substitute[]addprefix<accumulator>]" variable="imageTitle">
+<$action-log $$filter="imageTitle"/>
 <$action-sendmessage
 	$message="tm-edit-text-operation"
 	$param="insert-text"
@@ -30,14 +31,14 @@ condition: [<targetTiddler>filter{$:/config/Editor/EnableImportFilter}]
 />
 </$list>
 <<closePopupActions>>
-\end
+\end postImportActions
 
 \procedure buttons()
 \whitespace trim
 <$button class="tc-btn-invisible" actions=<<closePopupActions>> ><<lingo Listing/Cancel/Caption>></$button>
 &#32;
 <$button class="tc-btn-invisible" message="tm-perform-import" param=<<importTitle>> actions=<<postImportActions>> ><<lingo Listing/Import/Caption>></$button>
-\end
+\end buttons
 
 \whitespace trim
 <$reveal type="popup" state=<<importState>> tag="div" class="tc-editor-importpopup">

--- a/core/ui/EditorToolbar/file-import.tid
+++ b/core/ui/EditorToolbar/file-import.tid
@@ -11,8 +11,10 @@ condition: [<targetTiddler>filter{$:/config/Editor/EnableImportFilter}]
 \procedure tw5-ImageTemplate() [img[$(currentTiddler)$]]
 \procedure tw5-FileTemplate() [[$(currentTiddler)$]]
 
-\procedure markdown-ImageTemplate() ![](<#${ [<currentTiddler>encodeuri[]] }$>)
-\procedure markdown-FileTemplate() [](<#${ [<currentTiddler>encodeuri[]] }$>)
+\procedure escape-regexp() [()<>\\]
+\function escape.title() [search-replace:g:regexp<escape-regexp>,[\$&]]
+\procedure markdown-ImageTemplate() ![](<#${ [<currentTiddler>escape.title[]] }$>)
+\procedure markdown-FileTemplate() [](<#${ [<currentTiddler>escape.title[]] }$>)
 
 \function is.markdown.tiddler() [all[]type[text/x-markdown]] [all[]type[text/markdown]]
 \function is.image() [get[type]prefix[image]]
@@ -23,7 +25,6 @@ condition: [<targetTiddler>filter{$:/config/Editor/EnableImportFilter}]
 \procedure postImportActions()
 \whitespace trim
 <$list filter="[<importTitle>links[]] :reduce[get.link.template[]substitute[]addprefix<accumulator>]" variable="imageTitle">
-<$action-log $$filter="imageTitle"/>
 <$action-sendmessage
 	$message="tm-edit-text-operation"
 	$param="insert-text"

--- a/core/ui/EditorToolbar/file-import.tid
+++ b/core/ui/EditorToolbar/file-import.tid
@@ -2,19 +2,19 @@ title: $:/core/ui/EditorToolbar/file-import
 tags: $:/tags/EditorTools
 condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]]
 
-\define lingo-base() $:/language/Import/
+\procedure lingo-base() $:/language/Import/
 
-\define closePopupActions()
+\procedure closePopupActions()
 <$action-deletetiddler $filter="[title<importState>] [title<importTitle>]"/>
 \end
 
-\define replacement-text-image() [img[$title$]]
+\procedure replacement-text-image() [img[$1$]]
 
-\define replacement-text-file() [[$title$]]
+\procedure replacement-text-file() [[$1$]]
 
-\define postImportActions()
+\procedure postImportActions()
 \whitespace trim
-<$list filter="[<importTitle>links[]] :reduce[get[type]prefix[image]then<replacement-text-image>else<replacement-text-file>search-replace[$title$],<currentTiddler>addprefix<accumulator>]" variable="imageTitle">
+<$list filter="[<importTitle>links[]] :reduce[get[type]prefix[image]then<replacement-text-image>else<replacement-text-file>substitute<currentTiddler>addprefix<accumulator>]" variable="imageTitle">
 <$action-sendmessage
 	$message="tm-edit-text-operation"
 	$param="insert-text"
@@ -24,7 +24,7 @@ condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]
 <<closePopupActions>>
 \end
 
-\define buttons()
+\procedure buttons()
 \whitespace trim
 <$button class="tc-btn-invisible" actions=<<closePopupActions>> ><<lingo Listing/Cancel/Caption>></$button>
 &#32;

--- a/core/wiki/config/EditorEnableImportFilter.tid
+++ b/core/wiki/config/EditorEnableImportFilter.tid
@@ -1,4 +1,4 @@
 title: $:/config/Editor/EnableImportFilter
 type: text/vnd.tiddlywiki
 
-[all[current]type[text/vnd.tiddlywiki]] [all[current]!has[type]]
+[all[current]type[text/vnd.tiddlywiki]] [all[current]!has[type]] [all[current]type[text/markdown]] [all[current]type[text/x-markdown]]


### PR DESCRIPTION
This PR updates the import UI in the editor that is triggered by drag and drop to be reusable in x-markdown tiddlers.

- All macros have been updated to procedures, which is a safe change as none of the macros used text-substitution
- the UX tiddler has been updated to reuse the filter from `$:/config/Editor/EnableImportFilter` which defines whether importing in the editor is supported for that tiddler type

This PR explores an alternative to #8463 to reduce code duplication and closes #8388