### PR TITLE
Fix scaled plugin icon

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2662,7 +2662,7 @@ a.tc-tiddlylink.tc-plugin-info:hover > .tc-plugin-info-chunk .tc-plugin-info-sta
 
 .tc-plugin-info-chunk.tc-plugin-info-icon img, .tc-plugin-info-chunk.tc-plugin-info-icon svg {
 	width: 2em;
-	height: 2em;
+	height: auto;
 }
 
 .tc-plugin-info-dropdown {


### PR DESCRIPTION
The svg icons of some plugins are scaled to square which is unproper. The `height` attribute should be set to `auto`.

![图片](https://github.com/user-attachments/assets/050e484b-1f9c-4125-9312-9d4f290d50e7)
