### PR TITLE
Add start/end properties for table row/cell elements

### DIFF
--- a/core/modules/parsers/wikiparser/rules/table.js
+++ b/core/modules/parsers/wikiparser/rules/table.js
@@ -93,11 +93,12 @@ var processRow = function(prevColumns) {
 			}
 			// Check whether this is a heading cell
 			var cell;
+			var start = this.parser.pos;
 			if(chr === "!") {
 				this.parser.pos++;
-				cell = {type: "element", tag: "th", children: []};
+				cell = {type: "element", tag: "th", start: start, children: []};
 			} else {
-				cell = {type: "element", tag: "td", children: []};
+				cell = {type: "element", tag: "td", start: start, children: []};
 			}
 			tree.push(cell);
 			// Record information about this cell
@@ -121,6 +122,7 @@ var processRow = function(prevColumns) {
 			}
 			// Move back to the closing `|`
 			this.parser.pos--;
+			cell.end = this.parser.pos;
 		}
 		col++;
 		cellRegExp.lastIndex = this.parser.pos;

--- a/core/modules/parsers/wikiparser/rules/table.js
+++ b/core/modules/parsers/wikiparser/rules/table.js
@@ -169,12 +169,13 @@ exports.parse = function() {
 				rowContainer.children = this.parser.parseInlineRun(rowTermRegExp,{eatTerminator: true});
 			} else {
 				// Create the row
-				var theRow = {type: "element", tag: "tr", children: []};
+				var theRow = {type: "element", tag: "tr", children: [], start: rowMatch.index};
 				$tw.utils.addClassToParseTreeNode(theRow,rowCount%2 ? "oddRow" : "evenRow");
 				rowContainer.children.push(theRow);
 				// Process the row
 				theRow.children = processRow.call(this,prevColumns);
 				this.parser.pos = rowMatch.index + rowMatch[0].length;
+				theRow.end = this.parser.pos;
 				// Increment the row count
 				rowCount++;
 			}

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -360,6 +360,8 @@ describe("WikiText parser tests", function() {
 						orderedAttributes: [
 							{ name: 'align', type: 'string', value: 'left' },
 						],
+						start: 1,
+						end: 8,
 						children: [{type: 'text', text: 'Cell1', start: 2, end: 7}],
 					}, {
 						type: 'element',
@@ -370,6 +372,8 @@ describe("WikiText parser tests", function() {
 						orderedAttributes: [
 							{ name: 'align', type: 'string', value: 'left' },
 						],
+						start: 9,
+						end: 16,
 						children: [{type: 'text', text: 'Cell2', start: 10, end: 15}],
 					}],
 				}, {
@@ -392,6 +396,8 @@ describe("WikiText parser tests", function() {
 						orderedAttributes: [
 							{ name: 'align', type: 'string', value: 'left' },
 						],
+						start: 19,
+						end: 25,
 						children: [{type: 'text', text: 'Cell3', start: 19, end: 24}],
 					}, {
 						type: 'element',
@@ -402,6 +408,8 @@ describe("WikiText parser tests", function() {
 						orderedAttributes: [
 							{ name: 'align', type: 'string', value: 'left' },
 						],
+						start: 26,
+						end: 32,
 						children: [{type: 'text', text: 'Cell4', start: 26, end: 31}],
 					}],
 				}],

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -324,6 +324,88 @@ describe("WikiText parser tests", function() {
 
 	});
 
+        it("should parse tables", function() {
+		let wikitext = `
+|!Cell1 |!Cell2 |
+|Cell3 |Cell4 |`.trim();
+
+		let expectedParseTree = [{
+			type: 'element',
+			tag: 'table',
+			start: 0,
+			end: 33,
+			rule: 'table',
+			children: [{
+				type: 'element',
+				tag: 'tbody',
+				start: 0,
+				end: 33,
+				children: [{
+					type: 'element',
+					tag: 'tr',
+					attributes: {
+						'class': { name: 'class', type: 'string', value: 'evenRow' },
+					},
+					orderedAttributes: [
+						{ name: 'class', type: 'string', value: 'evenRow' },
+					],
+					children: [{
+						type: 'element',
+						tag: 'th',
+						attributes: {
+							'align': { name: 'align', type: 'string', value: 'left' },
+						},
+						orderedAttributes: [
+							{ name: 'align', type: 'string', value: 'left' },
+						],
+						children: [{type: 'text', text: 'Cell1', start: 2, end: 7}],
+					}, {
+						type: 'element',
+						tag: 'th',
+						attributes: {
+							'align': { name: 'align', type: 'string', value: 'left' },
+						},
+						orderedAttributes: [
+							{ name: 'align', type: 'string', value: 'left' },
+						],
+						children: [{type: 'text', text: 'Cell2', start: 10, end: 15}],
+					}],
+				}, {
+					type: 'element',
+					tag: 'tr',
+					attributes: {
+						'class': { name: 'class', type: 'string', value: 'oddRow' },
+					},
+					orderedAttributes: [
+						{ name: 'class', type: 'string', value: 'oddRow' },
+					],
+					children: [{
+						type: 'element',
+						tag: 'td',
+						attributes: {
+							'align': { name: 'align', type: 'string', value: 'left' },
+						},
+						orderedAttributes: [
+							{ name: 'align', type: 'string', value: 'left' },
+						],
+						children: [{type: 'text', text: 'Cell3', start: 19, end: 24}],
+					}, {
+						type: 'element',
+						tag: 'td',
+						attributes: {
+							'align': { name: 'align', type: 'string', value: 'left' },
+						},
+						orderedAttributes: [
+							{ name: 'align', type: 'string', value: 'left' },
+						],
+						children: [{type: 'text', text: 'Cell4', start: 26, end: 31}],
+					}],
+				}],
+			}],
+		}];
+
+		expect(parse(wikitext)).toEqual(expectedParseTree);
+        });
 });
 
 })();

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -349,6 +349,8 @@ describe("WikiText parser tests", function() {
 					orderedAttributes: [
 						{ name: 'class', type: 'string', value: 'evenRow' },
 					],
+					start: 0,
+					end: 18,
 					children: [{
 						type: 'element',
 						tag: 'th',
@@ -379,6 +381,8 @@ describe("WikiText parser tests", function() {
 					orderedAttributes: [
 						{ name: 'class', type: 'string', value: 'oddRow' },
 					],
+					start: 18,
+					end: 33,
 					children: [{
 						type: 'element',
 						tag: 'td',


### PR DESCRIPTION
Continuing on work from #7866 

I used my best judgement when determining the values for `start`/`end` - please check them over and make sure they make sense to you as well!