### PR TITLE
Fix social media preview url tiddler name

### DIFF
--- a/core/templates/social-metadata.tid
+++ b/core/templates/social-metadata.tid
@@ -27,7 +27,7 @@ tags: $:/tags/RawMarkupWikified
 <<meta-plain "og:type" "website" "property">>
 <<meta-wikified "og:title" "$:/SiteTitle" "property">>
 <<meta-wikified "og:description" "$:/SiteSubtitle" "property">>
-<<meta-plain "og:image" "$:/SitePreviewImageUrl" "property">>
+<<meta-plain "og:image" "$:/SitePreviewUrl" "property">>
 
 <!-- Twitter Meta Tags -->
 <<meta-plain "twitter:card" "summary_large_image">>
@@ -35,4 +35,4 @@ tags: $:/tags/RawMarkupWikified
 <<meta-plain "twitter:url" "$:/SiteUrl" "property">>
 <<meta-wikified "twitter:title" "$:/SiteTitle">>
 <<meta-wikified "twitter:description" "$:/SiteSubtitle">>
-<<meta-plain "twitter:image" "$:/SitePreviewImageUrl">>
+<<meta-plain "twitter:image" "$:/SitePreviewUrl">>


### PR DESCRIPTION
The control panel name and the name in the template don't match. I figured the shorter name is better, but let me know if you like the longer name.

This is a small fix for recently merged PR #8441.