### PR TITLE
Add more colors to Flexoki Light palette

### DIFF
--- a/core/palettes/FlexokiLight.tid
+++ b/core/palettes/FlexokiLight.tid
@@ -64,9 +64,9 @@ alert-highlight: <<colour flexoki-tx-3>>
 alert-muted-foreground: <<colour flexoki-tx-2>>
 background: <<colour flexoki-bg>>
 blockquote-bar: <<colour muted-foreground>>
-button-background:
-button-foreground:
-button-border:
+button-background: 
+button-foreground: 
+button-border: 
 code-background: <<colour flexoki-bg>>
 code-border: <<colour flexoki-tx>>
 code-foreground: <<colour flexoki-tx>>
@@ -78,7 +78,7 @@ diff-insert-background: <<colour flexoki-gr>>
 diff-insert-foreground: <<colour foreground>>
 diff-invisible-background: 
 diff-invisible-foreground: <<colour muted-foreground>>
-dirty-indicator: #ff0000
+dirty-indicator: <<colour flexoki-red-600>>
 download-background: <<colour flexoki-gr>>
 download-foreground: <<colour background>>
 dragger-background: <<colour foreground>>
@@ -107,40 +107,40 @@ modal-border: #999999
 modal-footer-background: #f5f5f5
 modal-footer-border: #dddddd
 modal-header-border: #eeeeee
-muted-foreground: #bbb
+muted-foreground: <<colour flexoki-ui-3>>
 network-activity-foreground: #448844
 notification-background: #ffffdd
 notification-border: #999999
 page-background: <<colour flexoki-bg-2>>
-pre-background: #f5f5f5
-pre-border: #cccccc
+pre-background: <<colour flexoki-bg>>
+pre-border: <<colour flexoki-ui-2>>
 primary: <<colour flexoki-cy>>
-selection-background:
-selection-foreground:
-select-tag-background:
-select-tag-foreground:
+selection-background: 
+selection-foreground: 
+select-tag-background: 
+select-tag-foreground: 
 sidebar-button-foreground: <<colour foreground>>
-sidebar-controls-foreground-hover: #000000
-sidebar-controls-foreground: #aaaaaa
+sidebar-controls-foreground-hover: <<colour flexoki-tx>>
+sidebar-controls-foreground: <<colour flexoki-tx-3>>
 sidebar-foreground-shadow: rgba(255,255,255, 0.8)
-sidebar-foreground: #acacac
-sidebar-muted-foreground-hover: #444444
-sidebar-muted-foreground: #c0c0c0
-sidebar-tab-background-selected: #f4f4f4
-sidebar-tab-background: #e0e0e0
+sidebar-foreground: <<colour flexoki-300>>
+sidebar-muted-foreground-hover: <<colour flexoki-700>>
+sidebar-muted-foreground: <<colour flexoki-200>>
+sidebar-tab-background-selected: <<colour flexoki-bg-2>>
+sidebar-tab-background: <<colour flexoki-ui>>
 sidebar-tab-border-selected: <<colour tab-border-selected>>
 sidebar-tab-border: <<colour tab-border>>
 sidebar-tab-divider: #e4e4e4
-sidebar-tab-foreground-selected:
+sidebar-tab-foreground-selected: 
 sidebar-tab-foreground: <<colour tab-foreground>>
-sidebar-tiddler-link-foreground-hover: #444444
-sidebar-tiddler-link-foreground: #999999
+sidebar-tiddler-link-foreground-hover: <<colour flexoki-tx-2>>
+sidebar-tiddler-link-foreground: <<colour flexoki-tx-3>>
 site-title-foreground: <<colour tiddler-title-foreground>>
-stability-stable: #008000
-stability-experimental: #c07c00
-stability-deprecated: #ff0000
-stability-legacy: #0000ff
-static-alert-foreground: #aaaaaa
+stability-stable: <<colour flexoki-green-600>>
+stability-experimental: <<colour flexoki-yellow-600>>
+stability-deprecated: <<colour flexoki-red-600>>
+stability-legacy: <<colour flexoki-blue-600>>
+static-alert-foreground: <<colour flexoki-tx-3>>
 tab-background-selected: <<colour background>>
 tab-background: <<colour flexoki-bg-2>>
 tab-border-selected: <<colour flexoki-ui-3>>
@@ -148,9 +148,9 @@ tab-border: <<colour flexoki-ui>>
 tab-divider: <<colour flexoki-ui-2>>
 tab-foreground-selected: <<colour tab-foreground>>
 tab-foreground: <<colour flexoki-tx>>
