### PR TITLE
Update PageControls buttons to use v5.3.2 syntax

### DIFF
--- a/core/ui/Actions/new-journal.tid
+++ b/core/ui/Actions/new-journal.tid
@@ -3,14 +3,14 @@ tags: $:/tags/Actions
 description: create a new journal tiddler
 
 \whitespace trim
-\function tf.get-tags() [<textFieldTags>] [<tagsFieldTags>] +[join[ ]]
+\function get-tags() [<textFieldTags>] [<tagsFieldTags>] +[join[ ]]
 <$let journalTitleTemplate={{$:/config/NewJournal/Title}} textFieldTags={{$:/config/NewJournal/Tags}} tagsFieldTags={{$:/config/NewJournal/Tags!!tags}} journalText={{$:/config/NewJournal/Text}}>
 <$wikify name="journalTitle" text="<$transclude $variable='now' format=<<journalTitleTemplate>>/>">
 <$reveal type="nomatch" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<tf.get-tags>> text={{{ [<journalTitle>get[]] }}}/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<get-tags>> text={{{ [<journalTitle>get[]] }}}/>
 </$reveal>
 <$reveal type="match" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<tf.get-tags>> text=<<journalText>>/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<get-tags>> text=<<journalText>>/>
 </$reveal>
 </$wikify>
 </$let>

--- a/core/ui/Actions/new-journal.tid
+++ b/core/ui/Actions/new-journal.tid
@@ -3,13 +3,14 @@ tags: $:/tags/Actions
 description: create a new journal tiddler
 
 \whitespace trim
+\function tf.get-tags() [<textFieldTags>] [<tagsFieldTags>] +[join[]]
 <$let journalTitleTemplate={{$:/config/NewJournal/Title}} textFieldTags={{$:/config/NewJournal/Tags}} tagsFieldTags={{$:/config/NewJournal/Tags!!tags}} journalText={{$:/config/NewJournal/Text}}>
 <$wikify name="journalTitle" text="<$transclude $variable='now' format=<<journalTitleTemplate>>/>">
 <$reveal type="nomatch" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=`$(textFieldTags)$ $(tagsFieldTags)$` text={{{ [<journalTitle>get[]] }}}/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<tf.get-tags>> text={{{ [<journalTitle>get[]] }}}/>
 </$reveal>
 <$reveal type="match" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=`$(textFieldTags)$ $(tagsFieldTags)$` text=<<journalText>>/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<tf.get-tags>> text=<<journalText>>/>
 </$reveal>
 </$wikify>
 </$let>

--- a/core/ui/Actions/new-journal.tid
+++ b/core/ui/Actions/new-journal.tid
@@ -3,7 +3,7 @@ tags: $:/tags/Actions
 description: create a new journal tiddler
 
 \whitespace trim
-\function tf.get-tags() [<textFieldTags>] [<tagsFieldTags>] +[join[]]
+\function tf.get-tags() [<textFieldTags>] [<tagsFieldTags>] +[join[ ]]
 <$let journalTitleTemplate={{$:/config/NewJournal/Title}} textFieldTags={{$:/config/NewJournal/Tags}} tagsFieldTags={{$:/config/NewJournal/Tags!!tags}} journalText={{$:/config/NewJournal/Text}}>
 <$wikify name="journalTitle" text="<$transclude $variable='now' format=<<journalTitleTemplate>>/>">
 <$reveal type="nomatch" state=<<journalTitle>> text="">

--- a/core/ui/Actions/new-journal.tid
+++ b/core/ui/Actions/new-journal.tid
@@ -2,15 +2,14 @@ title: $:/core/ui/Actions/new-journal
 tags: $:/tags/Actions
 description: create a new journal tiddler
 
-\define get-tags() $(textFieldTags)$ $(tagsFieldTags)$
 \whitespace trim
-<$vars journalTitleTemplate={{$:/config/NewJournal/Title}} textFieldTags={{$:/config/NewJournal/Tags}} tagsFieldTags={{$:/config/NewJournal/Tags!!tags}} journalText={{$:/config/NewJournal/Text}}>
-<$wikify name="journalTitle" text="<$macrocall $name='now' format=<<journalTitleTemplate>>/>">
+<$let journalTitleTemplate={{$:/config/NewJournal/Title}} textFieldTags={{$:/config/NewJournal/Tags}} tagsFieldTags={{$:/config/NewJournal/Tags!!tags}} journalText={{$:/config/NewJournal/Text}}>
+<$wikify name="journalTitle" text="<$transclude $variable='now' format=<<journalTitleTemplate>>/>">
 <$reveal type="nomatch" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<get-tags>> text={{{ [<journalTitle>get[]] }}}/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=`$(textFieldTags)$ $(tagsFieldTags)$` text={{{ [<journalTitle>get[]] }}}/>
 </$reveal>
 <$reveal type="match" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<get-tags>> text=<<journalText>>/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=`$(textFieldTags)$ $(tagsFieldTags)$` text=<<journalText>>/>
 </$reveal>
 </$wikify>
-</$vars>
+</$let>

--- a/core/ui/Actions/new-tiddler.tid
+++ b/core/ui/Actions/new-tiddler.tid
@@ -3,7 +3,7 @@ tags: $:/tags/Actions
 description: create a new empty tiddler
 
 \whitespace trim
-\function tf.get-tags() [<textFieldTags>] [<tagsFieldTags>] +[join[]]
+\function tf.get-tags() [<textFieldTags>] [<tagsFieldTags>] +[join[ ]]
 <$let textFieldTags={{$:/config/NewTiddler/Tags}} tagsFieldTags={{$:/config/NewTiddler/Tags!!tags}}>
 <$action-sendmessage $message="tm-new-tiddler" tags=<<tf.get-tags>>/>
 </$let>

