### PR TITLE
Fix overflow in table and table-of-contents

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2779,6 +2779,20 @@ a.tc-tiddlylink.tc-plugin-info:hover > .tc-plugin-info-chunk .tc-plugin-info-sta
 	display: table;
 }
 
+/* Fix overflow in table and toc */
+.tc-tiddler-body .tc-tabbed-table-of-contents {
+	overflow-x: auto;
+}
+
+.tc-tiddler-body > table {
+  display: block;
+  overflow: auto;
+}
+.tc-tiddler-body > table tbody {
+  display: table;
+  width: 100%;
+}
+
 /*
 ** Chooser
 */


### PR DESCRIPTION
Another approach to fix #8523 . The fix for table overflow used code suggested in the [Itonnote theme](https://github.com/tiddly-gittly/itonnote-theme).