### PR TITLE
Add a settings page for markdown plugin

### DIFF
--- a/plugins/tiddlywiki/markdown/config.tid
+++ b/plugins/tiddlywiki/markdown/config.tid
@@ -2,8 +2,6 @@ title: $:/plugins/tiddlywiki/markdown/config
 
 ! Plugin Configuration
 
-{{$:/plugins/tiddlywiki/markdown/settings}}
-
 <h2 style="margin-top:1.5em">~WikiText Pragma</h2>
 
 The value of [[renderWikiTextPragma|$:/config/markdown/renderWikiTextPragma]] has been carefully tuned to properly integrate markdown with ~TiddlyWiki. Changing this setting may produce unexpected results, but the inclusion of the following parser rules should be fine:

--- a/plugins/tiddlywiki/markdown/config.tid
+++ b/plugins/tiddlywiki/markdown/config.tid
@@ -2,15 +2,7 @@ title: $:/plugins/tiddlywiki/markdown/config
 
 ! Plugin Configuration
 
-|!Config |!Default |!Description |
-|[[breaks|$:/config/markdown/breaks]]|`false`|markdown-it library config: Convert '\n' in paragraphs into `<br>` |
-|[[linkify|$:/config/markdown/linkify]]|`false`|markdown-it library config: Autoconvert URL-like text to links |
-|[[renderWikiText|$:/config/markdown/renderWikiText]]|`true`|After Markdown is parsed, should any text elements be handed off to the ~WikiText parser for further processing? |
-|[[renderWikiTextPragma|$:/config/markdown/renderWikiTextPragma]]|<code><$view tiddler="$:/plugins/tiddlywiki/markdown" subtiddler="$:/config/markdown/renderWikiTextPragma" mode="inline"/></code>|When handing off to the ~WikiText parser, what parser rules should it follow? |
-|[[typographer|$:/config/markdown/typographer]]|`false`|markdown-it library config: Enable some language-neutral replacement + quotes beautification |
-|[[quotes|$:/config/markdown/quotes]]|`“”‘’`|markdown-it library config: Double + single quotes replacement pairs, when `typographer` is enabled |
-
-''IMPORTANT:'' You must reload your wiki for changes to take effect.
+{{$:/plugins/tiddlywiki/markdown/settings}}
 
 <h2 style="margin-top:1.5em">~WikiText Pragma</h2>
 

--- a/plugins/tiddlywiki/markdown/plugin.info
+++ b/plugins/tiddlywiki/markdown/plugin.info
@@ -2,6 +2,6 @@
 	"title": "$:/plugins/tiddlywiki/markdown",
 	"name": "Markdown",
 	"description": "Markdown parser based on markdown-it",
-	"list": "readme config syntax license",
+	"list": "readme config settings syntax license",
 	"stability": "STABILITY_2_STABLE"
 }

--- a/plugins/tiddlywiki/markdown/settings.tid
+++ b/plugins/tiddlywiki/markdown/settings.tid
@@ -2,7 +2,7 @@ title: $:/plugins/tiddlywiki/markdown/settings
 tags: $:/tags/ControlPanel/SettingsTab
 caption: Markdown
 
-These settings let you customise the behaviour of Markdown.
+These settings let you customise the behaviour of Markdown. See [[plugin|$:/plugins/tiddlywiki/markdown]] readme and config tab for more information.
 
 ''IMPORTANT:'' You must reload your wiki for changes to take effect.
 

--- a/plugins/tiddlywiki/markdown/settings.tid
+++ b/plugins/tiddlywiki/markdown/settings.tid
@@ -1,0 +1,19 @@
+title: $:/plugins/tiddlywiki/markdown/settings
+tags: $:/tags/ControlPanel/SettingsTab
+caption: Markdown
+
+These settings let you customise the behaviour of Markdown.
+
+''IMPORTANT:'' You must reload your wiki for changes to take effect.
+
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Settings/Markdown]]">
+
+<div class="tc-control-panel-setting" data-setting-title=<<currentTiddler>> >
+
+!!.tc-control-panel-accent <$link><$transclude field="caption"/></$link>
+
+<$transclude/>
+
+</div>
+
+</$list>

--- a/plugins/tiddlywiki/markdown/settings/breaks.tid
+++ b/plugins/tiddlywiki/markdown/settings/breaks.tid
@@ -1,0 +1,9 @@
+title: $:/plugins/tiddlywiki/markdown/settings/breaks
+tags: $:/tags/ControlPanel/Settings/Markdown
+caption: Breaks
+
+markdown-it library config: Convert `\n` in paragraphs into `<br>`
+
+<$checkbox tiddler="$:/config/markdown/breaks" field="text" checked="true" unchecked="false">
+    [[Breaks|$:/config/markdown/breaks]]
+</$checkbox>

