### PR TITLE
Fix geospatial plugin map state loading

### DIFF
--- a/plugins/tiddlywiki/geospatial/widgets/geomap.js
+++ b/plugins/tiddlywiki/geospatial/widgets/geomap.js
@@ -290,7 +290,7 @@ GeomapWidget.prototype.setMapView = function() {
 		this.map.setMaxZoom($tw.utils.parseInt(this.getAttribute("maxZoom")));
 	}
 	// Set the view to the content of the state tiddler
-	var stateTiddler = this.geomapStateTitle && this.wiki.getTiddler(this.geomapStateTitle);
+	var stateTiddler = this.getAttribute("state") && this.wiki.getTiddler(this.getAttribute("state"));
 	if(stateTiddler) {
 		this.map.setView([$tw.utils.parseNumber(stateTiddler.fields.lat,0),$tw.utils.parseNumber(stateTiddler.fields.long,0)], $tw.utils.parseNumber(stateTiddler.fields.zoom,0));
 		return true;


### PR DESCRIPTION
Loading map state from saved tiddlers was not working. The code was using a non-existent property `geomapStateTitle`. Replaced with `getAttribute("state")` and now the state loading is working.