--- a/core/ui/Actions/new-tiddler.tid
+++ b/core/ui/Actions/new-tiddler.tid
@@ -3,6 +3,7 @@ tags: $:/tags/Actions
 description: create a new empty tiddler
 
 \whitespace trim
+\function tf.get-tags() [<textFieldTags>] [<tagsFieldTags>] +[join[]]
 <$let textFieldTags={{$:/config/NewTiddler/Tags}} tagsFieldTags={{$:/config/NewTiddler/Tags!!tags}}>
-<$action-sendmessage $message="tm-new-tiddler" tags=`$(textFieldTags)$ $(tagsFieldTags)$`/>
+<$action-sendmessage $message="tm-new-tiddler" tags=<<tf.get-tags>>/>
 </$let>

--- a/core/ui/Actions/new-tiddler.tid
+++ b/core/ui/Actions/new-tiddler.tid
@@ -3,7 +3,7 @@ tags: $:/tags/Actions
 description: create a new empty tiddler
 
 \whitespace trim
-\function tf.get-tags() [<textFieldTags>] [<tagsFieldTags>] +[join[ ]]
+\function get-tags() [<textFieldTags>] [<tagsFieldTags>] +[join[ ]]
 <$let textFieldTags={{$:/config/NewTiddler/Tags}} tagsFieldTags={{$:/config/NewTiddler/Tags!!tags}}>
-<$action-sendmessage $message="tm-new-tiddler" tags=<<tf.get-tags>>/>
+<$action-sendmessage $message="tm-new-tiddler" tags=<<get-tags>>/>
 </$let>

--- a/core/ui/Actions/new-tiddler.tid
+++ b/core/ui/Actions/new-tiddler.tid
@@ -2,8 +2,7 @@ title: $:/core/ui/Actions/new-tiddler
 tags: $:/tags/Actions
 description: create a new empty tiddler
 
-\define get-tags() $(textFieldTags)$ $(tagsFieldTags)$
 \whitespace trim
-<$vars textFieldTags={{$:/config/NewTiddler/Tags}} tagsFieldTags={{$:/config/NewTiddler/Tags!!tags}}>
-<$action-sendmessage $message="tm-new-tiddler" tags=<<get-tags>>/>
-</$vars>
+<$let textFieldTags={{$:/config/NewTiddler/Tags}} tagsFieldTags={{$:/config/NewTiddler/Tags!!tags}}>
+<$action-sendmessage $message="tm-new-tiddler" tags=`$(textFieldTags)$ $(tagsFieldTags)$`/>
+</$let>

--- a/core/ui/PageControls/advanced-search.tid
+++ b/core/ui/PageControls/advanced-search.tid
@@ -4,15 +4,14 @@ caption: {{$:/core/images/advanced-search-button}} {{$:/language/Buttons/Advance
 description: {{$:/language/Buttons/AdvancedSearch/Hint}}
 
 \whitespace trim
-\define advanced-search-button(class)
-\whitespace trim
-<$button to="$:/AdvancedSearch" tooltip={{$:/language/Buttons/AdvancedSearch/Hint}} aria-label={{$:/language/Buttons/AdvancedSearch/Caption}} class="""$(tv-config-toolbar-class)$ $class$""">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+\procedure advanced-search-button(class)
+<$button to="$:/AdvancedSearch" tooltip={{$:/language/Buttons/AdvancedSearch/Hint}} aria-label={{$:/language/Buttons/AdvancedSearch/Caption}} class=`$(tv-config-toolbar-class)$ $(class)$`>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/advanced-search-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/AdvancedSearch/Caption}}/></span>
-</$list>
+<%endif%>
 </$button>
 \end
 

--- a/core/ui/PageControls/closeall.tid
+++ b/core/ui/PageControls/closeall.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/CloseAll/Hint}}
 
 \whitespace trim
 <$button message="tm-close-all-tiddlers" tooltip={{$:/language/Buttons/CloseAll/Hint}} aria-label={{$:/language/Buttons/CloseAll/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/close-all-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/CloseAll/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>

--- a/core/ui/PageControls/closeall.tid
+++ b/core/ui/PageControls/closeall.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/CloseAll/Hint}}
 
 \whitespace trim
 <$button message="tm-close-all-tiddlers" tooltip={{$:/language/Buttons/CloseAll/Hint}} aria-label={{$:/language/Buttons/CloseAll/Caption}} class=<<tv-config-toolbar-class>>>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/close-all-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/CloseAll/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>

--- a/core/ui/PageControls/controlpanel.tid
+++ b/core/ui/PageControls/controlpanel.tid
@@ -4,15 +4,14 @@ caption: {{$:/core/images/options-button}} {{$:/language/Buttons/ControlPanel/Ca
 description: {{$:/language/Buttons/ControlPanel/Hint}}
 
 \whitespace trim
-\define control-panel-button(class)
-\whitespace trim
-<$button to="$:/ControlPanel" tooltip={{$:/language/Buttons/ControlPanel/Hint}} aria-label={{$:/language/Buttons/ControlPanel/Caption}} class="""$(tv-config-toolbar-class)$ $class$""">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+\procedure control-panel-button(class)
+<$button to="$:/ControlPanel" tooltip={{$:/language/Buttons/ControlPanel/Hint}} aria-label={{$:/language/Buttons/ControlPanel/Caption}} class=`$(tv-config-toolbar-class)$ $(class)$`>
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/options-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/ControlPanel/Caption}}/></span>
-</$list>
+<% endif %>
 </$button>
 \end
 

