### PR TITLE
[DOCS] Deprecate D3 and Mobile Drag and Drop plugin

### DIFF
--- a/editions/tw5.com/tiddlers/plugins/D3 Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/D3 Plugin.tid
@@ -1,11 +1,11 @@
 created: 20160107223425581
-list: 
-modified: 20170228102531138
-tags: OfficialPlugins [[Plugin Editions]]
+caption: {{!!title}} - deprecated
+modified: 20240913122437925
+tags: OfficialPlugins [[Plugin Editions]] $:/deprecated
 title: D3 Plugin
 type: text/vnd.tiddlywiki
 
-The D3 plugin integrates the D3 visualisation library with TiddlyWiki.
+<<.deprecated-since "5.3.4">> The D3 plugin integrates the D3 visualisation library with TiddlyWiki.
 
 See https://tiddlywiki.com/plugins/tiddlywiki/d3/
 

--- a/editions/tw5.com/tiddlers/plugins/D3 Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/D3 Plugin.tid
@@ -1,5 +1,5 @@
 created: 20160107223425581
-caption: {{!!title}} - deprecated
+caption: {{!!title}} - ^^deprecated^^
 modified: 20240913122437925
 tags: OfficialPlugins [[Plugin Editions]] $:/deprecated
 title: D3 Plugin

--- a/editions/tw5.com/tiddlers/plugins/Mobile Drag And Drop Shim Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Mobile Drag And Drop Shim Plugin.tid
@@ -1,5 +1,5 @@
 created: 20170328173820802
-caption: {{!!title}} - deprecated
+caption: {{!!title}} - ^^deprecated^^
 modified: 20240913122844238
 tags: OfficialPlugins $:/deprecated
 title: Mobile Drag And Drop Shim Plugin

--- a/editions/tw5.com/tiddlers/plugins/Mobile Drag And Drop Shim Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Mobile Drag And Drop Shim Plugin.tid
@@ -1,7 +1,8 @@
 created: 20170328173820802
-modified: 20170328174328792
-tags: OfficialPlugins
+caption: {{!!title}} - deprecated
+modified: 20240913122844238
+tags: OfficialPlugins $:/deprecated
 title: Mobile Drag And Drop Shim Plugin
 type: text/vnd.tiddlywiki
 
-The Mobile Drag And Drop Shim Plugin provides a "shim" that enables HTML 5 compatible drag and drop operations on mobile browsers, including iOS and Android. The shim was created by Tim Ruffles and is published at https://github.com/timruffles/ios-html5-drag-drop-shim.
+<<.deprecated-since "5.3.4">> The Mobile Drag And Drop Shim Plugin provides a "shim" that enables HTML 5 compatible drag and drop operations on mobile browsers, including iOS and Android. The shim was created by Tim Ruffles and is published at https://github.com/timruffles/ios-html5-drag-drop-shim.


### PR DESCRIPTION
Deprecate D3 and Mobile Drag and Drop plugin that is marked deprecated
since 5.3.4
