### PR TITLE
Fix invalid accept header in put saver

### DIFF
--- a/core/modules/savers/put.js
+++ b/core/modules/savers/put.js
@@ -20,7 +20,7 @@ Retrieve ETag if available
 */
 var retrieveETag = function(self) {
 	var headers = {
-		Accept: "*/*;charset=UTF-8"
+		Accept: "*/*"
 	};
 	$tw.utils.httpRequest({
 		url: self.uri(),


### PR DESCRIPTION
IIUC the charset doesn't belong in the Accept header. It does belong in a Content-Type header though, see [1] and [2].

FYI this header causes problems for Tiddlyhost which must work around the invalid mime type, see [3] for the nitty-gritty.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
[2] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
[3] https://github.com/simonbaird/tiddlyhost/commit/10cd3535529adf9ec1241ab8cd639ba1a2abb16f