### PR TITLE
Fix suffix does not work for base64 operators

### DIFF
--- a/core/modules/filters/encodings.js
+++ b/core/modules/filters/encodings.js
@@ -18,8 +18,8 @@ Export our filter functions
 
 exports.decodebase64 = function(source,operator,options) {
 	var results = [];
-	var binary = operator.suffixes && operator.suffixes.indexOf("binary") !== -1;
-	var urlsafe = operator.suffixes && operator.suffixes.indexOf("urlsafe") !== -1;
+	var binary = operator.suffixes && operator.suffixes[0].indexOf("binary") !== -1;
+	var urlsafe = operator.suffixes && operator.suffixes[0].indexOf("urlsafe") !== -1;
 	source(function(tiddler,title) {
 		results.push($tw.utils.base64Decode(title,binary,urlsafe));
 	});
@@ -28,8 +28,9 @@ exports.decodebase64 = function(source,operator,options) {
 
 exports.encodebase64 = function(source,operator,options) {
 	var results = [];
-	var binary = operator.suffixes && operator.suffixes.indexOf("binary") !== -1;
-	var urlsafe = operator.suffixes && operator.suffixes.indexOf("urlsafe") !== -1;
+	console.log(operator.suffixes);
+	var binary = operator.suffixes && operator.suffixes[0].indexOf("binary") !== -1;
+	var urlsafe = operator.suffixes && operator.suffixes[0].indexOf("urlsafe") !== -1;
 	source(function(tiddler,title) {
 		results.push($tw.utils.base64Encode(title,binary,urlsafe));
 	});

--- a/core/modules/filters/encodings.js
+++ b/core/modules/filters/encodings.js
@@ -28,7 +28,6 @@ exports.decodebase64 = function(source,operator,options) {
 
 exports.encodebase64 = function(source,operator,options) {
 	var results = [];
-	console.log(operator.suffixes);
 	var binary = operator.suffixes && operator.suffixes[0].indexOf("binary") !== -1;
 	var urlsafe = operator.suffixes && operator.suffixes[0].indexOf("urlsafe") !== -1;
 	source(function(tiddler,title) {


### PR DESCRIPTION
When updating docs for base64 operators, I found that the `urlsafe` suffix is not working as described in tiddlywiki.com (the second one should be `8J-Yjg==`). 

![图片](https://github.com/user-attachments/assets/874bea7c-ba5c-4ad1-977e-b62f08ad6063)

There should be `[0]` after `operator.suffixes`, since `operator.suffixes` is a two-dimensional array.