### PR TITLE
[Docs] Simplify the Railroad Plugin tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/Railroad Diagrams.tid
+++ b/editions/tw5.com/tiddlers/concepts/Railroad Diagrams.tid
@@ -1,5 +1,5 @@
 created: 20150105133800000
-modified: 20211117212441252
+modified: 20240820214317983
 tags: Concepts
 title: Railroad Diagrams
 
@@ -14,5 +14,7 @@ start [:optional] {repeated +","} end
 In the example above, a comma appears between each occurrence of the `repeated` item. The comma path runs from right to left, and can only be reached by first passing through `repeated`.
 
 Characters in round boxes are literal, i.e. they denote themselves. A name in a rectangular box denotes a further railroad diagram.
+
+The TW [[Filter Syntax]] documentation makes extensive use of railroad diagrams.
 
 The railroad diagrams in ~TiddlyWiki's documentation are generated with the [[Railroad Plugin]].

--- a/editions/tw5.com/tiddlers/concepts/Railroad Diagrams.tid
+++ b/editions/tw5.com/tiddlers/concepts/Railroad Diagrams.tid
@@ -1,5 +1,5 @@
 created: 20150105133800000
-modified: 20240820214317983
+modified: 20211117212441252
 tags: Concepts
 title: Railroad Diagrams
 

--- a/editions/tw5.com/tiddlers/plugins/Railroad Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Railroad Plugin.tid
@@ -1,10 +1,16 @@
 created: 20160107223348621
 list: 
-modified: 20170228102501706
+modified: 20240820214405820
 tags: OfficialPlugins [[Plugin Editions]]
 title: Railroad Plugin
 type: text/vnd.tiddlywiki
 
+!! Railroad Diagrams
+
+{{Railroad Diagrams}}
+
+!! Plugin
+
 {{$:/plugins/tiddlywiki/railroad/readme}}
 
-{{$:/plugins/tiddlywiki/railroad/syntax}}
+Learn more about the [[Railroad Plguin Syntax Description|$:/plugins/tiddlywiki/railroad/syntax]]

--- a/editions/tw5.com/tiddlers/plugins/Railroad Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Railroad Plugin.tid
@@ -1,6 +1,6 @@
 created: 20160107223348621
 list: 
-modified: 20240820214405820
+modified: 20170228102501706
 tags: OfficialPlugins [[Plugin Editions]]
 title: Railroad Plugin
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
- This PR should make the Railroad Plugin tiddler simpler. 
- It adds a link to the plugin syntax docs instead of transcluding it
- It adds a link to Filter Syntax to the Railroad Diagrams tiddler

@jermolene this PR is docs only 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>