--- a/core/ui/PageControls/controlpanel.tid
+++ b/core/ui/PageControls/controlpanel.tid
@@ -6,12 +6,12 @@ description: {{$:/language/Buttons/ControlPanel/Hint}}
 \whitespace trim
 \procedure control-panel-button(class)
 <$button to="$:/ControlPanel" tooltip={{$:/language/Buttons/ControlPanel/Hint}} aria-label={{$:/language/Buttons/ControlPanel/Caption}} class=`$(tv-config-toolbar-class)$ $(class)$`>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/options-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/ControlPanel/Caption}}/></span>
-<% endif %>
+<%endif%>
 </$button>
 \end
 

--- a/core/ui/PageControls/encryption.tid
+++ b/core/ui/PageControls/encryption.tid
@@ -6,25 +6,25 @@ description: {{$:/language/Buttons/Encryption/Hint}}
 \whitespace trim
 <$reveal type="match" state="$:/isEncrypted" text="yes">
 <$button message="tm-clear-password" tooltip={{$:/language/Buttons/Encryption/ClearPassword/Hint}} aria-label={{$:/language/Buttons/Encryption/ClearPassword/Caption}} class=<<tv-config-toolbar-class>>>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/locked-padlock}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Encryption/ClearPassword/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>
 </$reveal>
 <$reveal type="nomatch" state="$:/isEncrypted" text="yes">
 <$button message="tm-set-password" tooltip={{$:/language/Buttons/Encryption/SetPassword/Hint}} aria-label={{$:/language/Buttons/Encryption/SetPassword/Caption}} class=<<tv-config-toolbar-class>>>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/unlocked-padlock}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Encryption/SetPassword/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>
 </$reveal>

