### PR TITLE
Fix extra p tag in colour-picker

### DIFF
--- a/core/wiki/macros/colour-picker.tid
+++ b/core/wiki/macros/colour-picker.tid
@@ -10,9 +10,7 @@ tags: $:/tags/Macro
 
 \define colour-picker-inner(actions)
 <$button tag="a" tooltip="""$(colour-picker-value)$""">
-
 $(colour-picker-update-recent)$
-
 <$transclude $variable="__actions__"/>
 
 <span style="display:inline-block; background-color: $(colour-picker-value)$; width: 100%; height: 100%; border-radius: 50%;"/>


### PR DESCRIPTION
The following code didn't display correctly in tiddlywiki, the color circle is displayed lower:

```
\procedure color-picker-actions()
<$action-setfield $tiddler=<<currentTiddler>> color=<<colour-picker-value>>/>
\end

<$transclude $variable="colour-picker" actions=<<color-picker-actions>>/>
```

I found that the p tag may be created when the `actions` parameter isn't empty. After I removed two newline the problem was solved.

![图片](https://github.com/user-attachments/assets/ad6332dd-913b-4507-acab-37b4b0eb9eaa)