--- a/plugins/tiddlywiki/markdown/settings/linkify.tid
+++ b/plugins/tiddlywiki/markdown/settings/linkify.tid
@@ -1,0 +1,9 @@
+title: $:/plugins/tiddlywiki/markdown/settings/linkify
+tags: $:/tags/ControlPanel/Settings/Markdown
+caption: Linkify
+
+markdown-it library config: Autoconvert URL-like text to links
+
+<$checkbox tiddler="$:/config/markdown/linkify" field="text" checked="true" unchecked="false">
+    [[Linkify|$:/config/markdown/linkify]]
+</$checkbox>

--- a/plugins/tiddlywiki/markdown/settings/quotes.tid
+++ b/plugins/tiddlywiki/markdown/settings/quotes.tid
@@ -1,0 +1,7 @@
+title: $:/plugins/tiddlywiki/markdown/settings/quotes
+tags: $:/tags/ControlPanel/Settings/Markdown
+caption: Quotes replacement
+
+markdown-it library config: Double + single quotes replacement pairs, when [[typographer|$:/config/markdown/typographer]] is enabled.
+
+|[[Quotes replacement|$:/config/markdown/quotes]]|<$edit-text tiddler="$:/config/markdown/quotes" tag="input"/> |

--- a/plugins/tiddlywiki/markdown/settings/quotes.tid
+++ b/plugins/tiddlywiki/markdown/settings/quotes.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/tiddlywiki/markdown/settings/quotes
 tags: $:/tags/ControlPanel/Settings/Markdown
 caption: Quotes replacement
+list-after: $:/plugins/tiddlywiki/markdown/settings/typographer
 
 markdown-it library config: Double + single quotes replacement pairs, when [[typographer|$:/config/markdown/typographer]] is enabled.
 

--- a/plugins/tiddlywiki/markdown/settings/renderWikiText.tid
+++ b/plugins/tiddlywiki/markdown/settings/renderWikiText.tid
@@ -5,5 +5,5 @@ caption: Enable WikiText
 After Markdown is parsed, should any text elements be handed off to the ~WikiText parser for further processing?
 
 <$checkbox tiddler="$:/config/markdown/renderWikiText" field="text" checked="true" unchecked="false">
-    Enable WikiText
+    [[Enable WikiText|$:/config/markdown/renderWikiText]]
 </$checkbox>

--- a/plugins/tiddlywiki/markdown/settings/renderWikiText.tid
+++ b/plugins/tiddlywiki/markdown/settings/renderWikiText.tid
@@ -1,0 +1,9 @@
+title: $:/plugins/tiddlywiki/markdown/settings/renderWikiText
+tags: $:/tags/ControlPanel/Settings/Markdown
+caption: Enable WikiText
+
+After Markdown is parsed, should any text elements be handed off to the ~WikiText parser for further processing?
+
+<$checkbox tiddler="$:/config/markdown/renderWikiText" field="text" checked="true" unchecked="false">
+    Enable WikiText
+</$checkbox>

--- a/plugins/tiddlywiki/markdown/settings/renderWikiTextPragma.tid
+++ b/plugins/tiddlywiki/markdown/settings/renderWikiTextPragma.tid
@@ -1,0 +1,7 @@
+title: $:/plugins/tiddlywiki/markdown/settings/renderWikiTextPragma
+tags: $:/tags/ControlPanel/Settings/Markdown
+caption: Enabled WikiText parser rules
+
+When handing off to the ~WikiText parser, what parser rules should it follow?
+
+|[[Enabled WikiText parser rules|$:/config/markdown/renderWikiTextPragma]]|<$edit tiddler="$:/config/markdown/renderWikiTextPragma" class="tc-edit-texteditor" autoHeight="yes"/> |

--- a/plugins/tiddlywiki/markdown/settings/typographer.tid
+++ b/plugins/tiddlywiki/markdown/settings/typographer.tid
@@ -1,0 +1,9 @@
+title: $:/plugins/tiddlywiki/markdown/settings/typographer
+tags: $:/tags/ControlPanel/Settings/Markdown
+caption: Typographer
+
+markdown-it library config: Enable some language-neutral replacement + quotes beautification
+
+<$checkbox tiddler="$:/config/markdown/typographer" field="text" checked="true" unchecked="false">
+    [[Typographer|$:/config/markdown/typographer]]
+</$checkbox>


### PR DESCRIPTION
The table in `$:/plugins/tiddlywiki/markdown/config` isn't convenient to edit configuations for markdown plugin, and it also causes the page to overflow in mobile devices.

This PR add a settings page for markdown plugin under the "Settings" tab in control panel, which is convenient to edit settings. It also removes the overflowed table in `$:/plugins/tiddlywiki/markdown/config`.