### PR TITLE
Add comment to vanilla base if "editorfontfamily" shall be used

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1297,7 +1297,7 @@ button.tc-btn-invisible.tc-remove-tag-button {
 	padding: 3px 3px 3px 3px;
 	border: 1px solid <<colour tiddler-editor-border>>;
 	line-height: 1.3em;
-	font-family: {{$:/themes/tiddlywiki/vanilla/settings/editorfontfamily}};
+	font-family: {{$:/themes/tiddlywiki/vanilla/settings/editorfontfamily}}; // is this on purpose?
 }
 
 .tc-tiddler-frame input.tc-edit-texteditor,


### PR DESCRIPTION
The base stylesheet defines a font-family transcluding a system tiddler that doesn't exist (editorfontfamily)

For now I've just added a comment if this is on purpose