### PR TITLE
Seperate clear cookie and disable actions in Browser Storage Plugin

### DIFF
--- a/plugins/tiddlywiki/browser-storage/startup.js
+++ b/plugins/tiddlywiki/browser-storage/startup.js
@@ -54,6 +54,13 @@ exports.startup = function() {
 		$tw.wiki.addTiddler({title: ENABLED_TITLE, text: "no"});
 		$tw.browserStorage.clearLocalStorage();
 	});
+	// Seperate clear cookie and disable action
+	$tw.rootWidget.addEventListener("tm-delete-browser-storage",function(event) {
+		$tw.browserStorage.clearLocalStorage();
+	});
+	$tw.rootWidget.addEventListener("tm-disable-browser-storage",function(event) {
+		$tw.wiki.addTiddler({title: ENABLED_TITLE, text: "no"});
+	});
 	// Helpers for protecting storage from eviction
 	var setPersistedState = function(state) {
 			$tw.wiki.addTiddler({title: PERSISTED_STATE_TITLE, text: state});


### PR DESCRIPTION
The Browser Storage plugin has a `tm-clear-browser-storage` action which deletes the cookie saved by the plugin and disables browser storage. I think it's better to seperate the two actions so that users can clear the saved cookies without disabling browser storage.

This PR adds two messages:
* `tm-delete-browser-storage` for deleting the cookie saved by the Browser Storage plugin
* `tm-disable-browser-storage` for disabling Browser Storage