### PR TITLE
Standardise whitespace in conditional shortcut syntax

### DIFF
--- a/core/modules/parsers/wikiparser/rules/conditional.js
+++ b/core/modules/parsers/wikiparser/rules/conditional.js
@@ -6,7 +6,7 @@ module-type: wikirule
 Conditional shortcut syntax
 
 ```
-This is a <% if [{something}] %>Elephant<% elseif [{else}] %>Pelican<% else %>Crocodile<% endif %>
+This is a <%if [{something}] %>Elephant<%elseif [{else}] %>Pelican<%else%>Crocodile<%endif%>
 ```
 
 \*/
@@ -27,7 +27,7 @@ exports.init = function(parser) {
 };
 
 exports.findNextMatch = function(startPos) {
-	// Look for the next <% if shortcut
+	// Look for the next <%if shortcut
 	this.matchRegExp.lastIndex = startPos;
 	this.match = this.matchRegExp.exec(this.parser.source);
 	// If not found then return no match

--- a/core/ui/AdvancedSearch/Shadows.tid
+++ b/core/ui/AdvancedSearch/Shadows.tid
@@ -83,11 +83,11 @@ first-search-filter: [all[shadows]search<userInput>sort[title]limit[250]] -[[$:/
 
 <div class="tc-search-results">
 
-<% if [<resultCount>match[0]] %>
+<%if [<resultCount>match[0]] %>
 	{{$:/language/Search/Matches/NoMatch}}
-<% else %>
+<%else%>
 	<<lingo Shadows/Matches>>
-<% endif %>
+<%endif%>
 
 <$list filter="[all[shadows]search{$:/temp/advancedsearch}sort[title]limit[250]] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]]">
 <span class={{{[<currentTiddler>addsuffix[-primaryList]] -[[$:/temp/advancedsearch/selected-item]get[text]] +[then[]else[tc-list-item-selected]] }}}>

--- a/core/ui/AdvancedSearch/System.tid
+++ b/core/ui/AdvancedSearch/System.tid
@@ -82,11 +82,11 @@ first-search-filter: [is[system]search<userInput>sort[title]limit[250]] -[[$:/te
 
 <div class="tc-search-results">
 
-<% if [<resultCount>match[0]] %>
+<%if [<resultCount>match[0]] %>
 	{{$:/language/Search/Matches/NoMatch}}
-<% else %>
+<%else%>
 	<<lingo System/Matches>>
-<% endif %>
+<%endif%>
 
 <$list filter="[is[system]search{$:/temp/advancedsearch}sort[title]limit[250]] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]] -[[$:/temp/advancedsearch/selected-item]]">
 <span class={{{[<currentTiddler>addsuffix[-primaryList]] -[[$:/temp/advancedsearch/selected-item]get[text]] +[then[]else[tc-list-item-selected]] }}}>

--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -31,11 +31,11 @@ second-search-filter: [subfilter<tagListFilter>is[system]search:title<userInput>
 \procedure add-tag-actions()
 <$let tag=<<_tf.getTag>> >
 	<$action-listops $tiddler=<<saveTiddler>> $field=<<tagField>> $subfilter='+[toggle<tag>trim[]]'/>
-	<% if [<tag>] :intersection[<saveTiddler>get<tagField>enlist-input[]] %>
+	<%if [<tag>] :intersection[<saveTiddler>get<tagField>enlist-input[]] %>
 		<!-- tag has been removed - do nothing -->
-	<% else %>
+	<%else%>
 		<<actions>>
-	<% endif %>
+	<%endif%>
 	<<delete-tag-state-tiddlers>>
 	<$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
 </$let>
@@ -46,11 +46,11 @@ second-search-filter: [subfilter<tagListFilter>is[system]search:title<userInput>
 The second ESC tries to close the "draft tiddler"
 -->
 \procedure clear-tags-actions-inner()
-<% if [<storeTitle>has[text]] ~[<newTagNameTiddler>has[text]] %>
+<%if [<storeTitle>has[text]] ~[<newTagNameTiddler>has[text]] %>
 	<<delete-tag-state-tiddlers>>
-<% else %>
+<%else%>
 		<<cancel-delete-tiddler-actions "cancel">>
-<% endif %>
+<%endif%>
 \end
 
 <!-- triggered by keyboard only -->
@@ -128,13 +128,13 @@ The second ESC tries to close the "draft tiddler"
 		>
 			{{$:/core/images/down-arrow}}
 		</$button>
-		<% if [<storeTitle>has[text]] %>
+		<%if [<storeTitle>has[text]] %>
 			<$button actions=<<delete-tag-state-tiddlers>> class="tc-btn-invisible tc-small-gap tc-btn-dropdown"
 				tooltip={{$:/language/EditTemplate/Tags/ClearInput/Hint}} aria-label={{$:/language/EditTemplate/Tags/ClearInput/Caption}}
 			>
 				{{$:/core/images/close-button}}
 			</$button>
-		<% endif %>
+		<%endif%>
 		<span class="tc-add-tag-button tc-small-gap-left">
 			<$let tag=<<_tf.getTag>>>
 				<$button set=<<newTagNameTiddler>> actions=<<add-button-actions>> >
@@ -144,13 +144,13 @@ The second ESC tries to close the "draft tiddler"
 		</span>
 	</div>
 	<div class="tc-block-dropdown-wrapper">
-		<% if [<tf.tagpicker-dropdown-id>has[text]] %>
+		<%if [<tf.tagpicker-dropdown-id>has[text]] %>
 			<div class="tc-block-dropdown tc-block-tags-dropdown">
 				<$macrocall $name="tag-picker-listTags" filter=<<nonSystemTagsFilter>> suffix="-primaryList" />
 				<hr>
 				<$macrocall $name="tag-picker-listTags" filter=<<systemTagsFilter>> suffix="-secondaryList" />
 			</div>
-		<% endif %>
+		<%endif%>
 	</div>
 </div>
 \end

--- a/editions/test/tiddlers/tests/data/conditionals/Basic.tid
+++ b/editions/test/tiddlers/tests/data/conditionals/Basic.tid
@@ -5,7 +5,7 @@ tags: [[$:/tags/wiki-test-spec]]
 
 title: Text
 
-This is a <% if [<something>match[one]] %>Elephant<% endif %>, I think.
+This is a <%if [<something>match[one]] %>Elephant<%endif%>, I think.
 +
 title: Output
 

--- a/editions/test/tiddlers/tests/data/conditionals/BlockMode.tid
+++ b/editions/test/tiddlers/tests/data/conditionals/BlockMode.tid
@@ -6,23 +6,23 @@ tags: [[$:/tags/wiki-test-spec]]
 title: Output
 
 \procedure test(animal)
-<% if [<animal>match[Elephant]] %>
+<%if [<animal>match[Elephant]] %>
 
 ! It is an elephant
 
-<% else %>
+<%else%>
 
-<% if [<animal>match[Giraffe]] %>
+<%if [<animal>match[Giraffe]] %>
 
 ! It is a giraffe
 
-<% else %>
+<%else%>
 
 ! It is completely unknown
 
-<% endif %>
+<%endif%>
 
-<% endif %>
+<%endif%>
 
 \end
 

--- a/editions/test/tiddlers/tests/data/conditionals/Else.tid
+++ b/editions/test/tiddlers/tests/data/conditionals/Else.tid
@@ -5,7 +5,7 @@ tags: [[$:/tags/wiki-test-spec]]
 
 title: Text
 
-This is a <% if [<something>match[one]] %>Elephant<% else %>Crocodile<% endif %>, I think.
+This is a <%if [<something>match[one]] %>Elephant<%else%>Crocodile<%endif%>, I think.
 +
 title: Output
 

--- a/editions/test/tiddlers/tests/data/conditionals/Elseif.tid
+++ b/editions/test/tiddlers/tests/data/conditionals/Elseif.tid
@@ -5,7 +5,7 @@ tags: [[$:/tags/wiki-test-spec]]
 
 title: Text
 
-This is a <% if [<something>match[one]] %>Elephant<% elseif [<something>match[two]] %>Antelope<% else %>Crocodile<% endif %>, I think.
+This is a <%if [<something>match[one]] %>Elephant<%elseif [<something>match[two]] %>Antelope<%else%>Crocodile<%endif%>, I think.
 +
 title: Output
 

--- a/editions/test/tiddlers/tests/data/conditionals/MissingEndIf.tid
+++ b/editions/test/tiddlers/tests/data/conditionals/MissingEndIf.tid
@@ -5,7 +5,7 @@ tags: [[$:/tags/wiki-test-spec]]
 
 title: Text
 
-This is a <% if [<something>match[one]] %>Elephant
+This is a <%if [<something>match[one]] %>Elephant
 +
 title: Output
 

--- a/editions/test/tiddlers/tests/data/conditionals/MultipleResults.tid
+++ b/editions/test/tiddlers/tests/data/conditionals/MultipleResults.tid
@@ -5,7 +5,7 @@ tags: [[$:/tags/wiki-test-spec]]
 
 title: Output
 
-This is a <% if 1 2 3 4 5 6 %>Elephant<% endif %>, I think.
+This is a <%if 1 2 3 4 5 6 %>Elephant<%endif%>, I think.
 +
 title: ExpectedResult
 

--- a/editions/test/tiddlers/tests/data/conditionals/Nested.tid
+++ b/editions/test/tiddlers/tests/data/conditionals/Nested.tid
@@ -6,15 +6,15 @@ tags: [[$:/tags/wiki-test-spec]]
 title: Output
 
 \procedure test(animal)
-<% if [<animal>match[Elephant]] %>
+<%if [<animal>match[Elephant]] %>
 It is an elephant
-<% else %>
-<% if [<animal>match[Giraffe]] %>
+<%else%>
+<%if [<animal>match[Giraffe]] %>
 It is a giraffe
-<% else %>
+<%else%>
 It is completely unknown
-<% endif %>
-<% endif %>
+<%endif%>
+<%endif%>
 \end
 
 <<test "Giraffe">>

--- a/editions/test/tiddlers/tests/data/conditionals/NestedElseif.tid
+++ b/editions/test/tiddlers/tests/data/conditionals/NestedElseif.tid
@@ -7,20 +7,20 @@ title: Text
 
 \whitespace trim
 This is a&#32;
-	<% if [<something>match[one]] %>
-		<% if [<another>match[one]] %>
+	<%if [<something>match[one]] %>
+		<%if [<another>match[one]] %>
 			Indian
-		<% elseif [<another>match[two]] %>
+		<%elseif [<another>match[two]] %>
 			African
-		<% else %>
+		<%else%>
 			Unknown
-		<% endif %>
+		<%endif%>
 		&#32;Elephant
-	<% elseif [<something>match[two]] %>
+	<%elseif [<something>match[two]] %>
 		Antelope
-	<% else %>
+	<%else%>
 		Crocodile
-	<% endif %>
+	<%endif%>
 , I think.
 +
 title: Output

--- a/editions/tw5.com/tiddlers/empty-tag-node-template.tid
+++ b/editions/tw5.com/tiddlers/empty-tag-node-template.tid
@@ -5,8 +5,8 @@ tags: $:/tags/ViewTemplate
 title: $:/editions/tw5.com/empty-tag-node-template
 type: 
 
-<% if [<storyTiddler>!has[text]!has[tags]tagging[]] %>
+<%if [<storyTiddler>!has[text]!has[tags]tagging[]] %>
 The following tiddlers are tagged with <<tag>>:
 
 <<list-links filter:"[<storyTiddler>!has[text]!has[tags]tagging[]]" class:"multi-columns">>
-<% endif %>
+<%endif%>

--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.3.2.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.3.2.tid
@@ -23,13 +23,13 @@ type: text/vnd.tiddlywiki
 These new token-based shortcuts allow a richer structure and expressivity than existing features such as widgets or pragmas. For example:
 
 ```
-<% if [<animal>match[Elephant]] %>
+<%if [<animal>match[Elephant]] %>
   It is an elephant
-<% elseif [<animal>match[Giraffe]] %>
+<%elseif [<animal>match[Giraffe]] %>
 	It is a giraffe
-<% else %>
+<%else%>
 	It is completely unknown
-<% endif %>
+<%endif%>
 ```
 
 Behind the scenes, the conditional shortcut syntax is rendered as the equivalent [[ListWidgets|ListWidget]].

--- a/editions/tw5.com/tiddlers/system/doc-macros.tid
+++ b/editions/tw5.com/tiddlers/system/doc-macros.tid
@@ -119,7 +119,7 @@ type: text/vnd.tiddlywiki
 \procedure .infoBox(text:"", title, icon:"$:/core/images/info-button", class, iconSize:"1.4rem")
 \function _f.tipClass() [[doc-icon-block]] [<class>!is[blank]then<class>] +[join[ ]]
 <div class=<<_f.tipClass>>>
-	<%if [<title>!is[blank]] %><div>''<<title>>''</div><% endif %>
+	<%if [<title>!is[blank]] %><div>''<<title>>''</div><%endif%>
 	<div class="doc-block-icon"><$transclude $tiddler=<<icon>> size=<<iconSize>>/></div>
 	<<text>>
 </div>

--- a/editions/tw5.com/tiddlers/system/filter-run-template.tid
+++ b/editions/tw5.com/tiddlers/system/filter-run-template.tid
@@ -9,18 +9,18 @@ type: text/vnd.tiddlywiki
 \whitespace trim
 
 \procedure .op-place()
-<% if [<op-name>!is[blank]] %>
+<%if [<op-name>!is[blank]] %>
 	<$macrocall $name=".place" _=<<op-name>> /><span class="tc-tiny-gap">=</span>
-<% endif %>
+<%endif%>
 \end
 
 \procedure .op-row()
-<% if [<op-body>!is[blank]] %>
+<%if [<op-body>!is[blank]] %>
 	<tr>
 		<th align="left"><<op-head>></th>
 		<td><<.op-place>><<op-body>></td>
 	</tr>
-<% endif %>
+<%endif%>
 \end
 
 <$list filter="[all[current]tag[Named Filter Run Prefix]]">

--- a/editions/tw5.com/tiddlers/system/operator-macros.tid
+++ b/editions/tw5.com/tiddlers/system/operator-macros.tid
@@ -16,9 +16,9 @@ title: $:/editions/tw5.com/operator-macros
 	<$list filter="[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix<n>]" variable=".state">
 		<$reveal state=<<.state>> type="nomatch" text="show">
 			<code><$text text=<<eg>>/></code>
-			<% if [<ie>!is[blank]] %>
+			<%if [<ie>!is[blank]] %>
 				<dd>&rarr;&nbsp;<<ie>></dd>
-			<% endif %>
+			<%endif%>
 			<dl>
 				<dd><$button actions=<<.operator-example-tryit-actions>>>Try it</$button></dd>
 			</dl>

--- a/editions/tw5.com/tiddlers/system/operator-template.tid
+++ b/editions/tw5.com/tiddlers/system/operator-template.tid
@@ -8,17 +8,17 @@ title: $:/editions/tw5.com/operator-template
 \whitespace trim
 
 \procedure .op-place()
-<% if [<op-name>!is[blank]] %>
+<%if [<op-name>!is[blank]] %>
 	<$macrocall $name=".place" _=<<op-name>> /><span class="tc-tiny-gap">=</span>
-<% endif %>
+<%endif%>
 \end
 
 \procedure .op-row()
-<% if [<op-body>!is[blank]] %>
+<%if [<op-body>!is[blank]] %>
 	<tr>
 		<th align="left"><<op-head>></th><td><<.op-place>><<op-body>></td>
 	</tr>
-<% endif %>
+<%endif%>
 \end
 
 <$list filter="[all[current]tag[Filter Operators]]">

--- a/editions/tw5.com/tiddlers/system/version-macros.tid
+++ b/editions/tw5.com/tiddlers/system/version-macros.tid
@@ -19,11 +19,11 @@ type: text/vnd.tiddlywiki
 \end
 
 \procedure .from-version(version)
-<% if [<version>compare:version:gteq<tf.from-version-reference>] %>
+<%if [<version>compare:version:gteq<tf.from-version-reference>] %>
 	<<.from-version-template "doc-from-version doc-from-version-new" "New in v">>
-<% else %>
+<%else%>
 	<<.from-version-template "doc-from-version" "Introduced in v">>
-<% endif %>
+<%endif%>
 \end
 
 \procedure .deprecated-since(version, superseded:"")

--- a/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
@@ -75,7 +75,7 @@ eg="""<$edit-text tiddler=<<currentTiddler>> field="heading" size="25" focus="ye
 eg="""\procedure onInput()
   <%if [get[temp]match[$:/]] %>
 		<$action-confirm $message="Yes, this is how system tiddler names begin!"/>
-  <% endif %>
+  <%endif%>
 \end
 
 Type a new tiddler name, starting with the system prefix `$:/`: <$edit-text inputActions=<<onInput>> field="temp" class="tc-edit-texteditor"/>

--- a/editions/tw5.com/tiddlers/widgets/EditWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditWidget.tid
@@ -26,7 +26,7 @@ The content of the `<$edit>` widget is ignored.
 
 ! Examples
 
-!! Edit the contents (text field) of a tiddler titled <%if [<now YYYY-0MM-0DD>is[tiddler]] %> <$tiddler tiddler=<<now YYYY-0MM-0DD>> > <$link/></$tiddler> <%else %> with today’s date <% endif %>
+!! Edit the contents (text field) of a tiddler titled <%if [<now YYYY-0MM-0DD>is[tiddler]] %> <$tiddler tiddler=<<now YYYY-0MM-0DD>> > <$link/></$tiddler> <%else %> with today’s date <%endif%>
 
 <$macrocall $name=".example" n="1"
 eg="""<$edit tiddler=<<now YYYY-0MM-0DD>> class="tc-edit-texteditor"/>

--- a/editions/tw5.com/tiddlers/wikitext/Conditional Shortcut Syntax.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Conditional Shortcut Syntax.tid
@@ -11,40 +11,40 @@ Within an "if" or "elseif" clause, the variable `condition` contains the value o
 A simple example:
 
 <$macrocall $name='wikitext-example-without-html'
-src='<% if [{$:/info/url/protocol}match[file:]] %>
+src='<%if [{$:/info/url/protocol}match[file:]] %>
   Loaded from a file URI
-<% else %>
+<%else%>
   Not loaded from a file URI
-<% endif %>
+<%endif%>
 '/>
 
-One or more `<% elseif %>` clauses may be included before the `<% else %>` clause:
+One or more `<%elseif%>` clauses may be included before the `<%else%>` clause:
 
 <$macrocall $name='wikitext-example-without-html'
-src='<% if [{$:/info/url/protocol}match[file:]] %>
+src='<%if [{$:/info/url/protocol}match[file:]] %>
   Loaded from a file URI
-<% elseif [{$:/info/url/protocol}match[https:]] %>
+<%elseif [{$:/info/url/protocol}match[https:]] %>
   Loaded from an HTTPS URI
-<% elseif [{$:/info/url/protocol}match[http:]] %>
+<%elseif [{$:/info/url/protocol}match[http:]] %>
   Loaded from an HTTP URI
-<% else %>
+<%else%>
   Loaded from an unknown protocol
-<% endif %>
+<%endif%>
 '/>
 
 The conditional shortcut syntax can be nested:
 
 <$macrocall $name='wikitext-example-without-html'
 src='\procedure test(animal)
-<% if [<animal>match[Elephant]] %>
+<%if [<animal>match[Elephant]] %>
   It is an elephant
-<% else %>
-  <% if [<animal>match[Giraffe]] %>
+<%else%>
+  <%if [<animal>match[Giraffe]] %>
     It is a giraffe
-  <% else %>
+  <%else%>
     It is completely unknown
-  <% endif %>
-<% endif %>
+  <%endif%>
+<%endif%>
 \end
 
 <<test "Giraffe">>
@@ -56,7 +56,7 @@ src='\procedure test(animal)
 
 Notes:
 
-* Clauses are parsed in inline mode by default. Force block mode parsing by following the opening `<% if %>`, `<% elseif %>` or `<% else %>` with two line breaks
+* Clauses are parsed in inline mode by default. Force block mode parsing by following the opening `<%if %>`, `<%elseif%>` or `<%else%>` with two line breaks
 * Widgets and HTML elements must be within a single conditional clause; it is not possible to start an element in one conditional clause and end it in another
 * The conditional shortcut syntax cannot contain pragmas such as procedure definitions
 

--- a/plugins/tiddlywiki/github-fork-ribbon/usage.tid
+++ b/plugins/tiddlywiki/github-fork-ribbon/usage.tid
@@ -6,11 +6,11 @@ title: $:/plugins/tiddlywiki/github-fork-ribbon/usage
 \end
 
 \procedure ribbonCreateActions()
-<% if [[$:/github-ribbon]!is[tiddler]] %>
+<%if [[$:/github-ribbon]!is[tiddler]] %>
 	<$action-setfield $tiddler="$:/github-ribbon" $field="text" $value=<<ribbonCode>>
 		tags="$:/tags/PageTemplate" 
 		code-body="yes" />
-<% endif %>
+<%endif%>
 <$action-navigate $to="$:/github-ribbon" />
 \end
 
@@ -18,9 +18,9 @@ title: $:/plugins/tiddlywiki/github-fork-ribbon/usage
 <$button actions=<<ribbonCreateActions>> >
 <%if [[$:/github-ribbon]!is[tiddler]] %>
 Create
-<% else %>
+<%else%>
 Show
-<% endif %> ~$:/github-ribbon
+<%endif%> ~$:/github-ribbon
 </$button>
 \end
 


### PR DESCRIPTION
The core currently inconsistently applies whitespace within the conditional shortcut syntax, using both the forms `<%if ... %>/<% else %>/<% endif %>` and `<%f ... >/<%else%>/<%endif%>`.

We have to decide on a single approach and use it consistently. My own view is that the whitespace does not make things more readable: it means that the brain has to process the two parts separately, rather than seeing them as a single symbol.

The other consideration is consistency with the way that we write widgets: we do not write <$ list filter="">.

A further but minor point is that omitting the whitespace will lead to smaller tiddlers.

This PR fixes the usages with whitespace to remove the whitespace.

See https://github.com/TiddlyWiki/TiddlyWiki5/pull/8579#issuecomment-2324796874 for further discussion