### PR TITLE
Remove unrealistic font-size from import-button

### DIFF
--- a/plugins/tiddlywiki/upgrade/styles.tid
+++ b/plugins/tiddlywiki/upgrade/styles.tid
@@ -48,7 +48,6 @@ tags: $:/tags/Stylesheet
 	left: 0;
 	right: 0;
 	bottom: 0;
-	font-size: 999px;
 	max-width: 100%;
 	max-height: 100%;
 	filter: alpha(opacity=0);

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -3024,13 +3024,12 @@ html body.tc-dirty span.tc-dirty-indicator, html body.tc-dirty span.tc-dirty-ind
 	position: absolute;
 	top: 0;
 	left: 0;
-	right: 0;
-	bottom: 0;
+	width: 100%;
+	height: 100%;
 	max-width: 100%;
 	max-height: 100%;
-	filter: alpha(opacity=0);
 	opacity: 0;
-	outline: none;
+	<!-- outline: none; -->
 	background: white;
 	cursor: pointer;
 	display: inline-block;

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -3026,7 +3026,6 @@ html body.tc-dirty span.tc-dirty-indicator, html body.tc-dirty span.tc-dirty-ind
 	left: 0;
 	right: 0;
 	bottom: 0;
-	font-size: 999px;
 	max-width: 100%;
 	max-height: 100%;
 	filter: alpha(opacity=0);

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -3029,7 +3029,7 @@ html body.tc-dirty span.tc-dirty-indicator, html body.tc-dirty span.tc-dirty-ind
 	max-width: 100%;
 	max-height: 100%;
 	opacity: 0;
-	<!-- outline: none; -->
+	outline: none;
 	background: white;
 	cursor: pointer;
 	display: inline-block;


### PR DESCRIPTION
This PR fixes #8167

- #8167 

It removes unrealistic font-size from import-button -- Edge on Windows 3D-view shows it as fixed.

![image](https://github.com/user-attachments/assets/c8d6c2bb-87ad-4da9-9690-b113221756a8)
