### PR TITLE
Add empty message to tag picker, search dropdown and advanced search

### DIFF
--- a/core/language/en-GB/EditTemplate.multids
+++ b/core/language/en-GB/EditTemplate.multids
@@ -26,6 +26,7 @@ Tags/ClearInput/Caption: clear input
 Tags/ClearInput/Hint: Clear tag input
 Tags/Dropdown/Caption: tag list
 Tags/Dropdown/Hint: Show tag list
+Tags/EmptyMessage: (no search result)
 Title/BadCharacterWarning: Warning: avoid using any of the characters <<bad-chars>> in tiddler titles
 Title/Exists/Prompt: Target tiddler already exists
 Title/Relink/Prompt: Update ''<$text text=<<fromTitle>>/>'' to ''<$text text=<<toTitle>>/>'' in the //tags// and //list// fields of other tiddlers

--- a/core/language/en-GB/Search.multids
+++ b/core/language/en-GB/Search.multids
@@ -6,6 +6,8 @@ Filter/Hint: Search via a [[filter expression|https://tiddlywiki.com/static/Filt
 Filter/Matches: //<small><<resultCount>> matches</small>//
 Matches: //<small><<resultCount>> matches</small>//
 Matches/All: All matches:
+Matches/NoMatch: //No match//
+Matches/NoResult: No search result
 Matches/Title: Title matches:
 Search: Search
 Search/TooShort: Search text too short

--- a/core/language/en-GB/Search.multids
+++ b/core/language/en-GB/Search.multids
@@ -7,7 +7,7 @@ Filter/Matches: //<small><<resultCount>> matches</small>//
 Matches: //<small><<resultCount>> matches</small>//
 Matches/All: All matches:
 Matches/NoMatch: //No match//
-Matches/NoResult: No search result
+Matches/NoResult: //No search result//
 Matches/Title: Title matches:
 Search: Search
 Search/TooShort: Search text too short

--- a/core/ui/AdvancedSearch/Shadows.tid
+++ b/core/ui/AdvancedSearch/Shadows.tid
@@ -79,11 +79,15 @@ first-search-filter: [all[shadows]search<userInput>sort[title]limit[250]] -[[$:/
 
 <$list filter="[{$:/temp/advancedsearch}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="<div class='tc-search-results'>{{$:/language/Search/Search/TooShort}}</div>" variable="listItem">
 
-<$set name="resultCount" value="<$count filter='[all[shadows]search{$:/temp/advancedsearch}] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]]'/>">
+<$set name="resultCount" value={{{ [all[shadows]search{$:/temp/advancedsearch}] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]] +[count[]]}}}>
 
 <div class="tc-search-results">
 
-<<lingo Shadows/Matches>>
+<% if [<resultCount>match[0]] %>
+	{{$:/language/Search/Matches/NoMatch}}
+<% else %>
+	<<lingo Shadows/Matches>>
+<% endif %>
 
 <$list filter="[all[shadows]search{$:/temp/advancedsearch}sort[title]limit[250]] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]]">
 <span class={{{[<currentTiddler>addsuffix[-primaryList]] -[[$:/temp/advancedsearch/selected-item]get[text]] +[then[]else[tc-list-item-selected]] }}}>

--- a/core/ui/AdvancedSearch/System.tid
+++ b/core/ui/AdvancedSearch/System.tid
@@ -78,11 +78,15 @@ first-search-filter: [is[system]search<userInput>sort[title]limit[250]] -[[$:/te
 
 <$list filter="[{$:/temp/advancedsearch}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="<div class='tc-search-results'>{{$:/language/Search/Search/TooShort}}</div>" variable="listItem">
 
-<$set name="resultCount" value="<$count filter='[is[system]search{$:/temp/advancedsearch}] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]] -[[$:/temp/advancedsearch/selected-item]]'/>">
+<$set name="resultCount" value={{{ [is[system]search{$:/temp/advancedsearch}] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]] -[[$:/temp/advancedsearch/selected-item]] +[count[]] }}}>
 
 <div class="tc-search-results">
 
-<<lingo System/Matches>>
+<% if [<resultCount>match[0]] %>
+	{{$:/language/Search/Matches/NoMatch}}
+<% else %>
+	<<lingo System/Matches>>
+<% endif %>
 
 <$list filter="[is[system]search{$:/temp/advancedsearch}sort[title]limit[250]] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]] -[[$:/temp/advancedsearch/selected-item]]">
 <span class={{{[<currentTiddler>addsuffix[-primaryList]] -[[$:/temp/advancedsearch/selected-item]get[text]] +[then[]else[tc-list-item-selected]] }}}>

--- a/core/ui/DefaultSearchResultList.tid
+++ b/core/ui/DefaultSearchResultList.tid
@@ -9,7 +9,7 @@ second-search-filter: [!is[system]search<userInput>sort[title]limit[250]]
 //<small>{{$:/language/Search/Matches/Title}}</small>//
 
 <$list filter="[<userInput>minlength[1]]" variable="ignore">
-<$list filter={{{ [<configTiddler>get[first-search-filter]] }}}>
+<$list filter={{{ [<configTiddler>get[first-search-filter]] }}} emptyMessage={{$:/language/Search/Matches/NoResult}}>
 <span class={{{[<currentTiddler>addsuffix[-primaryList]] -[<searchListState>get[text]] +[then[]else[tc-list-item-selected]] }}}>
 <$transclude tiddler="$:/core/ui/ListItemTemplate"/>
 </span>
@@ -19,7 +19,7 @@ second-search-filter: [!is[system]search<userInput>sort[title]limit[250]]
 //<small>{{$:/language/Search/Matches/All}}</small>//
 
 <$list filter="[<userInput>minlength[1]]" variable="ignore">
-<$list filter={{{ [<configTiddler>get[second-search-filter]] }}}>
+<$list filter={{{ [<configTiddler>get[second-search-filter]] }}} emptyMessage={{$:/language/Search/Matches/NoResult}}>
 <span class={{{[<currentTiddler>addsuffix[-secondaryList]] -[<searchListState>get[text]] +[then[]else[tc-list-item-selected]] }}}>
 <$transclude tiddler="$:/core/ui/ListItemTemplate"/>
 </span>

--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -83,6 +83,9 @@ The second ESC tries to close the "draft tiddler"
 		emptyMessage="<div class='tc-search-results'>{{$:/language/Search/Search/TooShort}}</div>" variable="listItem"
 	>
 		<$list filter=<<filter>> variable="tag">
+			<$list-empty>
+				<span class="tc-small-gap-left">{{$:/language/EditTemplate/Tags/EmptyMessage}}</span>
+			</$list-empty>
 			<!-- The buttonClasses filter is used to define tc-tag-button-selected state -->
 			<!-- tf.get-tagpicker-focus-selector has to be resolved for $:/core/ui/TagPickerTagTemplate,
 				othwerwise qualify in tf.tagpicker-dropdown-id causes problems -->


### PR DESCRIPTION
Implement feature described in #8343 and closes #8343 .

The count widget in `$:/core/ui/AdvancedSearch/Shadows` and `$:/core/ui/AdvancedSearch/System` is replaced by the count filter operator to let the conditional shortcut work.

