### PR TITLE
Fix outline color not showing properly for dark palettes

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -75,8 +75,10 @@ input[type="search"] {
 	outline-offset: initial;
 }
 
-button, textarea, input, select {
-	outline-color: <<colour primary>>;
+button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible {
+	outline: 2px solid <<colour primary>>;
+	outline-offset: -2px;
+	border-radius: 0.25em;
 }
 
 :-moz-focusring {


### PR DESCRIPTION
Looks like using `outline-color` does not work for palettes with `color-scheme` set to `dark`, so I used `outline` instead.

A further fix after #7317.