-table-border: #dddddd
-table-footer-background: #a8a8a8
-table-header-background: #f0f0f0
+table-border: <<colour flexoki-ui-2>>
+table-footer-background: <<colour flexoki-tx-3>>
+table-header-background: <<colour flexoki-bg-2>>
 tag-background: #ec6
 tag-foreground: #ffffff
 testcase-accent-level-1: #c1eaff
@@ -158,33 +158,33 @@ testcase-accent-level-2: #E3B740
 testcase-accent-level-3: #5FD564
 tiddler-background: <<colour background>>
 tiddler-border: <<colour background>>
-tiddler-controls-foreground-hover: #888888
-tiddler-controls-foreground-selected: #444444
-tiddler-controls-foreground: #cccccc
+tiddler-controls-foreground-hover: <<colour flexoki-tx-3>>
+tiddler-controls-foreground-selected: <<colour  flexoki-tx-2>>
+tiddler-controls-foreground: <<colour flexoki-ui-3>>
 tiddler-editor-background: #f8f8f8
 tiddler-editor-border-image: #ffffff
-tiddler-editor-border: #cccccc
+tiddler-editor-border: <<colour flexoki-ui-3>>
 tiddler-editor-fields-even: #e0e8e0
 tiddler-editor-fields-odd: #f0f4f0
-tiddler-info-background: #f8f8f8
-tiddler-info-border: #dddddd
-tiddler-info-tab-background: #f8f8f8
+tiddler-info-background: <<colour flexoki-bg-2>>
+tiddler-info-border: <<colour flexoki-200>>
+tiddler-info-tab-background: <<colour flexoki-bg>>
 tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: #c0c0c0
 tiddler-title-foreground: #182955
-toolbar-new-button:
-toolbar-options-button:
-toolbar-save-button:
-toolbar-info-button:
-toolbar-edit-button:
-toolbar-close-button:
-toolbar-delete-button:
-toolbar-cancel-button:
-toolbar-done-button:
+toolbar-new-button: 
+toolbar-options-button: 
+toolbar-save-button: 
+toolbar-info-button: 
+toolbar-edit-button: 
+toolbar-close-button: 
+toolbar-delete-button: 
+toolbar-cancel-button: 
+toolbar-done-button: 
 untagged-background: #999999
 very-muted-foreground: #888888
-wikilist-background: #e5e5e5
+wikilist-background: <<colour flexoki-ui>>
 wikilist-item: #fff
 wikilist-info: #000
 wikilist-title: #666

--- a/core/palettes/FlexokiLight.tid
+++ b/core/palettes/FlexokiLight.tid
@@ -64,9 +64,9 @@ alert-highlight: <<colour flexoki-tx-3>>
 alert-muted-foreground: <<colour flexoki-tx-2>>
 background: <<colour flexoki-bg>>
 blockquote-bar: <<colour muted-foreground>>
-button-background: 
-button-foreground: 
-button-border: 
+button-background: <<colour flexoki-bg-2>>
+button-foreground: <<colour flexoki-black>>
+button-border: <<colour flexoki-500>>
 code-background: <<colour flexoki-bg>>
 code-border: <<colour flexoki-tx>>
 code-foreground: <<colour flexoki-tx>>
@@ -87,7 +87,7 @@ dropdown-background: <<colour background>>
 dropdown-border: <<colour muted-foreground>>
 dropdown-tab-background-selected: #fff
 dropdown-tab-background: #ececec
-dropzone-background: rgba(0,200,0,0.7)
+dropzone-background: <<colour flexoki-gr>>
 external-link-background-hover: inherit
 external-link-background-visited: inherit
 external-link-background: inherit
@@ -98,27 +98,27 @@ footnote-target-background: #ecf2ff
 foreground: <<colour flexoki-tx>>
 highlight-background: #ffff00
 highlight-foreground: #000000
-message-background: #ecf2ff
-message-border: #cfd6e6
-message-foreground: #547599
+message-background: <<colour flexoki-bg>>
+message-border: <<colour flexoki-black>>
+message-foreground: <<colour flexoki-black>>
 modal-backdrop: <<colour foreground>>
 modal-background: <<colour background>>
 modal-border: #999999
 modal-footer-background: #f5f5f5
 modal-footer-border: #dddddd
 modal-header-border: #eeeeee