--- a/core/ui/PageControls/encryption.tid
+++ b/core/ui/PageControls/encryption.tid
@@ -6,25 +6,25 @@ description: {{$:/language/Buttons/Encryption/Hint}}
 \whitespace trim
 <$reveal type="match" state="$:/isEncrypted" text="yes">
 <$button message="tm-clear-password" tooltip={{$:/language/Buttons/Encryption/ClearPassword/Hint}} aria-label={{$:/language/Buttons/Encryption/ClearPassword/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/locked-padlock}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Encryption/ClearPassword/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>
 </$reveal>
 <$reveal type="nomatch" state="$:/isEncrypted" text="yes">
 <$button message="tm-set-password" tooltip={{$:/language/Buttons/Encryption/SetPassword/Hint}} aria-label={{$:/language/Buttons/Encryption/SetPassword/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/unlocked-padlock}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Encryption/SetPassword/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>
 </$reveal>

--- a/core/ui/PageControls/export-page.tid
+++ b/core/ui/PageControls/export-page.tid
@@ -3,4 +3,4 @@ tags: $:/tags/PageControls
 caption: {{$:/core/images/export-button}} {{$:/language/Buttons/ExportPage/Caption}}
 description: {{$:/language/Buttons/ExportPage/Hint}}
 
-<$macrocall $name="exportButton" exportFilter="[!is[system]sort[title]]" lingoBase="$:/language/Buttons/ExportPage/"/>
+<$transclude $variable="exportButton" exportFilter="[!is[system]sort[title]]" lingoBase="$:/language/Buttons/ExportPage/"/>

--- a/core/ui/PageControls/fold-all.tid
+++ b/core/ui/PageControls/fold-all.tid
@@ -6,12 +6,12 @@ description: {{$:/language/Buttons/FoldAll/Hint}}
 \whitespace trim
 <$button tooltip={{$:/language/Buttons/FoldAll/Hint}} aria-label={{$:/language/Buttons/FoldAll/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-fold-all-tiddlers" $param=<<currentTiddler>> foldedStatePrefix="$:/state/folded/"/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]" variable="listItem">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/fold-all-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/FoldAll/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>

--- a/core/ui/PageControls/fold-all.tid
+++ b/core/ui/PageControls/fold-all.tid
@@ -6,12 +6,12 @@ description: {{$:/language/Buttons/FoldAll/Hint}}
 \whitespace trim
 <$button tooltip={{$:/language/Buttons/FoldAll/Hint}} aria-label={{$:/language/Buttons/FoldAll/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-fold-all-tiddlers" $param=<<currentTiddler>> foldedStatePrefix="$:/state/folded/"/>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/fold-all-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/FoldAll/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>

--- a/core/ui/PageControls/full-screen.tid
+++ b/core/ui/PageControls/full-screen.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/FullScreen/Hint}}
 
 \whitespace trim
 <$button message="tm-full-screen" tooltip={{$:/language/Buttons/FullScreen/Hint}} aria-label={{$:/language/Buttons/FullScreen/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/full-screen-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/FullScreen/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>

--- a/core/ui/PageControls/full-screen.tid
+++ b/core/ui/PageControls/full-screen.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/FullScreen/Hint}}
 
 \whitespace trim
 <$button message="tm-full-screen" tooltip={{$:/language/Buttons/FullScreen/Hint}} aria-label={{$:/language/Buttons/FullScreen/Caption}} class=<<tv-config-toolbar-class>>>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/full-screen-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/FullScreen/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>

--- a/core/ui/PageControls/home.tid
+++ b/core/ui/PageControls/home.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/Home/Hint}}
 
 \whitespace trim
 <$button message="tm-home" tooltip={{$:/language/Buttons/Home/Hint}} aria-label={{$:/language/Buttons/Home/Caption}} class=<<tv-config-toolbar-class>>>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/home-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Home/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>

--- a/core/ui/PageControls/home.tid
+++ b/core/ui/PageControls/home.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/Home/Hint}}
 
 \whitespace trim
 <$button message="tm-home" tooltip={{$:/language/Buttons/Home/Hint}} aria-label={{$:/language/Buttons/Home/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/home-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Home/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>

--- a/core/ui/PageControls/import.tid
+++ b/core/ui/PageControls/import.tid
@@ -6,14 +6,14 @@ description: {{$:/language/Buttons/Import/Hint}}
 \whitespace trim
 <div class="tc-file-input-wrapper">
 <$button tooltip={{$:/language/Buttons/Import/Hint}} aria-label={{$:/language/Buttons/Import/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/import-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Import/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>
 <$browse tooltip={{$:/language/Buttons/Import/Hint}}/>
 </div>

--- a/core/ui/PageControls/import.tid
+++ b/core/ui/PageControls/import.tid
@@ -6,14 +6,14 @@ description: {{$:/language/Buttons/Import/Hint}}
 \whitespace trim
 <div class="tc-file-input-wrapper">
 <$button tooltip={{$:/language/Buttons/Import/Hint}} aria-label={{$:/language/Buttons/Import/Caption}} class=<<tv-config-toolbar-class>>>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/import-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Import/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>
 <$browse tooltip={{$:/language/Buttons/Import/Hint}}/>
 </div>

--- a/core/ui/PageControls/language.tid
+++ b/core/ui/PageControls/language.tid
@@ -6,16 +6,16 @@ description: {{$:/language/Buttons/Language/Hint}}
 \whitespace trim
 <span class="tc-popup-keep">
 <$button popup=<<qualify "$:/state/popup/language">> tooltip={{$:/language/Buttons/Language/Hint}} aria-label={{$:/language/Buttons/Language/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
     <span class="tc-image-button">
         <$set name="languagePluginTitle" value={{$:/language}}>
             <$image source=`$(languagePluginTitle)$/icon`/>
         </$set>
     </span>
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Language/Caption}}/></span>
-<% endif %>
+<%endif%>
 </$button>
 </span>
 <$reveal state=<<qualify "$:/state/popup/language">> type="popup" position="below" animate="yes">

--- a/core/ui/PageControls/language.tid
+++ b/core/ui/PageControls/language.tid
@@ -4,21 +4,18 @@ caption: {{$:/core/images/globe}} {{$:/language/Buttons/Language/Caption}}
 description: {{$:/language/Buttons/Language/Hint}}
 
 \whitespace trim
-\define flag-title()
-$(languagePluginTitle)$/icon
-\end
 <span class="tc-popup-keep">
 <$button popup=<<qualify "$:/state/popup/language">> tooltip={{$:/language/Buttons/Language/Hint}} aria-label={{$:/language/Buttons/Language/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
-<span class="tc-image-button">
-<$set name="languagePluginTitle" value={{$:/language}}>
-<$image source=<<flag-title>>/>
-</$set>
-</span>
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
+    <span class="tc-image-button">
+        <$set name="languagePluginTitle" value={{$:/language}}>
+            <$image source=`$(languagePluginTitle)$/icon`/>
+        </$set>
+    </span>
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Language/Caption}}/></span>
-</$list>
+<% endif %>
 </$button>
 </span>
 <$reveal state=<<qualify "$:/state/popup/language">> type="popup" position="below" animate="yes">

--- a/core/ui/PageControls/layout.tid
+++ b/core/ui/PageControls/layout.tid
@@ -6,10 +6,10 @@ description: {{$:/language/LayoutSwitcher/Description}}
 \whitespace trim
 <$button tooltip={{$:/language/Buttons/LayoutSwitcher/Hint}} aria-label={{$:/language/Buttons/LayoutSwitcher/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-show-switcher" switch="layout"/>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/layout-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/LayoutSwitcher/Caption}}/></span>
-<% endif %>
+<%endif%>
 </$button>

--- a/core/ui/PageControls/layout.tid
+++ b/core/ui/PageControls/layout.tid
@@ -6,10 +6,10 @@ description: {{$:/language/LayoutSwitcher/Description}}
 \whitespace trim
 <$button tooltip={{$:/language/Buttons/LayoutSwitcher/Hint}} aria-label={{$:/language/Buttons/LayoutSwitcher/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-show-switcher" switch="layout"/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/layout-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/LayoutSwitcher/Caption}}/></span>
-</$list>
+<% endif %>
 </$button>

--- a/core/ui/PageControls/manager.tid
+++ b/core/ui/PageControls/manager.tid
@@ -4,17 +4,16 @@ caption: {{$:/core/images/list}} {{$:/language/Buttons/Manager/Caption}}
 description: {{$:/language/Buttons/Manager/Hint}}
 
 \whitespace trim
-\define manager-button(class)
-\whitespace trim
-<$button to="$:/Manager" tooltip={{$:/language/Buttons/Manager/Hint}} aria-label={{$:/language/Buttons/Manager/Caption}} class="""$(tv-config-toolbar-class)$ $class$""">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+\procedure manager-button(class)
+<$button to="$:/Manager" tooltip={{$:/language/Buttons/Manager/Hint}} aria-label={{$:/language/Buttons/Manager/Caption}} class=`$(tv-config-toolbar-class)$ $(class)$`>
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/list}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Manager/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>
 \end
 

--- a/core/ui/PageControls/manager.tid
+++ b/core/ui/PageControls/manager.tid
@@ -6,14 +6,14 @@ description: {{$:/language/Buttons/Manager/Hint}}
 \whitespace trim
 \procedure manager-button(class)
 <$button to="$:/Manager" tooltip={{$:/language/Buttons/Manager/Hint}} aria-label={{$:/language/Buttons/Manager/Caption}} class=`$(tv-config-toolbar-class)$ $(class)$`>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/list}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Manager/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>
 \end
 

--- a/core/ui/PageControls/more-page-actions.tid
+++ b/core/ui/PageControls/more-page-actions.tid
@@ -12,14 +12,14 @@ description: {{$:/language/Buttons/More/Hint}}
 	class=<<tv-config-toolbar-class>>
 	selectedClass="tc-selected"
 >
-	<% if [<tv-config-toolbar-icons>match[yes]] %>
+	<%if [<tv-config-toolbar-icons>match[yes]] %>
 		{{$:/core/images/down-arrow}}
-	<% endif %>
-	<% if [<tv-config-toolbar-text>match[yes]] %>
+	<%endif%>
+	<%if [<tv-config-toolbar-text>match[yes]] %>
 		<span class="tc-btn-text">
 			<$text text={{$:/language/Buttons/More/Caption}}/>
 		</span>
-	<% endif %>
+	<%endif%>
 </$button>
 <$reveal state=<<qualify "$:/state/popup/more">> type="popup" position="below" animate="yes">
 	<div class="tc-drop-down">

--- a/core/ui/PageControls/more-page-actions.tid
+++ b/core/ui/PageControls/more-page-actions.tid
@@ -12,33 +12,29 @@ description: {{$:/language/Buttons/More/Hint}}
 	class=<<tv-config-toolbar-class>>
 	selectedClass="tc-selected"
 >
-	<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+	<% if [<tv-config-toolbar-icons>match[yes]] %>
 		{{$:/core/images/down-arrow}}
-	</$list>
-	<$list filter="[<tv-config-toolbar-text>match[yes]]">
+	<% endif %>
+	<% if [<tv-config-toolbar-text>match[yes]] %>
 		<span class="tc-btn-text">
 			<$text text={{$:/language/Buttons/More/Caption}}/>
 		</span>
-	</$list>
+	<% endif %>
 </$button>
 <$reveal state=<<qualify "$:/state/popup/more">> type="popup" position="below" animate="yes">
 	<div class="tc-drop-down">
-		<$set name="tv-config-toolbar-icons" value="yes">
-			<$set name="tv-config-toolbar-text" value="yes">
-				<$set name="tv-config-toolbar-class" value="tc-btn-invisible">
-					<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]] -[[$:/core/ui/Buttons/more-page-actions]]"
-						variable="listItem"
+		<$let tv-config-toolbar-icons="yes" tv-config-toolbar-text="yes" tv-config-toolbar-class="tc-btn-invisible">
+			<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]] -[[$:/core/ui/Buttons/more-page-actions]]"
+				variable="listItem"
+			>
+				<$reveal type="match" state=<<config-title>> text="hide">
+					<$set name="tv-config-toolbar-class"
+						filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]"
 					>
-						<$reveal type="match" state=<<config-title>> text="hide">
-							<$set name="tv-config-toolbar-class"
-								filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]"
-							>
-								<$transclude tiddler=<<listItem>> mode="inline"/>
-							</$set>
-						</$reveal>
-					</$list>
-				</$set>
-			</$set>
-		</$set>
+						<$transclude tiddler=<<listItem>> mode="inline"/>
+					</$set>
+				</$reveal>
+			</$list>
+		</$let>
 	</div>
 </$reveal>

