### PR TITLE
[DOCS] Using Stylesheets -- fix typos

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/Using Stylesheets.tid
+++ b/editions/tw5.com/tiddlers/howtos/Using Stylesheets.tid
@@ -41,7 +41,7 @@ You can then use your own [[styles and classes in WikiText|Styles and Classes in
 
 Custom stylesheets are applied independently from theme stylesheets. Therefore, it is often necessary for the css rules in your custom stylesheet to be more specific than those of the theme you want to override. For example, `html body.tc-body` is more specific than `body.tc-body`. 
 
-<<.tip "''You should always start with the least specific value that works!''<br><br>">>
+<<.tip """You should always start with the least specific value that works!""">>
 
 ! Stylesheet Types
 
@@ -76,4 +76,4 @@ The ~TiddlyWiki core provides several [[global macros that are helpful in constr
 
 !! See Also
 
-* <<list-links "[tag[Using Stylesheets]]">>
+<<list-links "[tag[Using Stylesheets]]">>


### PR DESCRIPTION
- Remove bold from "tip" text
- Remove redundant list-bullet in front of  `<<list-links` macro 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>