### PR TITLE
Fix strange links in $:/plugins/tiddlywiki/highlight/usage

### DIFF
--- a/plugins/tiddlywiki/highlight/usage.tid
+++ b/plugins/tiddlywiki/highlight/usage.tid
@@ -2,8 +2,8 @@ title: $:/plugins/tiddlywiki/highlight/usage
 
 \import $:/plugins/tiddlywiki/highlight/readme
 
-\define jsDelivrLink() https://www.jsdelivr.com/package/gh/highlightjs/cdn-release?path=build%2Flanguages&version=$(highlightVersion)$
-\define unpkgLink() https://unpkg.com/browse/@highlightjs/cdn-assets@$(highlightVersion)$/languages/
+\procedure jsDelivrLink() https://www.jsdelivr.com/package/gh/highlightjs/cdn-release?path=build%2Flanguages&version=$(highlightVersion)$
+\procedure unpkgLink() https://unpkg.com/browse/@highlightjs/cdn-assets@$(highlightVersion)$/languages/
 
 ! Usage
 
@@ -31,8 +31,8 @@ You can import language definitions into <$text text="JavaScript"/> tiddlers, wi
 
 First, locate the language file(s) you need. You can fetch the files from the following CDNs:
 
-* <a href=<<jsDelivrLink>>>jsDelivr</a>
-* <a href=<<unpkgLink>>>unpkg</a>
+* <a href=<<jsDelivrLink>> class="tc-tiddlylink-external" target="_blank">jsDelivr</a>
+* <a href=<<unpkgLink>> class="tc-tiddlylink-external" target="_blank">unpkg</a>
 
 Then, click the button below to create a "highlight" module. Copy and paste the content of a language file into the the text area. Give your tiddler a meaningful title so you can keep track of the languages you've installed. You may choose to either create one tiddler per language or lump all language definitions into one tiddler. Save and reload your wiki.
 

--- a/plugins/tiddlywiki/highlight/usage.tid
+++ b/plugins/tiddlywiki/highlight/usage.tid
@@ -2,8 +2,8 @@ title: $:/plugins/tiddlywiki/highlight/usage
 
 \import $:/plugins/tiddlywiki/highlight/readme
 
-\procedure jsDelivrLink() https://www.jsdelivr.com/package/gh/highlightjs/cdn-release?path=build%2Flanguages&version=$(highlightVersion)$
-\procedure unpkgLink() https://unpkg.com/browse/@highlightjs/cdn-assets@$(highlightVersion)$/languages/
+\define jsDelivrLink() https://www.jsdelivr.com/package/gh/highlightjs/cdn-release?path=build%2Flanguages&version=$(highlightVersion)$
+\define unpkgLink() https://unpkg.com/browse/@highlightjs/cdn-assets@$(highlightVersion)$/languages/
 
 ! Usage
 


### PR DESCRIPTION
This PR fixes strange links in `$:/plugins/tiddlywiki/highlight/usage` which doesn't obey palette colors and doesn't open links in a new tab.