--- a/core/ui/PageControls/network-activity.tid
+++ b/core/ui/PageControls/network-activity.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/NetworkActivity/Hint}}
 
 \whitespace trim
 <$button message="tm-http-cancel-all-requests" tooltip={{$:/language/Buttons/NetworkActivity/Hint}} aria-label={{$:/language/Buttons/NetworkActivity/Caption}} class=<<tv-config-toolbar-class>>>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/network-activity}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/NetworkActivity/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>

--- a/core/ui/PageControls/network-activity.tid
+++ b/core/ui/PageControls/network-activity.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/NetworkActivity/Hint}}
 
 \whitespace trim
 <$button message="tm-http-cancel-all-requests" tooltip={{$:/language/Buttons/NetworkActivity/Hint}} aria-label={{$:/language/Buttons/NetworkActivity/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/network-activity}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/NetworkActivity/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>

--- a/core/ui/PageControls/new-image.tid
+++ b/core/ui/PageControls/new-image.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/NewImage/Hint}}
 
 \whitespace trim
 <$button tooltip={{$:/language/Buttons/NewImage/Hint}} aria-label={{$:/language/Buttons/NewImage/Caption}} class=<<tv-config-toolbar-class>> actions={{$:/core/ui/Actions/new-image}}>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/new-image-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/NewImage/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>

--- a/core/ui/PageControls/new-image.tid
+++ b/core/ui/PageControls/new-image.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/NewImage/Hint}}
 
 \whitespace trim
 <$button tooltip={{$:/language/Buttons/NewImage/Hint}} aria-label={{$:/language/Buttons/NewImage/Caption}} class=<<tv-config-toolbar-class>> actions={{$:/core/ui/Actions/new-image}}>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/new-image-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/NewImage/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>

--- a/core/ui/PageControls/new-journal.tid
+++ b/core/ui/PageControls/new-journal.tid
@@ -6,14 +6,14 @@ description: {{$:/language/Buttons/NewJournal/Hint}}
 \whitespace trim
 \procedure journalButton()
 <$button tooltip={{$:/language/Buttons/NewJournal/Hint}} aria-label={{$:/language/Buttons/NewJournal/Caption}} class=<<tv-config-toolbar-class>> actions={{$:/core/ui/Actions/new-journal}}>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/new-journal-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/NewJournal/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>
 \end
 <<journalButton>>

