### PR TITLE
Update toolbar buttons to use v5.3.2 syntax

### DIFF
--- a/core/ui/EditToolbar/cancel.tid
+++ b/core/ui/EditToolbar/cancel.tid
@@ -5,10 +5,10 @@ description: {{$:/language/Buttons/Cancel/Hint}}
 
 \whitespace trim
 <$button actions=<<cancel-delete-tiddler-actions "cancel">> tooltip={{$:/language/Buttons/Cancel/Hint}} aria-label={{$:/language/Buttons/Cancel/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/cancel-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Cancel/Caption}}/></span>
-</$list>
+<%endif%>
 </$button>

--- a/core/ui/EditToolbar/delete.tid
+++ b/core/ui/EditToolbar/delete.tid
@@ -5,10 +5,10 @@ description: {{$:/language/Buttons/Delete/Hint}}
 
 \whitespace trim
 <$button actions=<<cancel-delete-tiddler-actions "delete">> tooltip={{$:/language/Buttons/Delete/Hint}} aria-label={{$:/language/Buttons/Delete/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/delete-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Delete/Caption}}/></span>
-</$list>
+<%endif%>
 </$button>

--- a/core/ui/EditToolbar/save.tid
+++ b/core/ui/EditToolbar/save.tid
@@ -4,8 +4,7 @@ caption: {{$:/core/images/done-button}} {{$:/language/Buttons/Save/Caption}}
 description: {{$:/language/Buttons/Save/Hint}}
 
 \whitespace trim
-\define save-tiddler-button()
-\whitespace trim
+\procedure save-tiddler-button()
 <$fieldmangler>
 	<$button
 		tooltip={{$:/language/Buttons/Save/Hint}}
@@ -13,12 +12,12 @@ description: {{$:/language/Buttons/Save/Hint}}
 		class=<<tv-config-toolbar-class>>
 	>
 		<<save-tiddler-actions>>
-		<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+		<%if [<tv-config-toolbar-icons>match[yes]] %>
 			{{$:/core/images/done-button}}
-		</$list>
-		<$list filter="[<tv-config-toolbar-text>match[yes]]">
+		<%endif%>
+		<%if [<tv-config-toolbar-text>match[yes]] %>
 			<span class="tc-btn-text"><$text text={{$:/language/Buttons/Save/Caption}}/></span>
-		</$list>
+		<%endif%>
 	</$button>
 </$fieldmangler>
 \end

