### PR TITLE
Testcase widget improve containment

### DIFF
--- a/core/ui/TestCases/DefaultTemplate.tid
+++ b/core/ui/TestCases/DefaultTemplate.tid
@@ -3,7 +3,7 @@ code-body: yes
 
 \whitespace trim
 
-\function tf.state() [<qualify "$:/state/testcase">]
+\function tf.state() "$:/state/testcase"
 
 \procedure linkcatcherActions()
 <%if [<navigateTo>has[title]] %>
@@ -102,9 +102,12 @@ code-body: yes
 [all[tiddlers]sort[]] Output +[putfirst[]]
 -Description
 -Narrative
+-[[$:/temp/testcase/draft-title]]
 -[has[plugin-type]]
 -[prefix<tf.state>]
 -[prefix[$:/state/popup/export]]
+-[prefix[$:/HistoryList]]
+-[prefix[$:/StoryList]]
 \end
 
 \procedure testcase-source()
@@ -129,13 +132,17 @@ code-body: yes
 \procedure testcase-body()
 <div class="tc-test-case-wrapper">
 	<<testcase-header>>
-	<%if [[Narrative]is[tiddler]] %>
-		<<testcase-narrative>>
-	<%endif%>
-	<%if [<testResult>match[fail]] %>
-		<<testcase-fail>>
-	<%endif%>
-	<<testcase-panes>>
+	<$let testcase-source-state = <<tf.state>>>
+		<$navigator story="$:/StoryList" history="$:/HistoryList">
+			<%if [[Narrative]is[tiddler]] %>
+				<<testcase-narrative>>
+			<%endif%>
+			<%if [<testResult>match[fail]] %>
+				<<testcase-fail>>
+			<%endif%>
+			<<testcase-panes>>
+		</$navigator>
+	</$let>
 </div>
 \end
 

--- a/core/ui/TestCases/DefaultTemplateSourceTabs.tid
+++ b/core/ui/TestCases/DefaultTemplateSourceTabs.tid
@@ -1,6 +1,22 @@
 title: $:/core/ui/testcases/DefaultTemplate/SourceTabs
 
 \whitespace trim
+
+\procedure testcaseNewTitle() $:/temp/testcase/draft-title
+
+\procedure saveActions()
+<$action-setfield $tiddler=<<currentTab>> $field="draft.title" $value=<<newTitle>>/>
+<$action-sendmessage $message="tm-save-tiddler" $param=<<title>> />
+<$action-setfield $tiddler=<<testcase-source-state>> text=<<newTitle>>/>
+<$action-deletetiddler $tiddler=<<testcaseNewTitle>>/>
+\end
+
+\procedure saveButton(title, newTitle)
+<$button class="tc-btn-invisible tc-test-case-save-button tc-small-gap-left" actions=<<saveActions>> disabled={{{ [<testcaseNewTitle>!has[text]then[yes]] }}}>
+{{$:/core/images/done-button}}
+</$button>
+\end
+
 \procedure body()
 <$list filter="[<currentTab>fields[]] -text +[limit[1]]" variable="ignore">
 	<table class="tc-field-table">
@@ -11,7 +27,12 @@ title: $:/core/ui/testcases/DefaultTemplate/SourceTabs
 						<$text text=<<fieldName>>/>
 					</td>
 					<td>
-						<$view tiddler=<<currentTab>> field=<<fieldName>>/>
+						<%if [<fieldName>match[draft.title]]  %>
+							<$edit-text class="tc-edit-texteditor tc-max-width-80" tiddler=<<testcaseNewTitle>> focus="yes" tag="input"/>
+							<$macrocall $name="saveButton" newTitle={{{ [<testcaseNewTitle>get[text]] }}} title=<<currentTab>>/>
+						<%else%>
+							<$view tiddler=<<currentTab>> field=<<fieldName>>/>
+						<%endif%>
 					</td>
 				</tr>
 			</$list>


### PR DESCRIPTION
This PR fixes #8458

- #8458 
  - The test-case-widget does not contain action-sendmessages
  - Or `<$action-` widgets in general

### To Test the PR

- Use the following code with a testcase-tiddler
- title: `test-new-tiddler-button`
- tag: `$:/tags/wiki-test-spec`
- type: `text/vnd.tiddlywiki-multiple`

```
title: Narrative

This code tests action-sendmessage with tm-new-tiddler

+
title: Output

<$button>
<$action-sendmessage $message="tm-new-tiddler" />
Create a new tiddler
</$button>
```

## This PR 

- The new tiddler is created in the testcase "environment".
- It implements a very minimalistic "edit template", that only allows users to define a tiddler title.

![grafik](https://github.com/user-attachments/assets/a2e7b32e-b800-4079-8835-bfb717255caf)

## I did Test With:

- action-createtiddler
- action-deletetiddler
- action-navigate
- action-sendmessage -- messages the are caught by the navigator-widget
- action-setfield

It seems to work well, with all messages, that the navigator-widget can handle. 

@btheado, @Leilei332 -- please test this PR. See link at: https://github.com/TiddlyWiki/TiddlyWiki5/pull/8529#issuecomment-2297562500
