### PR TITLE
Apply proper color for target footnote background in markdown

### DIFF
--- a/core/palettes/Blanca.tid
+++ b/core/palettes/Blanca.tid
@@ -33,6 +33,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
+footnote-target-background: #ecf2ff
 foreground: #333333
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/Blue.tid
+++ b/core/palettes/Blue.tid
@@ -33,6 +33,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
+footnote-target-background: #ecf2ff
 foreground: #333353
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/BrightMute.tid
+++ b/core/palettes/BrightMute.tid
@@ -33,6 +33,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
+footnote-target-background: #ecf2ff
 foreground: #333333
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/ContrastDark.tid
+++ b/core/palettes/ContrastDark.tid
@@ -33,7 +33,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #00a
 external-link-foreground: #00e
-footnote-target-background: <<colour foreground>>
+footnote-target-background: #e5e5e5
 foreground: #000
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/ContrastDark.tid
+++ b/core/palettes/ContrastDark.tid
@@ -33,6 +33,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #00a
 external-link-foreground: #00e
+footnote-target-background: <<colour foreground>>
 foreground: #000
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/ContrastLight.tid
+++ b/core/palettes/ContrastLight.tid
@@ -33,7 +33,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #00a
 external-link-foreground: #00e
-footnote-target-background: <<colour foreground>>
+footnote-target-background: #4c4c4c
 foreground: #fff
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/ContrastLight.tid
+++ b/core/palettes/ContrastLight.tid
@@ -33,6 +33,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #00a
 external-link-foreground: #00e
+footnote-target-background: <<colour foreground>>
 foreground: #fff
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -31,6 +31,7 @@ external-link-background: transparent
 external-link-foreground-hover: 
 external-link-foreground-visited: #BF5AF2
 external-link-foreground: #32D74B
+footnote-target-background: <<colour background>>
 foreground: #FFFFFF
 highlight-background: #ffff78
 highlight-foreground: #000000

--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -31,7 +31,7 @@ external-link-background: transparent
 external-link-foreground-hover: 
 external-link-foreground-visited: #BF5AF2
 external-link-foreground: #32D74B
-footnote-target-background: <<colour background>>
+footnote-target-background: #747474
 foreground: #FFFFFF
 highlight-background: #ffff78
 highlight-foreground: #000000

--- a/core/palettes/DarkPhotos.tid
+++ b/core/palettes/DarkPhotos.tid
@@ -35,6 +35,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
+footnote-target-background: #ecf2ff
 foreground: #333333
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/DesertSand.tid
+++ b/core/palettes/DesertSand.tid
@@ -39,7 +39,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #313163
 external-link-foreground: #555592
-footnote-target-background: #ECE5CF
+footnote-target-background: #fff7d9
 foreground: #2D2A23
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/DesertSand.tid
+++ b/core/palettes/DesertSand.tid
@@ -39,6 +39,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #313163
 external-link-foreground: #555592
+footnote-target-background: #ECE5CF
 foreground: #2D2A23
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/GruvBoxDark.tid
+++ b/core/palettes/GruvBoxDark.tid
@@ -40,6 +40,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #d3869b
 external-link-foreground: #8ec07c
+footnote-target-background: #83a598
 foreground: #fbf1c7
 highlight-background: #ffff79
 highlight-foreground: #000000

--- a/core/palettes/GruvBoxDark.tid
+++ b/core/palettes/GruvBoxDark.tid
@@ -40,7 +40,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #d3869b
 external-link-foreground: #8ec07c
-footnote-target-background: #83a598
+footnote-target-background: #665c54
 foreground: #fbf1c7
 highlight-background: #ffff79
 highlight-foreground: #000000

--- a/core/palettes/Nord.tid
+++ b/core/palettes/Nord.tid
@@ -40,6 +40,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #5E81AC
 external-link-foreground: #8FBCBB
+footnote-target-background: #2E3440
 foreground: #d8dee9
 highlight-background: #ffff78
 highlight-foreground: #000000

--- a/core/palettes/Rocker.tid
+++ b/core/palettes/Rocker.tid
@@ -33,6 +33,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
+footnote-target-background: #ecf2ff
 foreground: #333333
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/SolarFlare.tid
+++ b/core/palettes/SolarFlare.tid
@@ -104,6 +104,7 @@ foreground: #657b83
         dropdown-tab-background: <<colour tab-background>>
 : base3
     alert-background: <<colour base3>>
+    footnote-target-background: <<colour base3>>
     message-background: <<colour base3>>
 : yellow
 : orange

--- a/core/palettes/SolarFlare.tid
+++ b/core/palettes/SolarFlare.tid
@@ -104,7 +104,6 @@ foreground: #657b83
         dropdown-tab-background: <<colour tab-background>>
 : base3
     alert-background: <<colour base3>>
-    footnote-target-background: <<colour base3>>
     message-background: <<colour base3>>
 : yellow
 : orange
