### PR TITLE
Add type attribute to input fields in control panel

### DIFF
--- a/core/ui/ControlPanel/Basics.tid
+++ b/core/ui/ControlPanel/Basics.tid
@@ -25,7 +25,7 @@ caption: {{$:/language/ControlPanel/Basics/Caption}}
 |<$link to="$:/SiteTitle"><<lingo Title/Prompt>></$link> |<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
 |<$link to="$:/SiteSubtitle"><<lingo Subtitle/Prompt>></$link> |<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
 |<$link to="$:/status/UserName"><<lingo Username/Prompt>></$link> |<$edit-text tiddler="$:/status/UserName" default="" tag="input"/> |
-|<$link to="$:/config/AnimationDuration"><<lingo AnimDuration/Prompt>></$link> |<$edit-text tiddler="$:/config/AnimationDuration" default="" tag="input"/> |
+|<$link to="$:/config/AnimationDuration"><<lingo AnimDuration/Prompt>></$link> |<$edit-text tiddler="$:/config/AnimationDuration" default="" tag="input" type="number"/> |
 |<$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link> |<<lingo DefaultTiddlers/TopHint>><br> <$edit class="tc-edit-texteditor" tiddler="$:/DefaultTiddlers" autoHeight="yes"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |
 |<$link to="$:/language/DefaultNewTiddlerTitle"><<lingo NewTiddler/Title/Prompt>></$link> |<$edit-text tiddler="$:/language/DefaultNewTiddlerTitle" default="" tag="input"/> |
 |<$link to="$:/config/NewJournal/Title"><<lingo NewJournal/Title/Prompt>></$link> |<$edit-text tiddler="$:/config/NewJournal/Title" default="" tag="input"/> |

--- a/core/ui/ControlPanel/Saving/GitHub.tid
+++ b/core/ui/ControlPanel/Saving/GitHub.tid
@@ -13,4 +13,4 @@ caption: {{$:/language/ControlPanel/Saving/GitService/GitHub/Caption}}
 |<<lingo Branch>> |<$edit-text tiddler="$:/GitHub/Branch" default="main" tag="input"/> |
 |<<lingo Path>> |<$edit-text tiddler="$:/GitHub/Path" default="" tag="input"/> |
 |<<lingo Filename>> |<$edit-text tiddler="$:/GitHub/Filename" default="" tag="input"/> |
-|<<lingo ServerURL>> |<$edit-text tiddler="$:/GitHub/ServerURL" default="https://api.github.com" tag="input"/> |
+|<<lingo ServerURL>> |<$edit-text tiddler="$:/GitHub/ServerURL" default="https://api.github.com" tag="input" type="url"/> |

--- a/core/ui/ControlPanel/Saving/GitLab.tid
+++ b/core/ui/ControlPanel/Saving/GitLab.tid
@@ -13,4 +13,4 @@ caption: {{$:/language/ControlPanel/Saving/GitService/GitLab/Caption}}
 |<<lingo Branch>> |<$edit-text tiddler="$:/GitLab/Branch" default="master" tag="input"/> |
 |<<lingo Path>> |<$edit-text tiddler="$:/GitLab/Path" default="" tag="input"/> |
 |<<lingo Filename>> |<$edit-text tiddler="$:/GitLab/Filename" default="" tag="input"/> |
-|<<lingo ServerURL>> |<$edit-text tiddler="$:/GitLab/ServerURL" default="https://gitlab.com/api/v4" tag="input"/> |
+|<<lingo ServerURL>> |<$edit-text tiddler="$:/GitLab/ServerURL" default="https://gitlab.com/api/v4" tag="input" type="url"/> |

--- a/core/ui/ControlPanel/Saving/TiddlySpot.tid
+++ b/core/ui/ControlPanel/Saving/TiddlySpot.tid
@@ -34,7 +34,7 @@ http://$(userName)$.tiddlyspot.com/$path$/
 
 ''<<lingo Advanced/Heading>>''
 
-|<<lingo ServerURL>>  |<$edit-text tiddler="$:/UploadURL" default="" tag="input"/> |
+|<<lingo ServerURL>>  |<$edit-text tiddler="$:/UploadURL" default="" tag="input" type="url"/> |
 |<<lingo Filename>> |<$edit-text tiddler="$:/UploadFilename" default="index.html" tag="input"/> |
 |<<lingo UploadDir>> |<$edit-text tiddler="$:/UploadDir" default="." tag="input"/> |
 |<<lingo BackupDir>> |<$edit-text tiddler="$:/UploadBackupDir" default="." tag="input"/> |

--- a/core/ui/ControlPanel/Saving/gitea.tid
+++ b/core/ui/ControlPanel/Saving/gitea.tid
@@ -13,4 +13,4 @@ caption: {{$:/language/ControlPanel/Saving/GitService/Gitea/Caption}}
 |<<lingo Branch>> |<$edit-text tiddler="$:/Gitea/Branch" default="master" tag="input"/> |
 |<<lingo Path>> |<$edit-text tiddler="$:/Gitea/Path" default="" tag="input"/> |
 |<<lingo Filename>> |<$edit-text tiddler="$:/Gitea/Filename" default="" tag="input"/> |
