### PR TITLE
Fix shadow tiddler with code body displayed as missing

### DIFF
--- a/core/ui/ViewTemplate/body/code.tid
+++ b/core/ui/ViewTemplate/body/code.tid
@@ -1,6 +1,6 @@
 title: $:/core/ui/ViewTemplate/body/code
 
-<%if [<currentTiddler>is[missing]] %>
+<%if [<currentTiddler>is[missing]] :and[!is[shadow]] %>
 <$transclude tiddler="$:/language/MissingTiddler/Hint"/>
 <%else%>
 <$transclude $variable="copy-to-clipboard-above-right" src={{{ [<currentTiddler>get[text]] }}} />


### PR DESCRIPTION
Fix problem introduced in #8604

![图片](https://github.com/user-attachments/assets/91ab04e1-f063-41a8-963e-fb92546e0abc)
