### PR TITLE
Fix colour-picker dropdown auto close when selecting or typing a color

### DIFF
--- a/core/ui/TagManager.tid
+++ b/core/ui/TagManager.tid
@@ -55,7 +55,7 @@ color: #bbb
 \whitespace trim
 <div class="tc-drop-down-wrapper">
 <$button class="tc-btn-invisible" popup={{{ [[$:/state/tag-manager/color/]addsuffix<currentTiddler>] }}}>{{$:/core/images/palette}}</$button>
-<$reveal type="popup" tag="div" class="tc-drop-down" state={{{ [[$:/state/tag-manager/color/]addsuffix<currentTiddler>] }}}>
+<$reveal type="popup" tag="div" class="tc-drop-down tc-popup-keep" state={{{ [[$:/state/tag-manager/color/]addsuffix<currentTiddler>] }}}>
 <$transclude $variable="colour-picker" actions=<<color-picker-actions>>/>
 </$reveal>
 </div>


### PR DESCRIPTION
See the second problem described in [this comment](https://github.com/TiddlyWiki/TiddlyWiki5/pull/8606#issuecomment-2353405004)