### PR TITLE
Add drag and drop handling for export macro & rewrite using v5.3.2 syntax

### DIFF
--- a/core/wiki/macros/export.tid
+++ b/core/wiki/macros/export.tid
@@ -1,14 +1,14 @@
 title: $:/core/macros/export
-tags: $:/tags/Macro
+tags: $:/tags/Macro $:/tags/Global
 
-\define exportButtonFilename(baseFilename)
-$baseFilename$$(extension)$
+\function exportButtonFilename(baseFilename)
+[<baseFilename>] [<extension>] +[join[]]
 \end
 
-\define exportButton(exportFilter:"[!is[system]sort[title]]",lingoBase,baseFilename:"tiddlers")
+\procedure exportButton(exportFilter:"[!is[system]sort[title]]",lingoBase,baseFilename:"tiddlers")
 \whitespace trim
-<$vars hint={{{ [<__lingoBase__>addsuffix[Hint]get[text]] }}}
-	caption={{{  [<__lingoBase__>addsuffix[Caption]get[text]] }}}
+<$let hint={{{ [<lingoBase>addsuffix[Hint]get[text]] }}}
+	caption={{{  [<lingoBase>addsuffix[Caption]get[text]] }}}
 >
 	<span class="tc-popup-keep">
 		<$button popup=<<qualify "$:/state/popup/export">>
@@ -16,19 +16,20 @@ $baseFilename$$(extension)$
 			aria-label=<<caption>>
 			class=<<tv-config-toolbar-class>>
 			selectedClass="tc-selected"
+			dragFilter=<<exportFilter>>
 		>
-			<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+			<%if [<tv-config-toolbar-icons>match[yes]] %>
 				{{$:/core/images/export-button}}
-			</$list>
-			<$list filter="[<tv-config-toolbar-text>match[yes]]">
+			<%endif%>
+			<%if [<tv-config-toolbar-text>match[yes]] %>
 				<span class="tc-btn-text"><$text text=<<caption>>/></span>
-			</$list>
+			<%endif%>
 		</$button>
 	</span>
-</$vars>
+</$let>
 <$reveal state=<<qualify "$:/state/popup/export">> type="popup" position="below" animate="yes">
 	<div class="tc-drop-down">
-		<$set name="count" value={{{ [subfilter<__exportFilter__>count[]] }}}>
+		<$set name="count" value={{{ [subfilter<exportFilter>count[]] }}}>
 			<$list filter="[all[shadows+tiddlers]tag[$:/tags/Exporter]]">
 				<$list filter="[<currentTiddler>has[condition]subfilter{!!condition}limit[1]] ~[<currentTiddler>!has[condition]then[true]]"
 					variable="ignore"
@@ -36,8 +37,8 @@ $baseFilename$$(extension)$
 					<$button class="tc-btn-invisible">
 						<$action-sendmessage $message="tm-download-file"
 							$param=<<currentTiddler>>
-							exportFilter=<<__exportFilter__>>
-							filename={{{ [<__baseFilename__>addsuffix{!!extension}] }}}
+							exportFilter=<<exportFilter>>
+							filename={{{ [<baseFilename>addsuffix{!!extension}] }}}
 						/>
 						<$action-deletetiddler $tiddler=<<qualify "$:/state/popup/export">>/>
 						<$transclude field="description"/>


### PR DESCRIPTION
This PR closes #8497 .

Add drag and drop handling for export macro & rewrite it using v5.3.2 syntax as suggested in [this comment](https://github.com/TiddlyWiki/TiddlyWiki5/issues/8497#issuecomment-2277283396).