### PR TITLE
Fix wrong filename of contrast palettes

### DIFF
--- a/core/palettes/ContrastDark.tid
+++ b/core/palettes/ContrastDark.tid
@@ -1,7 +1,7 @@
-title: $:/palettes/ContrastLight
-name: Contrast (Light)
-color-scheme: light
-description: High contrast and unambiguous (light version)
+title: $:/palettes/ContrastDark
+name: Contrast (Dark)
+color-scheme: dark
+description: High contrast and unambiguous (dark version)
 tags: $:/tags/Palette
 type: application/x-tiddler-dictionary
 
@@ -9,7 +9,7 @@ alert-background: #f00
 alert-border: <<colour background>>
 alert-highlight: <<colour foreground>>
 alert-muted-foreground: #800
-background: #fff
+background: #000
 blockquote-bar: <<colour muted-foreground>>
 button-background: <<colour background>>
 button-foreground: <<colour foreground>>
@@ -33,8 +33,8 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #00a
 external-link-foreground: #00e
-footnote-target-background: #e5e5e5
-foreground: #000
+footnote-target-background: #4c4c4c
+foreground: #fff
 highlight-background: #ffff00
 highlight-foreground: #000000
 message-background: <<colour foreground>>
@@ -83,8 +83,8 @@ tab-foreground: <<colour background>>
 table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
-tag-background: #000
-tag-foreground: #fff
+tag-background: #fff
+tag-foreground: #000
 tiddler-background: <<colour background>>
 tiddler-border: <<colour foreground>>
 tiddler-controls-foreground-hover: #ddd

--- a/core/palettes/ContrastLight.tid
+++ b/core/palettes/ContrastLight.tid
@@ -1,7 +1,7 @@
-title: $:/palettes/ContrastDark
-name: Contrast (Dark)
-color-scheme: dark
-description: High contrast and unambiguous (dark version)
+title: $:/palettes/ContrastLight
+name: Contrast (Light)
+color-scheme: light
+description: High contrast and unambiguous (light version)
 tags: $:/tags/Palette
 type: application/x-tiddler-dictionary
 
@@ -9,7 +9,7 @@ alert-background: #f00
 alert-border: <<colour background>>
 alert-highlight: <<colour foreground>>
 alert-muted-foreground: #800
-background: #000
+background: #fff
 blockquote-bar: <<colour muted-foreground>>
 button-background: <<colour background>>
 button-foreground: <<colour foreground>>
@@ -33,8 +33,8 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #00a
 external-link-foreground: #00e
-footnote-target-background: #4c4c4c
-foreground: #fff
+footnote-target-background: #e5e5e5
+foreground: #000
 highlight-background: #ffff00
 highlight-foreground: #000000
 message-background: <<colour foreground>>
@@ -83,8 +83,8 @@ tab-foreground: <<colour background>>
 table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
-tag-background: #fff
-tag-foreground: #000
+tag-background: #000
+tag-foreground: #fff
 tiddler-background: <<colour background>>
 tiddler-border: <<colour foreground>>
 tiddler-controls-foreground-hover: #ddd


### PR DESCRIPTION
Fix wrong filename of contrast palettes to avoid confusion.

![图片](https://github.com/user-attachments/assets/f9b743d0-eb22-4a3f-9ac8-f6157e3f3241)
