### PR TITLE
make $:/core/macros/export code readable without changing any functionality

### DIFF
--- a/core/wiki/macros/export.tid
+++ b/core/wiki/macros/export.tid
@@ -7,27 +7,44 @@ $baseFilename$$(extension)$
 
 \define exportButton(exportFilter:"[!is[system]sort[title]]",lingoBase,baseFilename:"tiddlers")
 \whitespace trim
-<$vars hint={{{ [<__lingoBase__>addsuffix[Hint]get[text]] }}} caption={{{  [<__lingoBase__>addsuffix[Caption]get[text]] }}}>
-<span class="tc-popup-keep"><$button popup=<<qualify "$:/state/popup/export">> tooltip=<<hint>> aria-label=<<caption>> class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
-{{$:/core/images/export-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
-<span class="tc-btn-text"><$text text=<<caption>>/></span>
-</$list>
-</$button></span></$vars><$reveal state=<<qualify "$:/state/popup/export">> type="popup" position="below" animate="yes">
-<div class="tc-drop-down">
-<$set name="count" value={{{ [subfilter<__exportFilter__>count[]] }}}>
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/Exporter]]">
-<$list filter="[<currentTiddler>has[condition]subfilter{!!condition}limit[1]] ~[<currentTiddler>!has[condition]then[true]]" variable="ignore">
-<$button class="tc-btn-invisible">
-<$action-sendmessage $message="tm-download-file" $param=<<currentTiddler>> exportFilter=<<__exportFilter__>> filename={{{ [<__baseFilename__>addsuffix{!!extension}] }}}/>
-<$action-deletetiddler $tiddler=<<qualify "$:/state/popup/export">>/>
-<$transclude field="description"/>
-</$button>
-</$list>
-</$list>
-</$set>
-</div>
+<$vars hint={{{ [<__lingoBase__>addsuffix[Hint]get[text]] }}}
+	caption={{{  [<__lingoBase__>addsuffix[Caption]get[text]] }}}
+>
+	<span class="tc-popup-keep">
+		<$button popup=<<qualify "$:/state/popup/export">>
+			tooltip=<<hint>>
+			aria-label=<<caption>>
+			class=<<tv-config-toolbar-class>>
+			selectedClass="tc-selected"
+		>
+			<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+				{{$:/core/images/export-button}}
+			</$list>
+			<$list filter="[<tv-config-toolbar-text>match[yes]]">
+				<span class="tc-btn-text"><$text text=<<caption>>/></span>
+			</$list>
+		</$button>
+	</span>
+</$vars>
+<$reveal state=<<qualify "$:/state/popup/export">> type="popup" position="below" animate="yes">
+	<div class="tc-drop-down">
+		<$set name="count" value={{{ [subfilter<__exportFilter__>count[]] }}}>
+			<$list filter="[all[shadows+tiddlers]tag[$:/tags/Exporter]]">
+				<$list filter="[<currentTiddler>has[condition]subfilter{!!condition}limit[1]] ~[<currentTiddler>!has[condition]then[true]]"
+					variable="ignore"
+				>
+					<$button class="tc-btn-invisible">
+						<$action-sendmessage $message="tm-download-file"
+							$param=<<currentTiddler>>
+							exportFilter=<<__exportFilter__>>
+							filename={{{ [<__baseFilename__>addsuffix{!!extension}] }}}
+						/>
+						<$action-deletetiddler $tiddler=<<qualify "$:/state/popup/export">>/>
+						<$transclude field="description"/>
+					</$button>
+				</$list>
+			</$list>
+		</$set>
+	</div>
 </$reveal>
 \end


### PR DESCRIPTION
make $:/core/macros/export code readable without changing any functionality