-|<<lingo ServerURL>> |<$edit-text tiddler="$:/Gitea/ServerURL" default="https://gitea/api/v1" tag="input"/> |
+|<<lingo ServerURL>> |<$edit-text tiddler="$:/Gitea/ServerURL" default="https://gitea/api/v1" tag="input" type="url"/> |

--- a/core/ui/ControlPanel/SocialCard.tid
+++ b/core/ui/ControlPanel/SocialCard.tid
@@ -8,9 +8,9 @@ caption: {{$:/language/ControlPanel/SocialCard/Caption}}
 
 |<$link to="$:/SiteTitle"><<lingo Basics/Title/Prompt>></$link> |<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
 |<$link to="$:/SiteSubtitle"><<lingo Basics/Subtitle/Prompt>></$link> |<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
-|<$link to="$:/SiteDomain"><<lingo SocialCard/Domain/Prompt>></$link> |<$edit-text tiddler="$:/SiteDomain" default="" tag="input"/> |
-|<$link to="$:/SiteUrl"><<lingo SocialCard/Url/Prompt>></$link> |<$edit-text tiddler="$:/SiteUrl" default="" tag="input"/> |
-|<$link to="$:/SitePreviewUrl"><<lingo SocialCard/PreviewUrl/Prompt>></$link> |<$edit-text tiddler="$:/SitePreviewUrl" default="" tag="input"/> |
+|<$link to="$:/SiteDomain"><<lingo SocialCard/Domain/Prompt>></$link> |<$edit-text tiddler="$:/SiteDomain" default="" tag="input" type="url"/> |
+|<$link to="$:/SiteUrl"><<lingo SocialCard/Url/Prompt>></$link> |<$edit-text tiddler="$:/SiteUrl" default="" tag="input" type="url"/> |
+|<$link to="$:/SitePreviewUrl"><<lingo SocialCard/PreviewUrl/Prompt>></$link> |<$edit-text tiddler="$:/SitePreviewUrl" default="" tag="input" type="url"/> |
 
 <%if [[$:/SitePreviewUrl]get[text]else[]!is[blank]] %>
 <div>

--- a/plugins/tiddlywiki/codemirror/settings/cursorBlinkRate.tid
+++ b/plugins/tiddlywiki/codemirror/settings/cursorBlinkRate.tid
@@ -4,4 +4,4 @@ caption: {{$:/language/codemirror/cursorBlinkRate/hint}}
 
 \define lingo-base() $:/language/codemirror/cursorBlinkRate/
 
-|<$link to="$:/config/codemirror/cursorBlinkRate"><<lingo hint>></$link> |<$edit-text tiddler="$:/config/codemirror/cursorBlinkRate" default="" placeholder="cursorBlinkRate" tag="input"/> |
+|<$link to="$:/config/codemirror/cursorBlinkRate"><<lingo hint>></$link> |<$edit-text tiddler="$:/config/codemirror/cursorBlinkRate" default="" placeholder="cursorBlinkRate" tag="input" type="number"/> |

--- a/plugins/tiddlywiki/codemirror/settings/indentUnit.tid
+++ b/plugins/tiddlywiki/codemirror/settings/indentUnit.tid
@@ -4,4 +4,4 @@ caption: {{$:/language/codemirror/indentUnit/hint}}
 
 \define lingo-base() $:/language/codemirror/indentUnit/
 
-|<$link to="$:/config/codemirror/indentUnit"><<lingo hint>></$link> |<$edit-text tiddler="$:/config/codemirror/indentUnit" default="" placeholder="indentUnit" tag="input"/> |
+|<$link to="$:/config/codemirror/indentUnit"><<lingo hint>></$link> |<$edit-text tiddler="$:/config/codemirror/indentUnit" default="" placeholder="indentUnit" tag="input" type="number"/> |

--- a/plugins/tiddlywiki/codemirror/settings/tabSize.tid
+++ b/plugins/tiddlywiki/codemirror/settings/tabSize.tid
@@ -4,4 +4,4 @@ caption: {{$:/language/codemirror/tabSize/hint}}
 
 \define lingo-base() $:/language/codemirror/tabSize/
 
-|<$link to="$:/config/codemirror/tabSize"><<lingo hint>></$link> |<$edit-text tiddler="$:/config/codemirror/tabSize" default="" placeholder="tabSize" tag="input"/> |
+|<$link to="$:/config/codemirror/tabSize"><<lingo hint>></$link> |<$edit-text tiddler="$:/config/codemirror/tabSize" default="" placeholder="tabSize" tag="input" type="number"/> |


### PR DESCRIPTION
Add proper type attribute to settings in control panel (including the codemirror plugin), which enables virtual keyboards to switch to the proper one when editing settings.

It is suggested to merge #8517 before merging this one.