--- a/core/ui/ViewToolbar/clone.tid
+++ b/core/ui/ViewToolbar/clone.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/Clone/Hint}}
 
 \whitespace trim
 <$button message="tm-new-tiddler" param=<<currentTiddler>> tooltip={{$:/language/Buttons/Clone/Hint}} aria-label={{$:/language/Buttons/Clone/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/clone-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Clone/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>

--- a/core/ui/ViewToolbar/close-others.tid
+++ b/core/ui/ViewToolbar/close-others.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/CloseOthers/Hint}}
 
 \whitespace trim
 <$button message="tm-close-other-tiddlers" param=<<currentTiddler>> tooltip={{$:/language/Buttons/CloseOthers/Hint}} aria-label={{$:/language/Buttons/CloseOthers/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/close-others-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/CloseOthers/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>

--- a/core/ui/ViewToolbar/close.tid
+++ b/core/ui/ViewToolbar/close.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/Close/Hint}}
 
 \whitespace trim
 <$button message="tm-close-tiddler" tooltip={{$:/language/Buttons/Close/Hint}} aria-label={{$:/language/Buttons/Close/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/close-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Close/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>

--- a/core/ui/ViewToolbar/edit.tid
+++ b/core/ui/ViewToolbar/edit.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/Edit/Hint}}
 
 \whitespace trim
 <$button message="tm-edit-tiddler" tooltip={{$:/language/Buttons/Edit/Hint}} aria-label={{$:/language/Buttons/Edit/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/edit-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Edit/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>

--- a/core/ui/ViewToolbar/export-tiddler.tid
+++ b/core/ui/ViewToolbar/export-tiddler.tid
@@ -3,7 +3,4 @@ tags: $:/tags/ViewToolbar
 caption: {{$:/core/images/export-button}} {{$:/language/Buttons/ExportTiddler/Caption}}
 description: {{$:/language/Buttons/ExportTiddler/Hint}}
 
-\define makeExportFilter()
-[[$(currentTiddler)$]]
-\end
-<$macrocall $name="exportButton" exportFilter=<<makeExportFilter>> lingoBase="$:/language/Buttons/ExportTiddler/" baseFilename=<<currentTiddler>>/>
+<$transclude $variable="exportButton" exportFilter=`[[$(currentTiddler)$]]` lingoBase="$:/language/Buttons/ExportTiddler/" baseFilename=<<currentTiddler>>/>

--- a/core/ui/ViewToolbar/fold-others.tid
+++ b/core/ui/ViewToolbar/fold-others.tid
@@ -6,12 +6,12 @@ description: {{$:/language/Buttons/FoldOthers/Hint}}
 \whitespace trim
 <$button tooltip={{$:/language/Buttons/FoldOthers/Hint}} aria-label={{$:/language/Buttons/FoldOthers/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-fold-other-tiddlers" $param=<<currentTiddler>> foldedStatePrefix="$:/state/folded/"/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]" variable="listItem">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/fold-others-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/FoldOthers/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>

--- a/core/ui/ViewToolbar/fold.tid
+++ b/core/ui/ViewToolbar/fold.tid
@@ -7,26 +7,26 @@ description: {{$:/language/Buttons/Fold/Hint}}
 <$reveal type="nomatch" stateTitle=<<folded-state>> text="hide" default="show">
 <$button tooltip={{$:/language/Buttons/Fold/Hint}} aria-label={{$:/language/Buttons/Fold/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-fold-tiddler" $param=<<currentTiddler>> foldedState=<<folded-state>>/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]" variable="listItem">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/fold-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Fold/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>
 </$reveal>
 <$reveal type="match" stateTitle=<<folded-state>> text="hide" default="show">
 <$button tooltip={{$:/language/Buttons/Unfold/Hint}} aria-label={{$:/language/Buttons/Unfold/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-fold-tiddler" $param=<<currentTiddler>> foldedState=<<folded-state>>/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]" variable="listItem">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/unfold-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Unfold/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>
 </$reveal>

--- a/core/ui/ViewToolbar/info.tid
+++ b/core/ui/ViewToolbar/info.tid
@@ -4,31 +4,30 @@ caption: {{$:/core/images/info-button}} {{$:/language/Buttons/Info/Caption}}
 description: {{$:/language/Buttons/Info/Hint}}
 
 \whitespace trim
-\define button-content()
-\whitespace trim
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+\procedure button-content()
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/info-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Info/Caption}}/>
 </span>
-</$list>
+<%endif%>
 \end
 <$reveal state="$:/config/TiddlerInfo/Mode" type="match" text="popup">
 <$button popup=<<tiddlerInfoState>> tooltip={{$:/language/Buttons/Info/Hint}} aria-label={{$:/language/Buttons/Info/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<$macrocall $name="button-content" mode="inline"/>
+<$transclude $variable="button-content" $mode="inline"/>
 </$button>
 </$reveal>
 <$reveal state="$:/config/TiddlerInfo/Mode" type="match" text="sticky">
 <$reveal state=<<tiddlerInfoState>> type="match" text="" default="">
 <$button set=<<tiddlerInfoState>> setTo="yes" tooltip={{$:/language/Buttons/Info/Hint}} aria-label={{$:/language/Buttons/Info/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<$macrocall $name="button-content" mode="inline"/>
+<$transclude $variable="button-content" $mode="inline"/>
 </$button>
 </$reveal>
 <$reveal state=<<tiddlerInfoState>> type="nomatch" text="" default="">
 <$button set=<<tiddlerInfoState>> setTo="" tooltip={{$:/language/Buttons/Info/Hint}} aria-label={{$:/language/Buttons/Info/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<$macrocall $name="button-content" mode="inline"/>
+<$transclude $variable="button-content" $mode="inline"/>
 </$button>
 </$reveal>
 </$reveal>

--- a/core/ui/ViewToolbar/more-tiddler-actions.tid
+++ b/core/ui/ViewToolbar/more-tiddler-actions.tid
@@ -4,7 +4,6 @@ caption: {{$:/core/images/down-arrow}} {{$:/language/Buttons/More/Caption}}
 description: {{$:/language/Buttons/More/Hint}}
 
 \whitespace trim
-\define config-title() $:/config/ViewToolbarButtons/Visibility/$(listItem)$
 
 <$button popup=<<qualify "$:/state/popup/more">>
 	tooltip={{$:/language/Buttons/More/Hint}}
@@ -12,33 +11,29 @@ description: {{$:/language/Buttons/More/Hint}}
 	class=<<tv-config-toolbar-class>>
 	selectedClass="tc-selected"
 >
-	<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+	<%if [<tv-config-toolbar-icons>match[yes]] %>
 		{{$:/core/images/down-arrow}}
-	</$list>
-	<$list filter="[<tv-config-toolbar-text>match[yes]]">
+	<%endif%>
+	<%if [<tv-config-toolbar-text>match[yes]] %>
 		<span class="tc-btn-text">
 			<$text text={{$:/language/Buttons/More/Caption}}/>
 		</span>
-	</$list>
+	<%endif%>
 </$button>
 <$reveal state=<<qualify "$:/state/popup/more">> type="popup" position="belowleft" animate="yes">
 	<div class="tc-drop-down">
-		<$set name="tv-config-toolbar-icons" value="yes">
-			<$set name="tv-config-toolbar-text" value="yes">
-				<$set name="tv-config-toolbar-class" value="tc-btn-invisible">
-					<$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbar]!has[draft.of]] -[[$:/core/ui/Buttons/more-tiddler-actions]]"
-						variable="listItem"
+		<$let tv-config-toolbar-icons="yes" tv-config-toolbar-text="yes" tv-config-toolbar-class="tc-btn-invisible">
+			<$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbar]!has[draft.of]] -[[$:/core/ui/Buttons/more-tiddler-actions]]"
+				variable="listItem"
+			>
+				<$reveal type="match" state=`$:/config/ViewToolbarButtons/Visibility/$(listItem)$` text="hide">
+					<$set name="tv-config-toolbar-class"
+						filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]"
 					>
-						<$reveal type="match" state=<<config-title>> text="hide">
-							<$set name="tv-config-toolbar-class"
-								filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]"
-							>
-								<$transclude tiddler=<<listItem>> mode="inline"/>
-							</$set>
-						</$reveal>
-					</$list>
-				</$set>
-			</$set>
-		</$set>
+						<$transclude tiddler=<<listItem>> mode="inline"/>
+					</$set>
+				</$reveal>
+			</$list>
+		</$let>
 	</div>
 </$reveal>

--- a/core/ui/ViewToolbar/new-here.tid
+++ b/core/ui/ViewToolbar/new-here.tid
@@ -4,23 +4,21 @@ caption: {{$:/core/images/new-here-button}} {{$:/language/Buttons/NewHere/Captio
 description: {{$:/language/Buttons/NewHere/Hint}}
 
 \whitespace trim
-\define newHereActions()
-\whitespace trim
+\procedure newHereActions()
 <$set name="tags" filter="[<currentTiddler>] [enlist{$:/config/NewTiddler/Tags}]">
 <$action-sendmessage $message="tm-new-tiddler" tags=<<tags>>/>
 </$set>
 \end
-\define newHereButton()
-\whitespace trim
+\procedure newHereButton()
 <$button actions=<<newHereActions>> tooltip={{$:/language/Buttons/NewHere/Hint}} aria-label={{$:/language/Buttons/NewHere/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/new-here-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/NewHere/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>
 \end
 <<newHereButton>>

--- a/core/ui/ViewToolbar/new-journal-here.tid
+++ b/core/ui/ViewToolbar/new-journal-here.tid
@@ -4,29 +4,21 @@ caption: {{$:/core/images/new-journal-button}} {{$:/language/Buttons/NewJournalH
 description: {{$:/language/Buttons/NewJournalHere/Hint}}
 
 \whitespace trim
-\define journalButtonTags()
-[[$(currentTiddlerTag)$]] $(journalTags)$
-\end
-\define journalButton()
-\whitespace trim
+\procedure journalButton()
 <$button tooltip={{$:/language/Buttons/NewJournalHere/Hint}} aria-label={{$:/language/Buttons/NewJournalHere/Caption}} class=<<tv-config-toolbar-class>>>
-<$wikify name="journalTitle" text="""<$macrocall $name="now" format=<<journalTitleTemplate>>/>""">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<journalButtonTags>>/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<$wikify name="journalTitle" text="""<$transclude $variable="now" format=<<journalTitleTemplate>>/>""">
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=`[[$(currentTiddlerTag)$]] $(journalTags)$`/>
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/new-journal-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/NewJournalHere/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$wikify>
 </$button>
 \end
-<$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>
-<$set name="journalTags" value={{$:/config/NewJournal/Tags}}>
-<$set name="currentTiddlerTag" value=<<currentTiddler>>>
+<$let journalTitleTemplate={{$:/config/NewJournal/Title}} journalTags={{$:/config/NewJournal/Tags}} currentTiddlerTag=<<currentTiddler>>>
 <<journalButton>>
-</$set>
-</$set>
-</$set>
+</$let>

--- a/core/ui/ViewToolbar/open-window.tid
+++ b/core/ui/ViewToolbar/open-window.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/OpenWindow/Hint}}
 
 \whitespace trim
 <$button message="tm-open-window" tooltip={{$:/language/Buttons/OpenWindow/Hint}} aria-label={{$:/language/Buttons/OpenWindow/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/open-window}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/OpenWindow/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>

--- a/core/ui/ViewToolbar/permalink.tid
+++ b/core/ui/ViewToolbar/permalink.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/Permalink/Hint}}
 
 \whitespace trim
 <$button message="tm-permalink" tooltip={{$:/language/Buttons/Permalink/Hint}} aria-label={{$:/language/Buttons/Permalink/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/permalink-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Permalink/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>

--- a/core/ui/ViewToolbar/permaview.tid
+++ b/core/ui/ViewToolbar/permaview.tid
@@ -5,12 +5,12 @@ description: {{$:/language/Buttons/Permaview/Hint}}
 
 \whitespace trim
 <$button message="tm-permaview" tooltip={{$:/language/Buttons/Permaview/Hint}} aria-label={{$:/language/Buttons/Permaview/Caption}} class=<<tv-config-toolbar-class>>>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/permaview-button}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/language/Buttons/Permaview/Caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>

--- a/plugins/tiddlywiki/qrcode/ViewToolbarButton/Button.tid
+++ b/plugins/tiddlywiki/qrcode/ViewToolbarButton/Button.tid
@@ -8,50 +8,28 @@ description: Generate QR code for this tiddler
 \whitespace trim
 <span class="tc-popup-keep">
 <$button popup=<<qualify "$:/state/popup/qrcode">> tooltip={{$:/plugins/tiddlywiki/qrcode/ViewToolbarButton!!description}} aria-label={{$:/plugins/tiddlywiki/qrcode/ViewToolbarButton!!short-caption}} class=<<tv-config-toolbar-class>> class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/plugins/tiddlywiki/qrcode/icon}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">
 <$text text={{$:/plugins/tiddlywiki/qrcode/ViewToolbarButton!!short-caption}}/>
 </span>
-</$list>
+<%endif%>
 </$button>
 </span>
 <$reveal state=<<qualify "$:/state/popup/qrcode">> type="popup" position="below" animate="yes">
+    <div class="tc-drop-down">
 
-<div class="tc-drop-down">
+    {{$:/plugins/tiddlywiki/qrcode/ViewToolbarButton||description}}
 
-{{$:/plugins/tiddlywiki/qrcode/ViewToolbarButton||description}}
-
-<$set name="tv-config-toolbar-icons" value="yes">
-
-<$set name="tv-config-toolbar-text" value="yes">
-
-<$set name="tv-config-toolbar-class" value="tc-btn-invisible">
-
-<$set name="targetTiddler" value=<<currentTiddler>>>
-
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbarButton/QRcode]!has[draft.of]]">
-
-<$button popup=<<qualify "$:/state/popup/qrcode/type">> class="tc-btn-invisible" selectedClass="tc-selected">
-
-<$action-sendmessage $message="tm-modal" $param=<<currentTiddler>> currentTiddler=<<targetTiddler>>/>
-
-<$transclude field="caption" mode="inline"/>
-
-</$button>
-
-</$list>
-
-</$set>
-
-</$set>
-
-</$set>
-
-</$set>
-
-</div>
-
+        <$let tv-config-toolbar-icons="yes" tv-config-toolbar-text="yes" tv-config-toolbar-class="tc-btn-invisible" targetTiddler=<<currentTiddler>>>
+            <$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbarButton/QRcode]!has[draft.of]]">
+                <$button popup=<<qualify "$:/state/popup/qrcode/type">> class="tc-btn-invisible" selectedClass="tc-selected">
+                    <$action-sendmessage $message="tm-modal" $param=<<currentTiddler>> currentTiddler=<<targetTiddler>>/>
+                    <$transclude field="caption" mode="inline"/>
+                </$button>
+            </$list>
+        </$let>
+    </div>
 </$reveal>

--- a/plugins/tiddlywiki/text-slicer/ui/slice-toolbar-button.tid
+++ b/plugins/tiddlywiki/text-slicer/ui/slice-toolbar-button.tid
@@ -6,18 +6,18 @@ description: Slice this text tiddler by headings and lists
 
 \whitespace trim
 
-\define hint()
+\procedure hint()
 Slice this text tiddler into chunks
 \end
 
 <$list filter="[<currentTiddler>!is[image]!is[binary]]" variable="ignore">
 <$button tooltip=<<hint>> aria-label=<<hint>> class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-modal" $param="$:/plugins/tiddlywiki/text-slicer/ui/slice-modal" currentTiddler=<<currentTiddler>>/>
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+<%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/plugins/tiddlywiki/text-slicer/images/text-slicer-icon}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<%endif%>
+<%if [<tv-config-toolbar-text>match[yes]] %>
 <span class="tc-btn-text">Slice tiddler</span>
-</$list>
+<%endif%>
 </$button>
 </$list>


### PR DESCRIPTION
A further rewrite after #8579 .

Update toolbar buttons to use new syntax. Including:

* Replace some list widget with conditional shortcut syntax
* Replace macrocall widget with transclude widget
* Replace some macros with procedures and Substituted Attribute Values
* Replace multiple set widgets with let widget