### PR TITLE
tm-new-tiddler - Create empty tags field only if template or additionalFields contain a tags-field

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -184,7 +184,7 @@ NavigatorWidget.prototype.handleCloseOtherTiddlersEvent = function(event) {
 // Place a tiddler in edit mode
 NavigatorWidget.prototype.handleEditTiddlerEvent = function(event) {
 	var editTiddler = $tw.hooks.invokeHook("th-editing-tiddler",event),
-	    win = event.event && event.event.view ? event.event.view : window;
+		win = event.event && event.event.view ? event.event.view : window;
 	if(!editTiddler) {
 		return false;
 	}
@@ -306,7 +306,7 @@ NavigatorWidget.prototype.handleSaveTiddlerEvent = function(event) {
 	var title = event.param || event.tiddlerTitle,
 		tiddler = this.wiki.getTiddler(title),
 		storyList = this.getStoryList(),
-	    	win = event.event && event.event.view ? event.event.view : window;
+		win = event.event && event.event.view ? event.event.view : window;
 	// Replace the original tiddler with the draft
 	if(tiddler) {
 		var draftTitle = (tiddler.fields["draft.title"] || "").trim(),
@@ -412,7 +412,7 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 	event = $tw.hooks.invokeHook("th-new-tiddler", event);
 	// Get the story details
 	var storyList = this.getStoryList(),
-		templateTiddler, additionalFields, title, draftTitle, existingTiddler;
+		templateTiddler, additionalFields, title, draftTitle, existingTiddler, templateHasTags=false;
 	// Get the template tiddler (if any)
 	if(typeof event.param === "string") {
 		// Get the template tiddler
@@ -457,8 +457,10 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 		// Merge tags
 		mergedTags = $tw.utils.pushTop(mergedTags,$tw.utils.parseStringArray(additionalFields.tags));
 	}
+	var additionalFieldsHasTags = (additionalFields && (additionalFields.tags === "")) ? true : false;
 	if(templateTiddler && templateTiddler.fields.tags) {
 		// Merge tags
+		templateHasTags = true;
 		mergedTags = $tw.utils.pushTop(mergedTags,templateTiddler.fields.tags);
 	}
 	// Save the draft tiddler
@@ -474,7 +476,8 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 		{
 			title: draftTitle,
 			"draft.of": title,
-			tags: mergedTags
+			// If template or additionalFields have "tags" even if empty a tags field will be created.
+			tags: ((mergedTags.length>0) || templateHasTags || additionalFieldsHasTags) ? mergedTags : undefined
 		},this.wiki.getModificationFields());
 	this.wiki.addTiddler(draftTiddler);
 	// Update the story to insert the new draft at the top and remove any existing tiddler
@@ -526,7 +529,7 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	var systemMessage = $tw.language.getString("Import/Upgrader/Tiddler/Unselected");
 	$tw.utils.each(messages,function(message,title) {
 		newFields["message-" + title] = message;
-		if (message.indexOf(systemMessage) !== -1) {
+		if(message.indexOf(systemMessage) !== -1) {
 			newFields["selection-" + title] = "unchecked";
 		}
 	});

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -412,7 +412,8 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 	event = $tw.hooks.invokeHook("th-new-tiddler", event);
 	// Get the story details
 	var storyList = this.getStoryList(),
-		templateTiddler, additionalFields, title, draftTitle, existingTiddler, templateHasTags=false;
+		templateTiddler, additionalFields, title, draftTitle, existingTiddler,
+		templateHasTags = false;
 	// Get the template tiddler (if any)
 	if(typeof event.param === "string") {
 		// Get the template tiddler
@@ -457,7 +458,7 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 		// Merge tags
 		mergedTags = $tw.utils.pushTop(mergedTags,$tw.utils.parseStringArray(additionalFields.tags));
 	}
-	var additionalFieldsHasTags = (additionalFields && (additionalFields.tags === "")) ? true : false;
+	var additionalFieldsHasTags = !!(additionalFields && (additionalFields.tags === ""));
 	if(templateTiddler && templateTiddler.fields.tags) {
 		// Merge tags
 		templateHasTags = true;
@@ -477,7 +478,7 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 			title: draftTitle,
 			"draft.of": title,
 			// If template or additionalFields have "tags" even if empty a tags field will be created.
-			tags: ((mergedTags.length>0) || templateHasTags || additionalFieldsHasTags) ? mergedTags : undefined
+			tags: ((mergedTags.length > 0) || templateHasTags || additionalFieldsHasTags) ? mergedTags : undefined
 		},this.wiki.getModificationFields());
 	this.wiki.addTiddler(draftTiddler);
 	// Update the story to insert the new draft at the top and remove any existing tiddler

--- a/editions/test/tiddlers/tests/data/messages/tm-new-tiddler/create-a-new-tiddler-with-a-tag.tid
+++ b/editions/test/tiddlers/tests/data/messages/tm-new-tiddler/create-a-new-tiddler-with-a-tag.tid
@@ -1,0 +1,38 @@
+title: Message/tm-new-tiddler/create-a-new-tiddler-with-a-tag
+description: tm-new-tiddler message will create a new draft tiddler with a tag
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+<pre>{{Draft of 'New Tiddler'||output-template}}</pre>
++
+title: Actions
+
+<$navigator story="$:/StoryList">
+
+<$action-sendmessage $message="tm-new-tiddler"
+	text="some text"
+	z-field="a"
+	tags="test [[with spaces]]"
+/>
+
+</$navigator>
+
++
+title: output-template
+
+<!-- This template is used for saving tiddlers in TiddlyWeb *.tid format -->
+<$fields exclude='text bag created modified' template='$name$: $value$
+'></$fields>
+<$view field="text" format="text" />
++
+title: ExpectedResult
+
+<p><pre>draft.of: New Tiddler
+draft.title: New Tiddler
+tags: test [[with spaces]]
+title: Draft of 'New Tiddler'
+z-field: a
+
+some text</pre></p>

--- a/editions/test/tiddlers/tests/data/messages/tm-new-tiddler/default.tid
+++ b/editions/test/tiddlers/tests/data/messages/tm-new-tiddler/default.tid
@@ -1,0 +1,39 @@
+title: Message/tm-new-tiddler/default
+description: tm-new-tiddler message will create a new draft tiddler
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+<pre>{{Draft of 'New Tiddler'||output-template}}</pre>
++
+title: Actions
+
+<$navigator story="$:/StoryList">
+
+New in TW v5.3.6
+	Create a draft tiddler which should have __no__ tags field
+
+<$action-sendmessage $message="tm-new-tiddler"
+	text="some text"
+	z-field="a"
+/>
+
+</$navigator>
+
++
+title: output-template
+
+<!-- This template is used for saving tiddlers in TiddlyWeb *.tid format -->
+<$fields exclude='text bag created modified' template='$name$: $value$
+'></$fields>
+<$view field="text" format="text" />
++
+title: ExpectedResult
+
+<p><pre>draft.of: New Tiddler
+draft.title: New Tiddler
+title: Draft of 'New Tiddler'
+z-field: a
+
+some text</pre></p>

--- a/editions/test/tiddlers/tests/data/messages/tm-new-tiddler/new-from-template-with-tag.tid
+++ b/editions/test/tiddlers/tests/data/messages/tm-new-tiddler/new-from-template-with-tag.tid
@@ -1,0 +1,44 @@
+title: Message/tm-new-tiddler/new-from-template-with-tag
+description: tm-new-tiddler create a draft from a template. Template has an empty tags field
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+<pre>{{	Draft of 'new-tiddler-template 1'||output-template}}</pre>
++
+title: Actions
+
+<$navigator story="$:/StoryList">
+
+<$action-sendmessage $message="tm-new-tiddler"
+	$param="new-tiddler-template"
+	text="some text"
+	z-field="a"
+/>
+
+</$navigator>
+
++
+title: new-tiddler-template
+asdf: asdf
+tags:
+
++
+title: output-template
+
+<!-- This template is used for saving tiddlers in TiddlyWeb *.tid format -->
+<$fields exclude='text bag created modified' template='$name$: $value$
+'></$fields>
+<$view field="text" format="text" />
++
+title: ExpectedResult
+
+<p><pre>asdf: asdf
+draft.of: new-tiddler-template 1
+draft.title: new-tiddler-template 1
+tags: 
+title: Draft of 'new-tiddler-template 1'
+z-field: a
+
+some text</pre></p>

--- a/editions/test/tiddlers/tests/data/messages/tm-new-tiddler/new-from-template-without-tag.tid
+++ b/editions/test/tiddlers/tests/data/messages/tm-new-tiddler/new-from-template-without-tag.tid
@@ -1,0 +1,65 @@
+title: Message/tm-new-tiddler/new-from-template-without-tag
+description: tm-new-tiddler create 2 drafts from a template. Template has no tags field
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+<pre>{{	Draft of 'new-tiddler-template 1'||output-template}}</pre>
+<pre>{{	Draft of 'new-tiddler-template 2'||output-template}}</pre>
++
+title: Actions
+
+<$navigator story="$:/StoryList">
+
+New in TW v5.3.6
+	Create a new tiddler from a template, which has no tags field
+	So draft should also have __no__ tags field
+
+<$action-sendmessage $message="tm-new-tiddler"
+	$param="new-tiddler-template"
+	text="some text"
+	z-field="a"
+/>
+
+Create a new tiddler from a template, which has no tag field
+AND __add__ a tags field with the command below
+
+<$action-sendmessage $message="tm-new-tiddler"
+	$param="new-tiddler-template"
+	text="some text"
+	z-field="a"
+	tag=""
+/>
+
+</$navigator>
+
++
+title: new-tiddler-template
+asdf: asdf
+
++
+title: output-template
+
+<!-- This template is used for saving tiddlers in TiddlyWeb *.tid format -->
+<$fields exclude='text bag created modified' template='$name$: $value$
+'></$fields>
+<$view field="text" format="text" />
++
+title: ExpectedResult
+
+<p><pre>asdf: asdf
+draft.of: new-tiddler-template 1
+draft.title: new-tiddler-template 1
+title: Draft of 'new-tiddler-template 1'
+z-field: a
+
+some text</pre>
+<pre>asdf: asdf
+draft.of: new-tiddler-template 2
+draft.title: new-tiddler-template 2
+tag: 
+title: Draft of 'new-tiddler-template 2'
+z-field: a
+
+some text</pre></p>

--- a/editions/test/tiddlers/tests/data/messages/tm-new-tiddler/new-with-tag.tid
+++ b/editions/test/tiddlers/tests/data/messages/tm-new-tiddler/new-with-tag.tid
@@ -1,0 +1,40 @@
+title: Message/tm-new-tiddler/new-with-tag
+description: tm-new-tiddler message creates a draft tiddler with an empty tag field
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+<pre>{{Draft of 'New Tiddler'||output-template}}</pre>
++
+title: Actions
+
+<$navigator story="$:/StoryList">
+
+Create a draft tiddler which __should have a tags field__
+
+<$action-sendmessage $message="tm-new-tiddler"
+	text="some text"
+	z-field="a"
+	tag=""
+/>
+
+</$navigator>
+
++
+title: output-template
+
+<!-- This template is used for saving tiddlers in TiddlyWeb *.tid format -->
+<$fields exclude='text bag created modified' template='$name$: $value$
+'></$fields>
+<$view field="text" format="text" />
++
+title: ExpectedResult
+
+<p><pre>draft.of: New Tiddler
+draft.title: New Tiddler
+tag: 
+title: Draft of 'New Tiddler'
+z-field: a
+
+some text</pre></p>


### PR DESCRIPTION
This PR fixes #8553

With this PR the tm-new-tiddler message only creates an empty tags field if template tiddler or additionalFields already contain a tags-field

- This makes it possible to define if an empty tag field should be created or not. 
- Default is **no** tags field, if there is no parameter - (that's different to the current behaviour, that causes an issue see: #8553)
- If the `action-sendmessage` has a paramter `tags=""` it will be created in the new tiddler
- If the parameter `$params=template` is use and the template tiddler contains a tags-field -- It will be copied over, even if it is empty

Code to test: 

```
<$button>
<$action-sendmessage $message="tm-new-tiddler" title="template" text=<<now "Today is DDth, MMM YYYY">> hugo="" />
New Tiddler 
</$button>

<$button>
<$action-sendmessage $message="tm-new-tiddler" title="template-tags" text=<<now "Today is DDth, MMM YYYY">> tags="" />
New Tiddler with tags=""
</$button>


<$button>
<$action-sendmessage $message="tm-new-tiddler" $param=template title="This is newly created tiddler" text=<<now "Today is DDth, MMM YYYY">> />
New Tiddler from template
</$button>

<$button>
<$action-sendmessage $message="tm-new-tiddler" $param=template title="This is newly created tiddler" text=<<now "Today is DDth, MMM YYYY">> tags="" />
New Tiddler from template, param tags=""
</$button>


<$button>
<$action-sendmessage $message="tm-new-tiddler" $param=template-tags title="This is newly created tiddler" text=<<now "Today is DDth, MMM YYYY">> />
New Tiddler from template-tags
</$button>
```

