### PR TITLE
Make stability badge text translatable

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -96,6 +96,10 @@ Plugins/PluginWillRequireReload: (requires reload)
 Plugins/Plugins/Caption: Plugins
 Plugins/Plugins/Hint: Plugins
 Plugins/Reinstall/Caption: reinstall
+Plugins/Stability/Deprecated: DEPRECATED
+Plugins/Stability/Experimental: EXPERIMENTAL
+Plugins/Stability/Legacy: LEGACY
+Plugins/Stability/Stable: STABLE
 Plugins/Themes/Caption: Themes
 Plugins/Themes/Hint: Theme plugins
 Plugins/Update/Caption: update

--- a/core/ui/Components/plugin-info.tid
+++ b/core/ui/Components/plugin-info.tid
@@ -47,13 +47,13 @@ $:/config/Plugins/Disabled/$(currentTiddler)$
 	<h2>
 		<div>
 			<%if [<currentTiddler>get[stability]match[STABILITY_0_DEPRECATED]] %>
-				<span class="tc-plugin-info-stability tc-plugin-info-stability-deprecated">DEPRECATED</span>
+				<span class="tc-plugin-info-stability tc-plugin-info-stability-deprecated"><<lingo "Stability/Deprecated">></span>
 			<%elseif [<currentTiddler>get[stability]match[STABILITY_1_EXPERIMENTAL]] %>
-				<span class="tc-plugin-info-stability tc-plugin-info-stability-experimental">EXPERIMENTAL</span>
+				<span class="tc-plugin-info-stability tc-plugin-info-stability-experimental"><<lingo "Stability/Experimental">></span>
 			<%elseif [<currentTiddler>get[stability]match[STABILITY_2_STABLE]] %>
-				<span class="tc-plugin-info-stability tc-plugin-info-stability-stable">STABLE</span>
+				<span class="tc-plugin-info-stability tc-plugin-info-stability-stable"><<lingo "Stability/Stable">></span>
 			<%elseif [<currentTiddler>get[stability]match[STABILITY_3_LEGACY]] %>
-				<span class="tc-plugin-info-stability tc-plugin-info-stability-legacy">LEGACY</span>
+				<span class="tc-plugin-info-stability tc-plugin-info-stability-legacy"><<lingo "Stability/Legacy">></span>
 			<%endif%>
 			<em><$view field="version"/></em></div>
 	</h2>


### PR DESCRIPTION
Added four translatable string in `ControlPanel.multids` to make the text in the stability badge translatable.