-muted-foreground: <<colour flexoki-ui-3>>
+muted-foreground: <<colour flexoki-500>>
 network-activity-foreground: #448844
-notification-background: #ffffdd
-notification-border: #999999
+notification-background: <<colour flexoki-bg>>
+notification-border: <<color flexoki-black>>
 page-background: <<colour flexoki-bg-2>>
 pre-background: <<colour flexoki-bg>>
 pre-border: <<colour flexoki-ui-2>>
 primary: <<colour flexoki-cy>>
 selection-background: 
 selection-foreground: 
-select-tag-background: 
-select-tag-foreground: 
+select-tag-background: <<colour flexoki-bg>>
+select-tag-foreground: <<color flexoki-black>>
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: <<colour flexoki-tx>>
 sidebar-controls-foreground: <<colour flexoki-tx-3>>
@@ -130,11 +130,11 @@ sidebar-tab-background-selected: <<colour flexoki-bg-2>>
 sidebar-tab-background: <<colour flexoki-ui>>
 sidebar-tab-border-selected: <<colour tab-border-selected>>
 sidebar-tab-border: <<colour tab-border>>
-sidebar-tab-divider: #e4e4e4
+sidebar-tab-divider: <<colour flexoki-100>>
 sidebar-tab-foreground-selected: 
 sidebar-tab-foreground: <<colour tab-foreground>>
-sidebar-tiddler-link-foreground-hover: <<colour flexoki-tx-2>>
-sidebar-tiddler-link-foreground: <<colour flexoki-tx-3>>
+sidebar-tiddler-link-foreground-hover: <<colour flexoki-500>>
+sidebar-tiddler-link-foreground: <<colour flexoki-700>>
 site-title-foreground: <<colour tiddler-title-foreground>>
 stability-stable: <<colour flexoki-green-600>>
 stability-experimental: <<colour flexoki-yellow-600>>
@@ -153,15 +153,15 @@ table-footer-background: <<colour flexoki-tx-3>>
 table-header-background: <<colour flexoki-bg-2>>
 tag-background: #ec6
 tag-foreground: #ffffff
-testcase-accent-level-1: #c1eaff
-testcase-accent-level-2: #E3B740
-testcase-accent-level-3: #5FD564
+testcase-accent-level-1: <<colour flexoki-blue-400>>
+testcase-accent-level-2: <<colour flexoki-yellow-400>>
+testcase-accent-level-3: <<colour flexoki-green-400>>
 tiddler-background: <<colour background>>
 tiddler-border: <<colour background>>
 tiddler-controls-foreground-hover: <<colour flexoki-tx-3>>
 tiddler-controls-foreground-selected: <<colour  flexoki-tx-2>>
 tiddler-controls-foreground: <<colour flexoki-ui-3>>
-tiddler-editor-background: #f8f8f8
+tiddler-editor-background: <<colour flexoki-050>>
 tiddler-editor-border-image: #ffffff
 tiddler-editor-border: <<colour flexoki-ui-3>>
 tiddler-editor-fields-even: #e0e8e0
@@ -171,8 +171,8 @@ tiddler-info-border: <<colour flexoki-200>>
 tiddler-info-tab-background: <<colour flexoki-bg>>
 tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
-tiddler-subtitle-foreground: #c0c0c0
-tiddler-title-foreground: #182955
+tiddler-subtitle-foreground: <<colour flexoki-black>>
+tiddler-title-foreground: <<colour flexoki-magenta-600>>
 toolbar-new-button: 
 toolbar-options-button: 
 toolbar-save-button: 

--- a/core/palettes/FlexokiLight.tid
+++ b/core/palettes/FlexokiLight.tid
@@ -92,8 +92,8 @@ external-link-background-hover: inherit
 external-link-background-visited: inherit
 external-link-background: inherit
 external-link-foreground-hover: inherit
-external-link-foreground-visited: #0000aa
-external-link-foreground: #0000ee
+external-link-foreground-visited: <<colour flexoki-blue-600>>
+external-link-foreground: <<colour flexoki-blue-400>>
 footnote-target-background: #ecf2ff
 foreground: <<colour flexoki-tx>>
 highlight-background: #ffff00


### PR DESCRIPTION
Added more colors to flexoki light palette, including:

* Dirty indicator
* Table borders and headings
* Tiddler info
* Sidebar tabs and buttons
* Stability badges
* Code blocks
* Message boxes
* Notifications
* Tiddler and site title
* Buttons