--- a/core/ui/PageControls/new-journal.tid
+++ b/core/ui/PageControls/new-journal.tid
@@ -4,17 +4,16 @@ caption: {{$:/core/images/new-journal-button}} {{$:/language/Buttons/NewJournal/
 description: {{$:/language/Buttons/NewJournal/Hint}}
 
 \whitespace trim
-\define journalButton()
-\whitespace trim
+\procedure journalButton()
 <$button tooltip={{$:/language/Buttons/NewJournal/Hint}} aria-label={{$:/language/Buttons/NewJournal/Caption}} class=<<tv-config-toolbar-class>> actions={{$:/core/ui/Actions/new-journal}}>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/new-journal-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/NewJournal/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>
 \end
 <<journalButton>>

--- a/core/ui/PageControls/newtiddler.tid
+++ b/core/ui/PageControls/newtiddler.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/NewTiddler/Hint}}
 
 \whitespace trim
 <$button actions={{$:/core/ui/Actions/new-tiddler}} tooltip={{$:/language/Buttons/NewTiddler/Hint}} aria-label={{$:/language/Buttons/NewTiddler/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/new-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/NewTiddler/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>

--- a/core/ui/PageControls/newtiddler.tid
+++ b/core/ui/PageControls/newtiddler.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/NewTiddler/Hint}}
 
 \whitespace trim
 <$button actions={{$:/core/ui/Actions/new-tiddler}} tooltip={{$:/language/Buttons/NewTiddler/Hint}} aria-label={{$:/language/Buttons/NewTiddler/Caption}} class=<<tv-config-toolbar-class>>>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/new-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/NewTiddler/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>

--- a/core/ui/PageControls/palette.tid
+++ b/core/ui/PageControls/palette.tid
@@ -6,12 +6,12 @@ description: {{$:/language/Buttons/Palette/Hint}}
 \whitespace trim
 <span class="tc-popup-keep">
 <$button popup=<<qualify "$:/state/popup/palette">> tooltip={{$:/language/Buttons/Palette/Hint}} aria-label={{$:/language/Buttons/Palette/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/palette}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Palette/Caption}}/></span>
-</$list>
+<% endif %>
 </$button>
 </span>
 <$reveal state=<<qualify "$:/state/popup/palette">> type="popup" position="below" animate="yes">

--- a/core/ui/PageControls/palette.tid
+++ b/core/ui/PageControls/palette.tid
@@ -6,12 +6,12 @@ description: {{$:/language/Buttons/Palette/Hint}}
 \whitespace trim
 <span class="tc-popup-keep">
 <$button popup=<<qualify "$:/state/popup/palette">> tooltip={{$:/language/Buttons/Palette/Hint}} aria-label={{$:/language/Buttons/Palette/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/palette}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Palette/Caption}}/></span>
-<% endif %>
+<%endif%>
 </$button>
 </span>
 <$reveal state=<<qualify "$:/state/popup/palette">> type="popup" position="below" animate="yes">

--- a/core/ui/PageControls/print.tid
+++ b/core/ui/PageControls/print.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/Print/Hint}}
 
 \whitespace trim
 <$button message="tm-print" tooltip={{$:/language/Buttons/Print/Hint}} aria-label={{$:/language/Buttons/Print/Caption}} class=<<tv-config-toolbar-class>>>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/print-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Print/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>

--- a/core/ui/PageControls/print.tid
+++ b/core/ui/PageControls/print.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/Print/Hint}}
 
 \whitespace trim
 <$button message="tm-print" tooltip={{$:/language/Buttons/Print/Hint}} aria-label={{$:/language/Buttons/Print/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/print-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Print/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>

--- a/core/ui/PageControls/refresh.tid
+++ b/core/ui/PageControls/refresh.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/Refresh/Hint}}
 
 \whitespace trim
 <$button message="tm-browser-refresh" tooltip={{$:/language/Buttons/Refresh/Hint}} aria-label={{$:/language/Buttons/Refresh/Caption}} class=<<tv-config-toolbar-class>>>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/refresh-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Refresh/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>

--- a/core/ui/PageControls/refresh.tid
+++ b/core/ui/PageControls/refresh.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/Refresh/Hint}}
 
 \whitespace trim
 <$button message="tm-browser-refresh" tooltip={{$:/language/Buttons/Refresh/Hint}} aria-label={{$:/language/Buttons/Refresh/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/refresh-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Refresh/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>

--- a/core/ui/PageControls/savewiki.tid
+++ b/core/ui/PageControls/savewiki.tid
@@ -9,13 +9,13 @@ description: {{$:/language/Buttons/SaveWiki/Hint}}
 <$action-sendmessage $message="tm-save-wiki" $param={{$:/config/SaveWikiButton/Template}} filename=<<site-title>>/>
 </$wikify>
 <span class="tc-dirty-indicator">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/save-button-dynamic}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/SaveWiki/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </span>
 </$button>

--- a/core/ui/PageControls/savewiki.tid
+++ b/core/ui/PageControls/savewiki.tid
@@ -9,13 +9,13 @@ description: {{$:/language/Buttons/SaveWiki/Hint}}
 <$action-sendmessage $message="tm-save-wiki" $param={{$:/config/SaveWikiButton/Template}} filename=<<site-title>>/>
 </$wikify>
 <span class="tc-dirty-indicator">
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/save-button-dynamic}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/SaveWiki/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </span>
 </$button>

