### PR TITLE
Fix Issue With Highlight.js Demo Link

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/CodeblockWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/CodeblockWidget.tid
@@ -1,6 +1,6 @@
 caption: codeblock
 created: 20151103160200000
-modified: 20160817175325205
+modified: 20240809074611002
 tags: Widgets
 title: CodeBlockWidget
 type: text/vnd.tiddlywiki
@@ -22,7 +22,7 @@ The content of the `<$codeblock>` widget is ignored.
 
 The `language` attribute accepts either:
 
-* a Highlight.js language code (see https://highlightjs.org/static/demo/ for a list)
+* a Highlight.js language code (see https://highlightjs.org/demo for a list)
 * a MIME type (eg, `text/html` or `image/svg+xml`)
 
 ! Examples


### PR DESCRIPTION
Existing link redirects to warning about Highlight.js not being a CDN, perhaps due to link moving: https://highlightjs.org/not-a-cdn

Updated to new link: https://highlightjs.org/demo from https://highlightjs.org/static/demo/ 