### PR TITLE
docs: fix typo in a wikilink

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/parser/Places where the parser ignores WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/Places where the parser ignores WikiText.tid
@@ -1,6 +1,6 @@
 caption: ignore parser mode
 created: 20220111000929700
-modified: 20220122182842038
+modified: 20240921085112396
 tags: [[WikiText Parser Modes]]
 title: Places where the parser ignores WikiText
 type: text/vnd.tiddlywiki
@@ -10,5 +10,5 @@ Text enclosed by these constructs is skipped by the parser and WikiText punctuat
 |[[Code Blocks in WikiText]]|One of the main purposes of code blocks is to suppress wikitext expansion. Once the code block starts, the parser will ignore all WikiText punctuation until the code block ends.|
 |[[Images in WikiText]]|`[[img|literal image link text]]` - the text enclosed by square braces will be ignored. This means, for example, [[transclusions|Transclusion in WikiText]] and [[macro calls|Macro Calls]] cannot be used to dynamically construct the link text|
 |[[Linking in WikiText]]|`[[literal link target|literal link text]]` - the text enclosed by square braces will be ignored. This means, for example, [[transclusions|Transclusion in WikiText]] and [[macro calls|Macro Calls]] cannot be used to dynamically construct the link target or the link text|
-|[[Macro Calls]]|`<<mymacro ''notbold'' "literal text" "<<macro_expansion_ignored>>" {{transclusion_ignored}}>>` - while processing the text enclosed by a macro call, the parser will follow special rules for detecting macro parameters. These rules do not include detection of WikiText. However, after the parameters are substituted into the macro definition, the result will be parsed using [[normal rules|Wiki Text Parser Modes]]. This will likely result in the detection of any WikiText.|
+|[[Macro Calls]]|`<<mymacro ''notbold'' "literal text" "<<macro_expansion_ignored>>" {{transclusion_ignored}}>>` - while processing the text enclosed by a macro call, the parser will follow special rules for detecting macro parameters. These rules do not include detection of WikiText. However, after the parameters are substituted into the macro definition, the result will be parsed using the [[normal rules|WikiText Parser Modes]]. This will likely result in the detection of any WikiText.|
 


### PR DESCRIPTION
just like the title says 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>