### PR TITLE
Add import field to testcase tiddlers

### DIFF
--- a/core/ui/TestCaseTemplate.tid
+++ b/core/ui/TestCaseTemplate.tid
@@ -13,6 +13,7 @@ title: $:/core/ui/TestCaseTemplate
 		testActions="Actions"
 		testHideIfPass=<<hideIfPass>>
 	>
+		<$data $filter={{!!import}}/>
 		<$data $compound-filter={{!!import-compound}}/>
 		<$data $compound-tiddler=<<currentTiddler>>/>
 		<%if [{!!description}!is[blank]] %><$data title="Description" text={{!!description}}/><%endif%>

--- a/editions/tw5.com/tiddlers/concepts/TestCaseTiddlers.tid
+++ b/editions/tw5.com/tiddlers/concepts/TestCaseTiddlers.tid
@@ -1,5 +1,5 @@
 created: 20240507221902644
-modified: 20240729083054531
+modified: 20240808020847667
 tags: Concepts
 title: TestCaseTiddlers
 type: text/vnd.tiddlywiki
@@ -14,8 +14,9 @@ Test case tiddlers have the following ''fields'':
 |<<.field type>> |Needs to be set to `text/vnd.tiddlywiki-multiple` |
 |<<.field tags>> |Test cases are tagged [[$:/tags/wiki-test-spec]]. Test cases that intentionally fail are tagged [[$:/tags/wiki-test-spec-failing]] |
 |<<.field description>> |Descriptive heading for the test, intended to make it easy to identify the test |
-|<<.field display-format>> |Optional, defaults to `wikitext`. Set to `plaintext` to cause the output to be rended as plain text |
-|<<.field import-compound>> |<<.from-version "5.3.6">> A filter string, that defines a list of compound tiddlers, that should be imported. See: <<.wlink DataWidget>> widget |
+|<<.field display-format>> |Optional, defaults to `wikitext`. Set to `plaintext` to cause the output to be rendered as plain text |
+|<<.field import>> |<<.from-version "5.3.6">> A filter string that defines a list of tiddlers to import |
+|<<.field import-compound>> |<<.from-version "5.3.6">> A filter string that defines a list of compound tiddlers to import. See: <<.wlink DataWidget>> widget |
 
 Test case tiddlers with the appropriate tag are shown in the $:/ControlPanel ''-> Advanced -> Test Cases ''
 


### PR DESCRIPTION
Some test cases in the geospatial plugin depend on the presence of shadow tiddlers from the plugin tiddler in order to operate properly (see #8484). Using compound tiddlers, there is no way to include the plugin tiddler into the testcase.

This PR fixes that by changing the testcase tiddler template to create a `<$data $filter...>` widget from the contents of the testcase tiddler's `import` field.