### PR TITLE
Fix scaled language icon in dropdown

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -707,7 +707,7 @@ html body.tc-body .tc-btn-rounded:hover svg {
 }
 
 button svg.tc-image-button, button .tc-image-button img {
-	height: 1em;
+	height: auto;
 	width: 1em;
 }
 
@@ -2819,7 +2819,7 @@ a.tc-tiddlylink.tc-plugin-info:hover > .tc-plugin-info-chunk .tc-plugin-info-sta
 }
 
 .tc-language-chooser .tc-image-button img {
-	width: 2em;
+	width: auto;
 	vertical-align: -0.15em;
 }
 


### PR DESCRIPTION
Fix scaled language icon in dropdown and button. A further fix after #8540 .

![图片](https://github.com/user-attachments/assets/75889812-a9f8-40fb-bdba-97e193e907ab)

![图片](https://github.com/user-attachments/assets/5e1ce10b-75a5-48cc-a411-a06a4286f780)
