### PR TITLE
Make the default title created by excision translatable

### DIFF
--- a/core/language/en-GB/Buttons.multids
+++ b/core/language/en-GB/Buttons.multids
@@ -127,13 +127,13 @@ Excise/Caption: excise
 Excise/Caption/Excise: Perform excision
 Excise/Caption/MacroName: Macro name:
 Excise/Caption/NewTitle: Title of new tiddler:
-Excise/Caption/DefaultTitle: New Excision
 Excise/Caption/Replace: Replace excised text with:
 Excise/Caption/Replace/Macro: macro
 Excise/Caption/Replace/Link: link
 Excise/Caption/Replace/Transclusion: transclusion
 Excise/Caption/Tag: Tag new tiddler with the title of this tiddler
 Excise/Caption/TiddlerExists: Warning: tiddler already exists
+Excise/DefaultTitle: New Excision
 Excise/Hint: Excise the selected text into a new tiddler
 Heading1/Caption: heading 1
 Heading1/Hint: Apply heading level 1 formatting to lines containing selection

--- a/core/language/en-GB/Buttons.multids
+++ b/core/language/en-GB/Buttons.multids
@@ -127,6 +127,7 @@ Excise/Caption: excise
 Excise/Caption/Excise: Perform excision
 Excise/Caption/MacroName: Macro name:
 Excise/Caption/NewTitle: Title of new tiddler:
+Excise/Caption/DefaultTitle: New Excision
 Excise/Caption/Replace: Replace excised text with:
 Excise/Caption/Replace/Macro: macro
 Excise/Caption/Replace/Link: link

--- a/core/modules/editor/operations/text/excise.js
+++ b/core/modules/editor/operations/text/excise.js
@@ -15,7 +15,7 @@ Text editor operation to excise the selection to a new tiddler
 exports["excise"] = function(event,operation) {
 	var editTiddler = this.wiki.getTiddler(this.editTitle),
 		editTiddlerTitle = this.editTitle,
-		excisionBaseTitle = this.wiki.getTiddler("$:/language/Buttons/Excise/Caption/DefaultTitle").fields.text;
+		excisionBaseTitle = $tw.language.getString("Buttons/Excise/DefaultTitle");
 	if(editTiddler && editTiddler.fields["draft.of"]) {
 		editTiddlerTitle = editTiddler.fields["draft.of"];
 	}

--- a/core/modules/editor/operations/text/excise.js
+++ b/core/modules/editor/operations/text/excise.js
@@ -14,11 +14,12 @@ Text editor operation to excise the selection to a new tiddler
 
 exports["excise"] = function(event,operation) {
 	var editTiddler = this.wiki.getTiddler(this.editTitle),
-		editTiddlerTitle = this.editTitle;
+		editTiddlerTitle = this.editTitle,
+		excisionBaseTitle = this.wiki.getTiddler("$:/language/Buttons/Excise/Caption/DefaultTitle").fields.text;
 	if(editTiddler && editTiddler.fields["draft.of"]) {
 		editTiddlerTitle = editTiddler.fields["draft.of"];
 	}
-	var excisionTitle = event.paramObject.title || this.wiki.generateNewTitle("New Excision");
+	var excisionTitle = event.paramObject.title || this.wiki.generateNewTitle(excisionBaseTitle);
 	this.wiki.addTiddler(new $tw.Tiddler(
 		this.wiki.getCreationFields(),
 		this.wiki.getModificationFields(),


### PR DESCRIPTION
The title of the default title created by excision is fixed in `$:/core/modules/editor/operations/text/excise.js`, which should be translatable.

This PR adds a new translatable string `$:/language/Buttons/Excise/DefaultTitle` to fix the problem.