### PR TITLE
Normalize appearance of input element with other type

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -224,6 +224,10 @@ dl dt {
 textarea,
 input[type=text],
 input[type=search],
+input[type=number],
+input[type=password],
+input[type=email],
+input[type=tel],
 input[type=""],
 input:not([type]) {
 	color: <<colour foreground>>;

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -228,6 +228,7 @@ input[type=number],
 input[type=password],
 input[type=email],
 input[type=tel],
+input[type=url],
 input[type=""],
 input:not([type]) {
 	color: <<colour foreground>>;


### PR DESCRIPTION
When the type attribute of the input element isn't `text` or `search`, it's style won't obey the color palettes.

Since the input element displayed like normal input fields when the type attribute is set to `email`, `number`, `password`, `tel` or `url`, they should be applied the same style to use palette colors.

![图片](https://github.com/user-attachments/assets/3a595af0-f139-478d-afbb-b50857e20ae4)