@@ -132,6 +131,7 @@ external-link-background-hover: inherit
 external-link-background-visited: inherit
 external-link-background: inherit
 external-link-foreground-hover: inherit
+footnote-target-background: #ded8c5
 highlight-background: #ffff00
 highlight-foreground: #000000
 message-border: #cfd6e6

--- a/core/palettes/SolarizedDark.tid
+++ b/core/palettes/SolarizedDark.tid
@@ -34,6 +34,7 @@ external-link-background-visited: inherit
 external-link-foreground: #268bd2
 external-link-foreground-hover:
 external-link-foreground-visited: #268bd2
+footnote-target-background: #002b36
 foreground: #839496
 highlight-background: #ffff78
 highlight-foreground: #000000

--- a/core/palettes/SolarizedDark.tid
+++ b/core/palettes/SolarizedDark.tid
@@ -34,7 +34,7 @@ external-link-background-visited: inherit
 external-link-foreground: #268bd2
 external-link-foreground-hover:
 external-link-foreground-visited: #268bd2
-footnote-target-background: #002b36
+footnote-target-background: #073642
 foreground: #839496
 highlight-background: #ffff78
 highlight-foreground: #000000

--- a/core/palettes/SolarizedLight.tid
+++ b/core/palettes/SolarizedLight.tid
@@ -34,7 +34,7 @@ external-link-background-visited: inherit
 external-link-foreground: #268bd2
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #268bd2
-footnote-target-background: #fdf6e3
+footnote-target-background: #eee8d5
 foreground: #657b83
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/SolarizedLight.tid
+++ b/core/palettes/SolarizedLight.tid
@@ -34,6 +34,7 @@ external-link-background-visited: inherit
 external-link-foreground: #268bd2
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #268bd2
+footnote-target-background: #fdf6e3
 foreground: #657b83
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/SpartanDay.tid
+++ b/core/palettes/SpartanDay.tid
@@ -33,7 +33,7 @@ external-link-background: transparent
 external-link-foreground-hover: 
 external-link-foreground-visited: 
 external-link-foreground: 
-footnote-target-background: <<colour background>>
+footnote-target-background: #ececec
 foreground: rgba(0, 0, 0, 0.87)
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/SpartanDay.tid
+++ b/core/palettes/SpartanDay.tid
@@ -33,6 +33,7 @@ external-link-background: transparent
 external-link-foreground-hover: 
 external-link-foreground-visited: 
 external-link-foreground: 
+footnote-target-background: <<colour background>>
 foreground: rgba(0, 0, 0, 0.87)
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/core/palettes/SpartanNight.tid
+++ b/core/palettes/SpartanNight.tid
@@ -33,6 +33,7 @@ external-link-background: transparent
 external-link-foreground-hover: 
 external-link-foreground-visited: #7c318c
 external-link-foreground: #9e3eb3
+footnote-target-background: <<colour background>>
 foreground: rgba(255, 255, 255, 0.7)
 highlight-background: #ffff78
 highlight-foreground: #000000

--- a/core/palettes/SpartanNight.tid
+++ b/core/palettes/SpartanNight.tid
@@ -33,7 +33,7 @@ external-link-background: transparent
 external-link-foreground-hover: 
 external-link-foreground-visited: #7c318c
 external-link-foreground: #9e3eb3
-footnote-target-background: <<colour background>>
+footnote-target-background: #494949
 foreground: rgba(255, 255, 255, 0.7)
 highlight-background: #ffff78
 highlight-foreground: #000000

--- a/core/palettes/Twilight.tid
+++ b/core/palettes/Twilight.tid
@@ -42,6 +42,7 @@ external-link-background-visited: inherit
 external-link-foreground: rgb(179, 179, 255)
 external-link-foreground-hover: inherit
 external-link-foreground-visited: rgb(153, 153, 255)
+footnote-target-background: <<colour tag-foreground>>
 foreground: rgb(179, 179, 179)
 highlight-background: #ffff78
 highlight-foreground: #000000

--- a/core/palettes/Vanilla.tid
+++ b/core/palettes/Vanilla.tid
@@ -41,6 +41,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
+footnote-target-background: #ecf2ff
 foreground: #333333
 highlight-background: #ffff00
 highlight-foreground: #000000

--- a/plugins/tiddlywiki/markdown/styles.tid
+++ b/plugins/tiddlywiki/markdown/styles.tid
@@ -36,7 +36,7 @@ code-body: yes
 	margin-left: 0.25em;
 }
 .markdown a.footnote-ref:target, .markdown .footnote-item:target {
-	background-color: <<colour message-background>>;
+	background-color: <<colour footnote-target-background>>;
 	scroll-margin-top: {{{ [{$:/themes/tiddlywiki/vanilla/options/stickytitles}match[yes]then[120px]else[60px]] }}};
 }
 .markdown li > p:first-child {


### PR DESCRIPTION
This PR fixes #8481 .

Applys proper colors to target footnote background. In order to fix the problem, the index `footnote-target-background` is also added to all palettes.