### PR TITLE
fix typing problem in advanced search filter tab

### DIFF
--- a/core/ui/AdvancedSearch/Filter.tid
+++ b/core/ui/AdvancedSearch/Filter.tid
@@ -63,15 +63,13 @@ caption: {{$:/language/Search/Filter/Caption}}
 &#32;
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/AdvancedSearch/FilterButton]!has[draft.of]]"><$transclude/></$list>
 </div>
-<$reveal state="$:/temp/advancedsearch" type="nomatch" text="">
+<$reveal state="$:/temp/advancedsearch" type="nomatch" text="" tag="div" class="tc-search-results">
 <$set name="resultCount" value="<$count filter={{$:/temp/advancedsearch}}/>">
-<div class="tc-search-results">
 <p><<lingo Filter/Matches>></p>
 <$list filter={{$:/temp/advancedsearch}}>
 <span class={{{[<currentTiddler>addsuffix[-primaryList]] -[[$:/temp/advancedsearch/selected-item]get[text]] +[then[]else[tc-list-item-selected]] }}}>
 <$transclude tiddler="$:/core/ui/ListItemTemplate"/>
 </span>
 </$list>
-</div>
 </$set>
 </$reveal>


### PR DESCRIPTION
This PR is related to: **[BUG] Search input in "Filter" tab in advanced search drops key presses as of 5.3.5 on Firefox** #8551

**The text input will register fast typing again.** No matter how many results are shown. So `[all[]]` does not cause any problems with typing anymore.

But it does not explain why there was a problem in the first place. 

@hoelzro Can you check? -- As I wrote it does not explain why deleting a blank line caused the problem. 