### PR TITLE
Add docs for some hidden settings

### DIFF
--- a/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting Content to be displayed for empty story.tid
+++ b/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting Content to be displayed for empty story.tid
@@ -1,0 +1,12 @@
+created: 20240811052854726
+modified: 20240811053649554
+tags: [[Hidden Settings]]
+title: Hidden Setting: Content to be displayed for empty story
+
+To display content when the story is empty, create $:/config/EmptyStoryMessage and enter the desired contents.
+
+The following would show the GettingStarted tiddler when all others are closed.
+
+```
+{{GettingStarted||$:/core/ui/ViewTemplate}}
+```

--- a/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting Default Tiddler Colour.tid
+++ b/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting Default Tiddler Colour.tid
@@ -1,0 +1,7 @@
+created: 20240907042443909
+modified: 20240907042629405
+tags: [[Hidden Settings]]
+title: Hidden Setting: Default Tiddler Colour
+type: text/vnd.tiddlywiki
+
+A default tiddler colour can be specified by creating a tiddler called $:/config/DefaultTiddlerColour containing the title of the tiddler containing the CSS color value.


### PR DESCRIPTION
The documention for `$:/config/EmptyStoryMessage` and `$:/config/DefaultTiddlerColour` is only included in [HistoryMechanism](https://tiddlywiki.com/#HistoryMechanism) and [Tiddler Colour Cascade](https://tiddlywiki.com/#Tiddler%20Colour%20Cascade). I think it is better to create documention about it in hidden settings so that users can find it easier.