### PR TITLE
Update docs for base64 operators

### DIFF
--- a/editions/tw5.com/tiddlers/filters/decodebase64 Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/decodebase64 Operator (Examples).tid
@@ -1,0 +1,10 @@
+created: 20240831025944330
+modified: 20240831041423075
+tags: [[decodebase64 Operator]] [[Operator Examples]]
+title: decodebase64 Operator (Examples)
+
+<<.operator-example 1 "[[dGVzdA==]decodebase64[]]">>
+
+<<.operator-example 2 "[[8J+Yjg==]decodebase64[]]">>
+
+<<.operator-example 3 "[[8J-Yjg==]decodebase64:urlsafe[]]">>

--- a/editions/tw5.com/tiddlers/filters/decodebase64 Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/decodebase64 Operator.tid
@@ -1,14 +1,16 @@
 caption: decodebase64
+created: 20240831034919913
+from-version: 5.2.6
+modified: 20240831034931703
 op-input: a [[selection of titles|Title Selection]]
 op-output: the input with base 64 decoding applied
-op-suffix: optional: `binary` to produce binary output, `urlsafe` for URL-safe input
 op-parameter: 
 op-parameter-name: 
-op-purpose: apply base 64 decoding to a string
+op-purpose: apply [[base 64|Base64]] decoding to a string
+op-suffix: optional: `binary` to produce binary output, `urlsafe` for URL-safe input
 tags: [[Filter Operators]] [[String Operators]]
 title: decodebase64 Operator
 type: text/vnd.tiddlywiki
-from-version: 5.2.6
 
 See Mozilla Developer Network for details of [[base 64 encoding|https://developer.mozilla.org/en-US/docs/Glossary/Base64]]. TiddlyWiki uses [[library code from @nijikokun|https://gist.github.com/Nijikokun/5192472]] to handle the conversion.
 

--- a/editions/tw5.com/tiddlers/filters/encodebase64 Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/encodebase64 Operator (Examples).tid
@@ -1,0 +1,10 @@
+created: 20240831025156306
+modified: 20240831041537886
+tags: [[encodebase64 Operator]] [[Operator Examples]]
+title: encodebase64 Operator (Examples)
+
+<<.operator-example 1 "[[test]encodebase64[]]">>
+
+<<.operator-example 2 "[[😎]encodebase64[]]">>
+
+<<.operator-example 3 "[[😎]encodebase64:urlsafe[]]">>

--- a/editions/tw5.com/tiddlers/filters/encodebase64 Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/encodebase64 Operator.tid
@@ -1,14 +1,16 @@
 caption: encodebase64
+created: 20240831034955575
+from-version: 5.2.6
+modified: 20240831035003716
 op-input: a [[selection of titles|Title Selection]]
 op-output: the input with base 64 encoding applied
-op-suffix: optional: `binary` to treat input as binary data, `urlsafe` for URL-safe output
 op-parameter: 
 op-parameter-name: 
-op-purpose: apply base 64 encoding to a string
+op-purpose: apply [[base 64|Base64]] encoding to a string
+op-suffix: optional: `binary` to treat input as binary data, `urlsafe` for URL-safe output
 tags: [[Filter Operators]] [[String Operators]]
 title: encodebase64 Operator
 type: text/vnd.tiddlywiki
-from-version: 5.2.6
 
 See Mozilla Developer Network for details of [[base 64 encoding|https://developer.mozilla.org/en-US/docs/Glossary/Base64]]. TiddlyWiki uses [[library code from @nijikokun|https://gist.github.com/Nijikokun/5192472]] to handle the conversion.
 


### PR DESCRIPTION
Update docs for decodebase64 and encodebase64 operator. Added exmaples for them.

Since it requires #8574 to work, this PR points to the master branch.