### PR TITLE
make unfold button icon more prominent

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -708,21 +708,35 @@ button svg.tc-image-button, button .tc-image-button img {
 
 .tc-unfold-banner {
 	position: absolute;
-	padding: 0;
-	margin: 0;
+	padding: .1em 0 .1em 0;
+	margin-top: 4px;
+	margin-left: -43px;
 	background: none;
 	border: none;
-	width: 100%;
+	width: 100%; /* for old browsers which can not handle calc() */
 	width: calc(100% + 2px);
-	margin-left: -43px;
 	text-align: center;
-	border-top: 2px solid <<colour tiddler-info-background>>;
-	margin-top: 4px;
+	border-top: 1px solid <<colour tiddler-info-background>>;
+	border-bottom: 1px solid <<colour tiddler-info-background>>;
 }
+
+.tc-unfold-banner .tc-image-button {
+	outline: 2px solid <<colour tiddler-controls-foreground>>;
+	min-width: 1.7em;
+	min-height: 1.7em;
+	padding: .3em;
+	border-radius: 50%;
+}
+
+.tc-unfold-banner:hover .tc-image-button {
+	outline-color: <<colour tiddler-controls-foreground-hover>>;
+}
+
 
 .tc-unfold-banner:hover {
 	background: <<colour tiddler-info-background>>;
 	border-top: 2px solid <<colour tiddler-info-border>>;
+	border-bottom: 2px solid <<colour tiddler-info-border>>;
 }
 
 .tc-unfold-banner svg, .tc-fold-banner svg {


### PR DESCRIPTION
This PR makes the unfold button icon more prominent

See Talk thread: https://talk.tiddlywiki.org/t/feature-request-option-to-automatically-open-folded-tiddlers-when-clicking-a-link-to-them/10418/12

**standard unfold banner**

![9cf9e372a8eb8849bb530f550b8b382df95fed81_2_1035x90](https://github.com/user-attachments/assets/6e5a7a26-ca20-4e04-b894-7f48dabbdaaa)


**hover state**

![c537b39a6511c7c7aea6b9086f76c74c0d112ae0_2_1035x90](https://github.com/user-attachments/assets/131b4387-939d-446d-acf8-0c6687428bee)

