### PR TITLE
Index instead of Property

### DIFF
--- a/editions/tw5.com/tiddlers/filters/list.tid
+++ b/editions/tw5.com/tiddlers/filters/list.tid
@@ -1,16 +1,16 @@
+caption: list
 created: 20140410103123179
-modified: 20211115092315020
+modified: 20240811083650364
+op-input: ignored
+op-neg-input: a [[selection of titles|Title Selection]]
+op-neg-output: those input titles that are <<.em not>> mentioned at <<.place R>>
+op-output: the titles stored as a [[title list|Title List]] at <<.place R>>
+op-parameter: a [[reference|TextReference]] to a [[field|TiddlerFields]] or [[index|DataTiddlers]] of a particular tiddler
+op-parameter-name: R
+op-purpose: select titles via a list field
 tags: [[Filter Operators]] [[Field Operators]] [[Selection Constructors]] [[Negatable Operators]]
 title: list Operator
 type: text/vnd.tiddlywiki
-caption: list
-op-purpose: select titles via a list field
-op-input: ignored
-op-neg-input: a [[selection of titles|Title Selection]]
-op-parameter: a [[reference|TextReference]] to a [[field|TiddlerFields]] or [[property|DataTiddlers]] of a particular tiddler
-op-parameter-name: R
-op-output: the titles stored as a [[title list|Title List]] at <<.place R>>
-op-neg-output: those input titles that are <<.em not>> mentioned at <<.place R>>
 
 <<.place R>> can reference either a field or a property. See [[TextReference]] for the syntax.
 


### PR DESCRIPTION
The word property is a bit misleading. Along with field, the index is more common. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>