### PR TITLE
Fix missing tiddler with code body isn't displayed properly.

### DIFF
--- a/core/ui/ViewTemplate/body/code.tid
+++ b/core/ui/ViewTemplate/body/code.tid
@@ -1,4 +1,8 @@
 title: $:/core/ui/ViewTemplate/body/code
 
+<%if [<currentTiddler>is[missing]] %>
+<$transclude tiddler="$:/language/MissingTiddler/Hint"/>
+<%else%>
 <$transclude $variable="copy-to-clipboard-above-right" src={{{ [<currentTiddler>get[text]] }}} />
 <$codeblock code={{{ [<currentTiddler>get[text]] }}} language={{{ [<currentTiddler>get[type]else[text/vnd.tiddlywiki]] }}}/>
+<%endif%>


### PR DESCRIPTION
This PR fixes missing tiddlers that are matched in `$:/config/ViewTemplateBodyFilters/system` isn't displayed properly.

![图片](https://github.com/user-attachments/assets/1828ad7c-9af3-402f-bd19-c55f5157a50f)
