### PR TITLE
Add support for language Chinese (Hong Kong)

### DIFF
--- a/editions/full/tiddlywiki.info
+++ b/editions/full/tiddlywiki.info
@@ -57,7 +57,8 @@
 		"sl-SI",
 		"sv-SE",
 		"zh-Hans",
-		"zh-Hant"
+		"zh-Hant",
+		"zh-HK"
 	],
 	"themes": [
 		"tiddlywiki/centralised",

--- a/languages/zh-HK/Buttons.multids
+++ b/languages/zh-HK/Buttons.multids
@@ -1,0 +1,17 @@
+title: $:/language/Buttons/
+
+ControlPanel/Hint: 開啓控制台
+FoldOthers/Hint: 收合其他已開啓條目的內容
+FoldAll/Hint: 收合所有已開啓條目的內容
+UnfoldAll/Hint: 展開所有已開啓條目的內容
+Help/Caption: 説明
+Help/Hint: 顯示説明中心
+Home/Hint: 開啓首頁條目
+LayoutSwitcher/Hint: 開啓版面切換器
+Manager/Hint: 開啓條目管理器
+OpenControlPanel/Hint: 開啓控制台
+OpenWindow/Caption: 開啓於新視窗
+OpenWindow/Hint: 在新視窗中開啓條目
+Permaview/Hint: 設定瀏覽器網址列為直接連結到當前所有已開啓條目
+Timestamp/On/Caption: 時間戳記開啓
+Stamp/New/Text: 片段的文字。（記得在 `caption` 欄位中新增一個説明性的標題）。

--- a/languages/zh-HK/ControlPanel.multids
+++ b/languages/zh-HK/ControlPanel.multids
@@ -1,0 +1,31 @@
+title: $:/language/ControlPanel/
+
+Basics/DefaultTiddlers/BottomHint: 標題含空白時請使用 &#91;&#91;雙中括弧&#93;&#93;，或者您可用 {{保留開啓中的條目順序||$:/snippets/retain-story-ordering-button}}
+Basics/DefaultTiddlers/TopHint: 預設開啓的條目
+KeyboardShortcuts/Platform/All: 所有平台
+KeyboardShortcuts/Platform/Mac: 僅 Macintosh 平台
+KeyboardShortcuts/Platform/NonMac: 僅非 Macintosh 平台
+KeyboardShortcuts/Platform/Linux: 僅 Linux 平台
+KeyboardShortcuts/Platform/NonLinux: 僅非 Linux 平台
+KeyboardShortcuts/Platform/Windows: 僅 Windows 平台
+KeyboardShortcuts/Platform/NonWindows: 僅非 Windows 平台
+Plugins/Enable/Caption: 啓用
+Plugins/Enable/Hint: 重新載入頁面時啓用此插件
+Plugins/OpenPluginLibrary: 開啓插件程式庫
+Parsing/Hint: 在此您可以全域停用或啓用維基解析規則。要使更改生效，請儲存並重新載入您的維基。停用某些解析規則，會妨礙 <$text text="TiddlyWiki"/>  正常運作。可使用[[安全模式|https://tiddlywiki.com/#SafeMode]]恢復正常操作。
+Saving/DownloadSaver/AutoSave/Hint: 啓用下載儲存模組的自動儲存
+Saving/GitService/GitHub/Password: 密碼、OAUTH 權杖，或個人存取權杖 (詳見 [[GitHub 説明頁面|https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line]])
+Saving/GitService/GitLab/Password: 個人存取權杖的 API (詳見 [[GitLab 説明頁面|https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html]])
+Settings/CamelCase/Caption: 駝峯式維基鏈接
+Settings/CamelCase/Hint: 您可以全域停用駝峯式短語自動鏈接。須儲存後重新載入，方才生效。
+Settings/CamelCase/Description: 啓用自動駝峯式鏈接
+Settings/EditorToolbar/Hint: 啓用或停用編輯器工具列︰
+Settings/InfoPanelMode/Sticky/Description: 條目資訊面板保持開啓狀態，直到明確關閉
+Settings/LinkToBehaviour/Caption: 條目開啓行為
+Settings/LinkToBehaviour/OpenAbove: 開啓於當前條目之上
+Settings/LinkToBehaviour/OpenBelow: 開啓於當前條目之下
+Settings/LinkToBehaviour/OpenAtTop: 開啓於故事河的頂端
+Settings/LinkToBehaviour/OpenAtBottom: 開啓於故事河的底部
+Settings/MissingLinks/Description: 啓用鏈接到佚失條目
+Settings/NavigationAddressBar/Permaview/Description: 包括目標條目和當前已開啓的條目序列
+Settings/PerformanceInstrumentation/Description: 啓用效能檢測

--- a/languages/zh-HK/Docs/ModuleTypes.multids
+++ b/languages/zh-HK/Docs/ModuleTypes.multids
@@ -1,0 +1,4 @@
+title: $:/language/Docs/ModuleTypes/
+
+isfilteroperator: ''is'' 篩選器運算子的蔘數。
+startup: 啓動時期的功能函數。

--- a/languages/zh-HK/Docs/ModuleTypes.multids
+++ b/languages/zh-HK/Docs/ModuleTypes.multids
@@ -1,4 +1,3 @@
 title: $:/language/Docs/ModuleTypes/
 
-isfilteroperator: ''is'' 篩選器運算子的蔘數。
 startup: 啓動時期的功能函數。

--- a/languages/zh-HK/Fields.multids
+++ b/languages/zh-HK/Fields.multids
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Fields/
+
+class: 渲染條目時，套用到條目的 CSS 類別 - 請參閲[[依自訂類別的自訂樣式|Custom styles by user-class]]。也適用於[[互動視窗|Modals]]
+description: 插件的説明、描述
+toc-link: 若設定為 ''no''，則抑制目錄樹中的條目鏈接。

--- a/languages/zh-HK/GettingStarted.tid
+++ b/languages/zh-HK/GettingStarted.tid
@@ -1,0 +1,18 @@
+title: GettingStarted
+
+\define lingo-base() $:/language/ControlPanel/Basics/
+歡迎使用 ~TiddlyWiki 及參與 ~TiddlyWiki 社羣
+
+開始將重要資訊存放於 ~TiddlyWiki 之前，確認您可以可靠地儲存變更是很重要的。詳細資訊請參閲 https://tiddlywiki.com/#GettingStarted
+
+!! 設定此 ~TiddlyWiki
+
+<div class="tc-control-panel">
+
+|tc-table-no-border tc-first-col-min-width tc-first-link-nowrap|k
+| <$link to="$:/SiteTitle"><<lingo Title/Prompt>></$link>|<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
+| <$link to="$:/SiteSubtitle"><<lingo Subtitle/Prompt>></$link>|<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
+|^ <$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link><br><<lingo DefaultTiddlers/TopHint>>|<$edit tag="textarea" tiddler="$:/DefaultTiddlers"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |
+</div>
+
+請參閲[[控制枱|$:/ControlPanel]]查看更多選項。

--- a/languages/zh-HK/Help/listen.tid
+++ b/languages/zh-HK/Help/listen.tid
@@ -1,0 +1,35 @@
+title: $:/language/Help/listen
+description: 為 TiddlyWiki 提供一個 HTTP 伺服器介面
+
+通過 HTTP 提供一個維基服務。
+
+listen 命令使用[[命名的命令參數|NamedCommandParameters]]：
+
+```
+--listen [<name>=<value>]...
+```
+
+所有參數都是可選的, 具有安全的預設值, 可以按任意順序指定。認可的參數有:
+
+* ''host'' - 可選的主機名稱， (預設為 "127.0.0.1" 或名為 "localhost")
+* ''path-prefix'' - 可選的路徑前綴
+* ''port'' - 偵聽的埠號；非數值會被解譯為一個系統環境變數，從其中提取埠號 (預設為 "8080")
+* ''credentials'' - 憑證 CSV 檔案的路徑名（相對於維基資料夾）
+* ''anon-username'' - 匿名使用者的編輯署名
+* ''username'' - 可選的基本驗證使用者名稱
+* ''password'' - 可選的基本驗證密碼
+* ''authenticated-user-header'' - 可選的 HTTP 請求功能參數名稱，用於受信任身份驗證
+* ''readers'' - 允許讀取此維基，以逗號分隔的使用者名稱的清單
+* ''writers'' - 允許寫入此維基，以逗號分隔的使用者名稱的清單
+* ''csrf-disable'' - 設定為 "yes" 以停用 CSRF 檢查 (預設為 "no")
+* ''sse-enabled'' - 設定為 "yes" 以啟用伺服器傳送的事件 (預設為 "no")
+* ''root-tiddler'' - 服務的基本條目 (預設為 "$:/core/save/all")
+* ''root-render-type'' - 呈現的基本條目的內容類型 (預設為 "text/plain")
+* ''root-serve-type'' - 服務的基本條目的內容類型 (預設為 "text/html")
+* ''tls-cert'' - TLS 證書檔案的路徑名（相對於維基資料夾）
+* ''tls-key'' - TLS 密鑰檔案的路徑名（相對於維基資料夾）
+* ''debug-level'' - 可選的偵錯層級；設定為 "debug" 來檢視請求的詳細資訊；(預設為 "none")
+* ''gzip'' - 設為 "yes" 以啟用某些 http 端點的 gzip 壓縮 (預設為 "no")
+* ''use-browser-cache'' - 設定為 "yes" ，允許瀏覽器快取回應，以節省頻寬（預設值為 "no"）
+
+有關向整個本地網路開啟實例的資訊，以及可能的安全問題，請參閲 TiddlyWiki.com 的 WebServer 條目。

--- a/languages/zh-HK/Help/notfound.tid
+++ b/languages/zh-HK/Help/notfound.tid
@@ -1,0 +1,3 @@
+title: $:/language/Help/notfound
+
+無此項目説明

--- a/languages/zh-HK/Help/password.tid
+++ b/languages/zh-HK/Help/password.tid
@@ -1,0 +1,10 @@
+title: $:/language/Help/password
+description: 設定用以加密的密碼
+
+設定用以加密的密碼
+
+```
+--password <password>
+```
+
+''請注意''：這不是用於提供 TiddlyWiki 具有密碼保護功能。相反地，請看 [[ServerCommand]] 的密碼選項説明。

--- a/languages/zh-HK/Help/render.tid
+++ b/languages/zh-HK/Help/render.tid
@@ -1,0 +1,34 @@
+title: $:/language/Help/render
+description: 呈現個別條目到檔案
+
+呈現由篩選器標識的個別條目，並將結果儲存到指定的檔案。
+
+可選擇性地指定範本條目名稱。在此情況下，不是直接呈現每個條目，而是使用設為正在呈現的條目名稱的 "currentTiddler" 變數，來呈現範本條目。
+
+也可以選擇性地指定附加變數的名稱和值。
+
+```
+--render <tiddler-filter> [<filename-filter>] [<render-type>] [<template>] [ [<name>] [<value>] ]*
+```
+
+* ''tiddler-filter'': 標識要呈現的條目的篩選器
+* ''filename-filter'': 可選的篩選器，轉換條目名稱至路徑名。如果省略，預設為 `[is[tiddler]addsuffix[.html]]`，其使用未改變的條目名稱為檔名
+* ''template'': 可選的範本，用於呈現每個條目
+* ''render-type'': 可選的呈現類型：`text/html` (預設值) 會傳回完整的 HTML 文字，而 `text/plain` 只會傳迴文字內容 (即其忽略 HTML 標記與其他不可印出的資料)
+* ''name'': 可選的變數名稱
+* ''value'': 可選的變數值
+
+預設情況下，檔名被解析為相對於發行版資料夾的 `output` 子資料夾。`--output` 命令可用於將輸出指到一個不同的資料夾。
+
+附註：
+
+* 輸出資料夾不清除任何現有的檔案
+* 檔名的路徑中，任何不存在的資料夾，將自動建立。
+* 當正呈現的條目名稱中帶有空格，請注意同時使用命令列介面所要求的引號，與 TiddlyWiki 的雙重方括號：`--render "[[Motovun Jack.jpg]]"`
+* 所選的項目被設定為當前正在呈現的條目名稱，以此評估檔名篩選器，允條目名稱用作基礎計算的檔名。例如，`[encodeuricomponent[]addprefix[static/]]` 為每個條目名稱套用 URI 編碼，然後增加首碼 `static/`
+* `--render` 命令是已棄用的 `--rendertiddler` 和 `--rendertiddlers` 的一個更靈活的替代命令。
+
+範例：
+
+* `--render "[!is[system]]" "[encodeuricomponent[]addprefix[tiddlers/]addsuffix[.html]]"` -- 呈現所有非系統條目為 "tiddlers" 子資料夾中的檔案，檔名為 URL 編碼的條目名稱和副檔名 HTML
+* `--render '.' 'tiddlers.json' 'text/plain' '$:/core/templates/exporters/JsonFile' 'exportFilter' '[tag[HelloThere]]'` -- 將標籤為 "HelloThere" 的條目渲染到名為 "tiddlers.json" 的 JSON 檔案

--- a/languages/zh-HK/Help/savetiddlers.tid
+++ b/languages/zh-HK/Help/savetiddlers.tid
@@ -1,0 +1,16 @@
+title: $:/language/Help/savetiddlers
+description: 將一羣條目的原始內容儲存到一個資料夾
+
+(請注意：`--savetiddlers` 命令已被棄用，而支援新的、更靈活得 `--save` 命令)
+
+儲存一羣條目的原始文字或二進位格式到指定的資料夾。
+
+```
+--savetiddlers <filter> <pathname> [noclean]
+```
+
+預設情況下，路徑名被解析為相對於發行版資料夾的 `output` 子資料夾。 `--output` 命令可以用於將輸出指定到一個不同的資料夾。
+
+儲存指定的檔案之前，會先清除輸出目錄的現有檔案。可藉由指定 ''noclean'' 旗標，停用該刪除動作。
+
+自動建立在路徑中任何缺少的資料夾。

--- a/languages/zh-HK/Help/server.tid
+++ b/languages/zh-HK/Help/server.tid
@@ -1,0 +1,44 @@
+title: $:/language/Help/server
+description: （已棄用：請參閲 'listen' 命令）提供一個 HTTP 伺服器介面到 TiddlyWiki
+
+在伺服器中內建 TiddlyWiki5 是非常簡單。雖與 TiddlyWeb 相容，但不支援許多健全網際網路面向的使用方式所需的功能。
+
+提供呈現一個指定條目，也可將個別條目編碼成 JSON，且支援基本的 HTTP 操作 `GET`、`PUT` 及 `DELETE`.
+
+```
+--server <port> <root-tiddler> <root-render-type> <root-serve-type> <username> <password> <host> <path-prefix> <debug-level>
+```
+
+參數説明：
+
+* ''port'' - 要偵聽的埠號；非數值會被解譯為一個系統環境變數，從其中提取埠號 (預設為 "8080")
+* ''root-tiddler'' - 服務的基本條目 (預設為 "$:/core/save/all")
+* ''root-render-type'' - 呈現的基本條目的內容類型 (預設為 "text/plain")
+* ''root-serve-type'' - 服務的基本條目的內容類型 (預設為 "text/html")
+* ''username'' - 預設的編輯者署名
+* ''password'' - 可選的基本驗證密碼
+* ''host'' - 可選的主機名稱， (預設為 "127.0.0.1" 或名為 "localhost")
+* ''path-prefix'' - 可選的的路徑前綴
+* ''debug-level'' - 可選的偵錯層級；設定為 "debug" 來檢視請求的詳細資訊；(預設為 "none")
+
+若指定密碼參數，瀏覽器將提示使用者輸入帳號與密碼。注意，密碼係以明碼方式傳遞，應只在受信任的網路或 HTTPS 上使用。
+
+例如：
+
+```
+--server 8080 $:/core/save/all text/plain text/html MyUserName passw0rd
+```
+
+若您需要設定主機名稱或路徑前綴，而不要求輸入密碼，則可以指定空字串的使用者名和密碼。
+
+```
+--server 8080 $:/core/save/all text/plain text/html "" "" 192.168.0.245
+```
+
+使用這樣的位址，會將您的系統暴露給本地網路。有關向整個本地網路開啟實例的資訊，以及可能的安全問題，請參閲 TiddlyWiki.com 的 WebServer 條目。
+
+同時執行多個 TiddlyWiki 伺服器，須分別指定不同的埠號。使用環境變數，有助於將埠號傳遞給 Node.js 進程。本示例引用一個名為 "MY_PORT_NUMBER" 的環境變數:
+
+```
+--server MY_PORT_NUMBER $:/core/save/all text/plain text/html MyUserName passw0rd
+```

--- a/languages/zh-HK/Help/setfield.tid
+++ b/languages/zh-HK/Help/setfield.tid
@@ -1,0 +1,17 @@
+title: $:/language/Help/setfield
+description: 準備用於外部條目
+
+//請注意此命令是試驗性的，且可能會更改或在最終定稿前被替換//
+
+設定一羣條目的指定欄位到 wikifying 範本條目的結果，其中的 `currentTiddler` 變數設定為各該條目。
+
+```
+--setfield <filter> <fieldname> <templatetitle> <rendertype>
+```
+
+參數説明：
+
+* ''filter'' - 受影響的辨識條目的篩選條件
+* ''fieldname'' - 要修改的欄位（預設為 "text"）
+* ''templatetitle'' - 該條目 wikify 到指定欄位。若為空白或丟失，則刪除指定的欄位
+* ''rendertype'' - 要呈現的文本類型（預設為 "text/plain"; "text/html" 可以用於包含 HTML 標記)）

--- a/languages/zh-HK/Misc.multids
+++ b/languages/zh-HK/Misc.multids
@@ -1,0 +1,5 @@
+title: $:/language/
+
+InternalJavaScriptError/Hint: 喔，真是令人尷尬。建議刷新您的瀏覽器，重新啓動 TiddlyWiki
+LayoutSwitcher/Description: 開啓版面切換器
+Shortcuts/Input/AdvancedSearch/Hint: 從側邊欄搜尋欄位內開啓[[進階搜尋|$:/AdvancedSearch]]面板

--- a/languages/zh-HK/SideBar.multids
+++ b/languages/zh-HK/SideBar.multids
@@ -1,0 +1,3 @@
+title: $:/language/SideBar/
+
+Open/Caption: 開啓

--- a/languages/zh-HK/Snippets/ProcedureDefinition.tid
+++ b/languages/zh-HK/Snippets/ProcedureDefinition.tid
@@ -1,0 +1,7 @@
+title: $:/language/Snippets/ProcedureDefinition
+tags: $:/tags/TextEditor/Snippet
+caption: 程序定義
+
+\procedure procName(param1:"預設值",param2)
+這裏就是您的文字了。
+\end

--- a/languages/zh-HK/ThemeTweaks.multids
+++ b/languages/zh-HK/ThemeTweaks.multids
@@ -1,0 +1,3 @@
+title: $:/language/ThemeTweaks/
+
+Options/StickyTitles/Hint: 使條目名稱"黏着"於瀏覽器視窗的頂端


### PR DESCRIPTION
Although Hong Kong and Taiwan region both uses traditional chinese characters, there are a few characters that is different (like 啓 and 啟, 説 and 說, 羣 and 群). This PR adds support for Chinese (Hong Kong) by replacing characters with Hong Kong ones.

In addition, this PR adds the Chinese (Hong Kong) language to the full edition for testing.