### PR TITLE
Style Refresh: put stylesheets into single style tags

### DIFF
--- a/core/modules/startup/render.js
+++ b/core/modules/startup/render.js
@@ -21,6 +21,7 @@ exports.synchronous = true;
 // Default story and history lists
 var PAGE_TITLE_TITLE = "$:/core/wiki/title";
 var PAGE_STYLESHEET_TITLE = "$:/core/ui/PageStylesheet";
+var ROOT_STYLESHEET_TITLE = "$:/core/ui/RootStylesheet";
 var PAGE_TEMPLATE_TITLE = "$:/core/ui/RootTemplate";
 
 // Time (in ms) that we defer refreshing changes to draft tiddlers

--- a/core/modules/startup/render.js
+++ b/core/modules/startup/render.js
@@ -43,21 +43,11 @@ exports.startup = function() {
 		}
 	});
 	// Set up the styles
-	$tw.styleWidgetNode = $tw.wiki.makeTranscludeWidget(PAGE_STYLESHEET_TITLE,{document: $tw.fakeDocument});
-	$tw.styleContainer = $tw.fakeDocument.createElement("style");
-	$tw.styleWidgetNode.render($tw.styleContainer,null);
-	$tw.styleWidgetNode.assignedStyles = $tw.styleContainer.textContent;
-	$tw.styleElement = document.createElement("style");
-	$tw.styleElement.innerHTML = $tw.styleWidgetNode.assignedStyles;
-	document.head.insertBefore($tw.styleElement,document.head.firstChild);
+	var styleParser = $tw.wiki.parseTiddler(ROOT_STYLESHEET_TITLE,{parseAsInline: true}),
+		styleWidgetNode = $tw.wiki.makeWidget(styleParser,{document: document});
+	styleWidgetNode.render(document.head,null);
 	$tw.wiki.addEventListener("change",$tw.perf.report("styleRefresh",function(changes) {
-		if($tw.styleWidgetNode.refresh(changes,$tw.styleContainer,null)) {
-			var newStyles = $tw.styleContainer.textContent;
-			if(newStyles !== $tw.styleWidgetNode.assignedStyles) {
-				$tw.styleWidgetNode.assignedStyles = newStyles;
-				$tw.styleElement.innerHTML = $tw.styleWidgetNode.assignedStyles;
-			}
-		}
+		styleWidgetNode.refresh(changes,document.head,null);
 	}));
 	// Display the $:/core/ui/PageTemplate tiddler to kick off the display
 	$tw.perf.report("mainRender",function() {

--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -64,24 +64,16 @@ exports.startup = function() {
 			$tw.wiki.removeEventListener("change",refreshHandler);
 		},false);
 		// Set up the styles
-		var styleWidgetNode = $tw.wiki.makeTranscludeWidget("$:/core/ui/PageStylesheet",{
-				document: $tw.fakeDocument,
-				variables: variables,
-				importPageMacros: true}),
-			styleContainer = $tw.fakeDocument.createElement("style");
-		styleWidgetNode.render(styleContainer,null);
-		var styleElement = srcDocument.createElement("style");
-		styleElement.innerHTML = styleContainer.textContent;
-		srcDocument.head.insertBefore(styleElement,srcDocument.head.firstChild);
+		var styleParser = $tw.wiki.parseTiddler("$:/core/ui/RootStylesheet",{parseAsInline: true}),
+			styleWidgetNode = $tw.wiki.makeWidget(styleParser,{document: srcDocument});
+		styleWidgetNode.render(srcDocument.head,null);
 		// Render the text of the tiddler
 		var parser = $tw.wiki.parseTiddler(template),
 			widgetNode = $tw.wiki.makeWidget(parser,{document: srcDocument, parentWidget: $tw.rootWidget, variables: variables});
 		widgetNode.render(srcDocument.body,srcDocument.body.firstChild);
 		// Function to handle refreshes
 		refreshHandler = function(changes) {
-			if(styleWidgetNode.refresh(changes,styleContainer,null)) {
-				styleElement.innerHTML = styleContainer.textContent;
-			}
+			styleWidgetNode.refresh(changes);
 			widgetNode.refresh(changes);
 		};
 		$tw.wiki.addEventListener("change",refreshHandler);

--- a/core/ui/RootStylesheet.tid
+++ b/core/ui/RootStylesheet.tid
@@ -1,0 +1,12 @@
+title: $:/core/ui/RootStylesheet
+code-body: yes
+
+\import [subfilter{$:/core/config/GlobalImportFilter}]
+\whitespace trim
+<$let currentTiddler={{$:/language}} languageTitle={{!!name}}>
+	<$list filter="[all[shadows+tiddlers]tag[$:/tags/Stylesheet]!is[draft]]">
+		<style type="text/css">
+			<$view format={{{ [<currentTiddler>tag[$:/tags/Stylesheet/Static]then[text]else[plainwikified]] }}} mode="block"/>
+		</style>
+	</$list>
+</$let>


### PR DESCRIPTION
This PR is an attempt to put every stylesheet in its dedicated `<style>` tag in the document's header.
It's a very simple approach here and it works really well.

Look at the [TiddlyFlex Layout](https://burningtreec.github.io/TiddlyFlex/) where this is enabled for testing purposes and the performance instrumentation is enabled.
Drag the sidebar resizer around and notice that the styleRefresh is very low.
In the TiddlyFlex Layout this is achieved by a "refresh-blocker" widget that blocks refreshing down the widget-tree if a given tiddler changes and another given tiddler exists.
The UI is wrapped within refresh-blocker widgets which makes the mainRefresh 0-1ms when dragging the sidebar.
The stylesheets that don't need to be refreshes when the tiddlers change that make the sidebar resize are also wrapped within refresh-blocker widgets. That makes the styleRefresh 3-5ms when dragging the sidebar.

The idea would be to add a refresh-blocker to the core, also add a sidebar resizer and make use of the upsides of this.

What do you think?