--- a/core/ui/PageControls/storyview.tid
+++ b/core/ui/PageControls/storyview.tid
@@ -4,19 +4,16 @@ caption: {{$:/core/images/storyview-classic}} {{$:/language/Buttons/StoryView/Ca
 description: {{$:/language/Buttons/StoryView/Hint}}
 
 \whitespace trim
-\define icon()
-$:/core/images/storyview-$(storyview)$
-\end
 <span class="tc-popup-keep">
 <$button popup=<<qualify "$:/state/popup/storyview">> tooltip={{$:/language/Buttons/StoryView/Hint}} aria-label={{$:/language/Buttons/StoryView/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 <$set name="storyview" value={{$:/view}}>
-<$transclude tiddler=<<icon>>/>
+<$transclude tiddler=`$:/core/images/storyview-$(storyview)$`/>
 </$set>
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/StoryView/Caption}}/></span>
-</$list>
+<% endif %>
 </$button>
 </span>
 <$reveal state=<<qualify "$:/state/popup/storyview">> type="popup" position="below" animate="yes">

--- a/core/ui/PageControls/storyview.tid
+++ b/core/ui/PageControls/storyview.tid
@@ -6,14 +6,14 @@ description: {{$:/language/Buttons/StoryView/Hint}}
 \whitespace trim
 <span class="tc-popup-keep">
 <$button popup=<<qualify "$:/state/popup/storyview">> tooltip={{$:/language/Buttons/StoryView/Hint}} aria-label={{$:/language/Buttons/StoryView/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 <$set name="storyview" value={{$:/view}}>
 <$transclude tiddler=`$:/core/images/storyview-$(storyview)$`/>
 </$set>
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/StoryView/Caption}}/></span>
-<% endif %>
+<%endif%>
 </$button>
 </span>
 <$reveal state=<<qualify "$:/state/popup/storyview">> type="popup" position="below" animate="yes">

--- a/core/ui/PageControls/tag-button.tid
+++ b/core/ui/PageControls/tag-button.tid
@@ -6,14 +6,14 @@ description: {{$:/language/Buttons/TagManager/Hint}}
 \whitespace trim
 \procedure control-panel-button(class)
 <$button to="$:/TagManager" tooltip={{$:/language/Buttons/TagManager/Hint}} aria-label={{$:/language/Buttons/TagManager/Caption}} class=`$(tv-config-toolbar-class)$ $(class)$`>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/tag-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/TagManager/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>
 \end
 

--- a/core/ui/PageControls/tag-button.tid
+++ b/core/ui/PageControls/tag-button.tid
@@ -4,17 +4,16 @@ caption: {{$:/core/images/tag-button}} {{$:/language/Buttons/TagManager/Caption}
 description: {{$:/language/Buttons/TagManager/Hint}}
 
 \whitespace trim
-\define control-panel-button(class)
-\whitespace trim
-<$button to="$:/TagManager" tooltip={{$:/language/Buttons/TagManager/Hint}} aria-label={{$:/language/Buttons/TagManager/Caption}} class="""$(tv-config-toolbar-class)$ $class$""">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+\procedure control-panel-button(class)
+<$button to="$:/TagManager" tooltip={{$:/language/Buttons/TagManager/Hint}} aria-label={{$:/language/Buttons/TagManager/Caption}} class=`$(tv-config-toolbar-class)$ $(class)$`>
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/tag-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/TagManager/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>
 \end
 

--- a/core/ui/PageControls/theme.tid
+++ b/core/ui/PageControls/theme.tid
@@ -6,12 +6,12 @@ description: {{$:/language/Buttons/Theme/Hint}}
 \whitespace trim
 <span class="tc-popup-keep">
 <$button popup=<<qualify "$:/state/popup/theme">> tooltip={{$:/language/Buttons/Theme/Hint}} aria-label={{$:/language/Buttons/Theme/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/theme-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Theme/Caption}}/></span>
-</$list>
+<% endif %>
 </$button>
 </span>
 <$reveal state=<<qualify "$:/state/popup/theme">> type="popup" position="below" animate="yes">

--- a/core/ui/PageControls/theme.tid
+++ b/core/ui/PageControls/theme.tid
@@ -6,12 +6,12 @@ description: {{$:/language/Buttons/Theme/Hint}}
 \whitespace trim
 <span class="tc-popup-keep">
 <$button popup=<<qualify "$:/state/popup/theme">> tooltip={{$:/language/Buttons/Theme/Hint}} aria-label={{$:/language/Buttons/Theme/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/theme-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Theme/Caption}}/></span>
-<% endif %>
+<%endif%>
 </$button>
 </span>
 <$reveal state=<<qualify "$:/state/popup/theme">> type="popup" position="below" animate="yes">

--- a/core/ui/PageControls/timestamp.tid
+++ b/core/ui/PageControls/timestamp.tid
@@ -7,26 +7,26 @@ description: {{$:/language/Buttons/Timestamp/Hint}}
 <$reveal type="nomatch" state="$:/config/TimestampDisable" text="yes">
 <$button tooltip={{$:/language/Buttons/Timestamp/On/Hint}} aria-label={{$:/language/Buttons/Timestamp/On/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-setfield $tiddler="$:/config/TimestampDisable" $value="yes"/>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/timestamp-on}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Timestamp/On/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>
 </$reveal>
 <$reveal type="match" state="$:/config/TimestampDisable" text="yes">
 <$button tooltip={{$:/language/Buttons/Timestamp/Off/Hint}} aria-label={{$:/language/Buttons/Timestamp/Off/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-setfield $tiddler="$:/config/TimestampDisable" $value="no"/>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/timestamp-off}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Timestamp/Off/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>
 </$reveal>

--- a/core/ui/PageControls/timestamp.tid
+++ b/core/ui/PageControls/timestamp.tid
@@ -7,26 +7,26 @@ description: {{$:/language/Buttons/Timestamp/Hint}}
 <$reveal type="nomatch" state="$:/config/TimestampDisable" text="yes">
 <$button tooltip={{$:/language/Buttons/Timestamp/On/Hint}} aria-label={{$:/language/Buttons/Timestamp/On/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-setfield $tiddler="$:/config/TimestampDisable" $value="yes"/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/timestamp-on}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Timestamp/On/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>
 </$reveal>
 <$reveal type="match" state="$:/config/TimestampDisable" text="yes">
 <$button tooltip={{$:/language/Buttons/Timestamp/Off/Hint}} aria-label={{$:/language/Buttons/Timestamp/Off/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-setfield $tiddler="$:/config/TimestampDisable" $value="no"/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/timestamp-off}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Timestamp/Off/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>
 </$reveal>

--- a/core/ui/PageControls/unfold-all.tid
+++ b/core/ui/PageControls/unfold-all.tid
@@ -6,12 +6,12 @@ description: {{$:/language/Buttons/UnfoldAll/Hint}}
 \whitespace trim
 <$button tooltip={{$:/language/Buttons/UnfoldAll/Hint}} aria-label={{$:/language/Buttons/UnfoldAll/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-unfold-all-tiddlers" $param=<<currentTiddler>> foldedStatePrefix="$:/state/folded/"/>
-<% if [<tv-config-toolbar-icons>match[yes]] %>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/unfold-all-button}}
-<% endif %>
-<% if [<tv-config-toolbar-text>match[yes]] %>
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/UnfoldAll/Caption}}/>
 </span>
-<% endif %>
+<%endif%>
 </$button>

--- a/core/ui/PageControls/unfold-all.tid
+++ b/core/ui/PageControls/unfold-all.tid
@@ -6,12 +6,12 @@ description: {{$:/language/Buttons/UnfoldAll/Hint}}
 \whitespace trim
 <$button tooltip={{$:/language/Buttons/UnfoldAll/Hint}} aria-label={{$:/language/Buttons/UnfoldAll/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-unfold-all-tiddlers" $param=<<currentTiddler>> foldedStatePrefix="$:/state/folded/"/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]" variable="listItem">
+<% if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/unfold-all-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<% endif %>
+<% if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/UnfoldAll/Caption}}/>
 </span>
-</$list>
+<% endif %>
 </$button>

--- a/plugins/tiddlywiki/help/help.tid
+++ b/plugins/tiddlywiki/help/help.tid
@@ -8,22 +8,22 @@ description: {{$:/language/Buttons/Help/Hint}}
 \whitespace trim
 <$list filter="[[$:/config/ShowHelp]get[text]] +[else[no]match[yes]]" variable="ignore">
 <$button set="$:/config/ShowHelp" setTo="no" tooltip={{$:/language/Buttons/Help/Hint}} aria-label={{$:/language/Buttons/Help/Caption}} class="""$(tv-config-toolbar-class)$ tc-selected""">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/help}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Help/Caption}}/></span>
-</$list>
+<%endif%>
 </$button>
 </$list>
 <$list filter="[[$:/config/ShowHelp]get[text]] +[else[no]!match[yes]]" variable="ignore">
 <$button set="$:/config/ShowHelp" setTo="yes" tooltip={{$:/language/Buttons/Help/Hint}} aria-label={{$:/language/Buttons/Help/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/help}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Help/Caption}}/></span>
-</$list>
+<%endif%>
 </$button>
 </$list>
 \end

--- a/plugins/tiddlywiki/markdown-legacy/new-markdown.tid
+++ b/plugins/tiddlywiki/markdown-legacy/new-markdown.tid
@@ -7,10 +7,10 @@ list-after: $:/core/ui/Buttons/new-tiddler
 \whitespace trim
 <$button tooltip={{$:/language/Buttons/NewMarkdown/Hint}} aria-label={{$:/language/Buttons/NewMarkdown/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-new-tiddler" type="text/markdown"/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/plugins/tiddlywiki/markdown-legacy/images/new-markdown-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/NewMarkdown/Caption}}/></span>
-</$list>
+<%endif%>
 </$button>

--- a/plugins/tiddlywiki/markdown/new-markdown.tid
+++ b/plugins/tiddlywiki/markdown/new-markdown.tid
@@ -7,10 +7,10 @@ list-after: $:/core/ui/Buttons/new-tiddler
 \whitespace trim
 <$button tooltip={{$:/language/Buttons/NewMarkdown/Hint}} aria-label={{$:/language/Buttons/NewMarkdown/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-new-tiddler" type="text/markdown"/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/plugins/tiddlywiki/markdown/images/new-markdown-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/NewMarkdown/Caption}}/></span>
-</$list>
+<%endif%>
 </$button>

--- a/plugins/tiddlywiki/tiddlyweb/save-wiki-button.tid
+++ b/plugins/tiddlywiki/tiddlyweb/save-wiki-button.tid
@@ -9,12 +9,12 @@ $:/config/PageControlButtons/Visibility/$(listItem)$
 \end
 <$button popup=<<qualify "$:/state/popup/save-wiki">> tooltip="Status of synchronisation with server" aria-label="Server status" class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
 <span class="tc-dirty-indicator">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/plugins/tiddlywiki/tiddlyweb/icon/cloud}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text="Server status"/></span>
-</$list>
+<%endif%>
 </span>
 </$button>
 <$reveal state=<<qualify "$:/state/popup/save-wiki">> type="popup" position="belowleft" animate="yes">


### PR DESCRIPTION
It is strange that PageControls buttons uses list widget to display text and icons.

This PR rewrites PageControls buttons and actions to use newer syntax. Including:

* Replace some list widget with conditonal shortcut syntax
* Replace macrocall widget with transclude widget
* Replace some macros with procedures and Substituted Attribute Values
* Replace vars widget and some set widget with let widget