### PR TITLE
MWS remove function wrapper

### DIFF
--- a/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-create-bag.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-create-bag.js
@@ -8,8 +8,6 @@ Command to load archive of recipes, bags and tiddlers from a directory
 --mws-create-bag <name> <description>
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -43,5 +41,3 @@ Command.prototype.execute = function() {
 };
 
 exports.Command = Command;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-create-recipe.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-create-recipe.js
@@ -10,8 +10,6 @@ Command to load archive of recipes, bags and tiddlers from a directory
 The parameter "bag-list" should be a space delimited list of bags
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -46,5 +44,3 @@ Command.prototype.execute = function() {
 };
 
 exports.Command = Command;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-listen.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-listen.js
@@ -6,8 +6,6 @@ module-type: command
 Listen for HTTP requests and serve tiddlers
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -45,5 +43,3 @@ Command.prototype.execute = function() {
 };
 
 exports.Command = Command;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-load-archive.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-load-archive.js
@@ -6,8 +6,6 @@ module-type: command
 Command to load archive of recipes, bags and tiddlers from a directory
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -89,5 +87,3 @@ function sanitiseTiddler(tiddler) {
 }
 
 exports.Command = Command;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-load-plugin-bags.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-load-plugin-bags.js
@@ -6,8 +6,6 @@ module-type: command
 Command to create and load a bag for each plugin in the repo
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -77,5 +75,3 @@ function loadPluginBags() {
 }
 
 exports.Command = Command;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-load-tiddlers.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-load-tiddlers.js
@@ -6,8 +6,6 @@ module-type: command
 Command to recursively load a directory of tiddler files into a bag
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -36,5 +34,3 @@ Command.prototype.execute = function() {
 };
 
 exports.Command = Command;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-load-wiki-folder.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-load-wiki-folder.js
@@ -8,8 +8,6 @@ Command to create and load a bag for the specified core editions
 --mws-load-wiki-folder <path> <bag-name> <bag-description> <recipe-name> <recipe-description>
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -89,5 +87,3 @@ function loadWikiFolder(options) {
 }
 
 exports.Command = Command;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-save-archive.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-save-archive.js
@@ -6,8 +6,6 @@ module-type: command
 Command to load an archive of recipes, bags and tiddlers to a directory
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -58,5 +56,3 @@ function saveArchive(archivePath) {
 }
 
 exports.Command = Command;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-save-tiddler-text.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-save-tiddler-text.js
@@ -8,8 +8,6 @@ Command to load archive of recipes, bags and tiddlers from a directory
 --mws-save-tiddler-text <bag-name> <tiddler-title> <tiddler-text>
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -40,5 +38,3 @@ Command.prototype.execute = function() {
 };
 
 exports.Command = Command;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-test-server.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/commands/mws-test-server.js
@@ -8,8 +8,6 @@ Command to test a local or remote MWS server
 tiddlywiki editions/multiwikiserver/ --listen --mws-test-server http://127.0.0.1:8080/
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -154,5 +152,3 @@ const testSpecs = [
 ];
 
 exports.Command = Command;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/delete-bag-tiddler.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/delete-bag-tiddler.js
@@ -6,8 +6,6 @@ module-type: mws-route
 DELETE /bags/:bag_name/tiddler/:title
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -33,5 +31,3 @@ exports.handler = function(request,response,state) {
 		response.end();
 	}
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-bag-tiddler-blob.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-bag-tiddler-blob.js
@@ -6,8 +6,6 @@ module-type: mws-route
 GET /bags/:bag_name/tiddler/:title/blob
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -34,5 +32,3 @@ exports.handler = function(request,response,state) {
 	response.writeHead(404);
 	response.end();
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-bag-tiddler.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-bag-tiddler.js
@@ -10,8 +10,6 @@ Parameters:
 fallback=<url> // Optional redirect if the tiddler is not found
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -64,5 +62,3 @@ exports.handler = function(request,response,state) {
 		}
 	}
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-bag.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-bag.js
@@ -7,8 +7,6 @@ GET /bags/:bag_name/
 GET /bags/:bag_name
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -51,5 +49,3 @@ exports.handler = function(request,response,state) {
 		response.end();
 	}
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-index.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-index.js
@@ -6,8 +6,6 @@ module-type: mws-route
 GET /?show_system=true
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -41,5 +39,3 @@ exports.handler = function(request,response,state) {
 		response.end();
 	}
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-recipe-events.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-recipe-events.js
@@ -10,8 +10,6 @@ headers:
 Last-Event-ID: 
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -84,5 +82,3 @@ exports.handler = function(request,response,state) {
 	response.writeHead(404);
 	response.end();
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-recipe-tiddler.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-recipe-tiddler.js
@@ -10,8 +10,6 @@ Parameters:
 fallback=<url> // Optional redirect if the tiddler is not found
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -61,5 +59,3 @@ exports.handler = function(request,response,state) {
 		}
 	}
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-recipe-tiddlers-json.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-recipe-tiddlers-json.js
@@ -6,8 +6,6 @@ module-type: mws-route
 GET /recipes/:recipe_name/tiddlers.json?last_known_tiddler_id=:last_known_tiddler_id&include_deleted=true|false
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -35,5 +33,3 @@ exports.handler = function(request,response,state) {
 	response.end();
 
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-system.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-system.js
@@ -12,8 +12,6 @@ Retrieves a system file. System files are stored in configuration tiddlers with 
 GET /.system/:filename
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -48,5 +46,3 @@ exports.handler = function(request,response,state) {
 		response.end();
 	}
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-wiki.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/get-wiki.js
@@ -6,8 +6,6 @@ module-type: mws-route
 GET /wiki/:recipe_name
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -89,5 +87,3 @@ exports.handler = function(request,response,state) {
 		response.end();
 	}
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/post-bag-tiddlers.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/post-bag-tiddlers.js
@@ -6,8 +6,6 @@ module-type: mws-route
 POST /bags/:bag_name/tiddlers/
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -66,5 +64,3 @@ exports.handler = function(request,response,state) {
 		}
 	});
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/post-bag.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/post-bag.js
@@ -11,8 +11,6 @@ bag_name
 description
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -46,5 +44,3 @@ exports.handler = function(request,response,state) {
 		});
 	}
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/post-recipe.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/post-recipe.js
@@ -12,8 +12,6 @@ description
 bag_names: space separated list of bags
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -47,5 +45,3 @@ exports.handler = function(request,response,state) {
 		});
 	}
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/put-bag.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/put-bag.js
@@ -6,8 +6,6 @@ module-type: mws-route
 PUT /bags/:bag_name
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -38,5 +36,3 @@ exports.handler = function(request,response,state) {
 		response.end();
 	}
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/put-recipe-tiddler.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/put-recipe-tiddler.js
@@ -6,8 +6,6 @@ module-type: mws-route
 PUT /recipes/:recipe_name/tiddlers/:title
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -41,5 +39,3 @@ exports.handler = function(request,response,state) {
 	response.end();
 
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/put-recipe.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/handlers/put-recipe.js
@@ -6,8 +6,6 @@ module-type: mws-route
 PUT /recipes/:recipe_name
 
 \*/
-(function() {
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -38,5 +36,3 @@ exports.handler = function(request,response,state) {
 		response.end();
 	}
 };
-
-}());

--- a/plugins/tiddlywiki/multiwikiserver/modules/routes/helpers/multipart-forms.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/routes/helpers/multipart-forms.js
@@ -7,9 +7,6 @@ A function that handles an incoming multipart/form-data stream, streaming the da
 in the store/inbox folder. Once the data is received, it imports any tiddlers and invokes a callback.
 
 \*/
-
-(function() {
-
 /*
 Process an incoming new multipart/form-data stream. Options include:
 
@@ -96,5 +93,3 @@ exports.processIncomingStream = function(options) {
 		}
 	});
 };
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/startup.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/startup.js
@@ -6,8 +6,6 @@ module-type: startup
 Multi wiki server initialisation
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -54,5 +52,3 @@ ServerManager.prototype.createServer = function(options) {
 	this.servers.push(server);
 	return server;
 }
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/store/attachments.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/store/attachments.js
@@ -26,9 +26,6 @@ store/
 	database.sql - The database file (managed by sql-tiddler-database.js)
 
 \*/
-
-(function() {
-
 /*
 Class to handle an attachment store. Options include:
 
@@ -177,5 +174,3 @@ AttachmentStore.prototype.getAttachmentMetadata = function(attachmentBlob) {
 	return null;
 };
 exports.AttachmentStore = AttachmentStore;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/store/sql-engine.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/store/sql-engine.js
@@ -8,9 +8,6 @@ Low level functions to work with the SQLite engine, either via better-sqlite3 or
 This class is intended to encapsulate all engine-specific logic.
 
 \*/
-
-(function() {
-
 /*
 Create a database engine. Options include:
 
@@ -135,5 +132,3 @@ SqlEngine.prototype.transaction = function(fn) {
 };
 
 exports.SqlEngine = SqlEngine;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/store/sql-tiddler-database.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/store/sql-tiddler-database.js
@@ -9,9 +9,6 @@ This class is intended to encapsulate all the SQL queries used to access the dat
 Validation is for the most part left to the caller
 
 \*/
-
-(function() {
-
 /*
 Create a tiddler store. Options include:
 
@@ -576,5 +573,3 @@ SqlTiddlerDatabase.prototype.getRecipeTiddlerAttachmentBlob = function(title,rec
 };
 
 exports.SqlTiddlerDatabase = SqlTiddlerDatabase;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/store/sql-tiddler-store.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/store/sql-tiddler-store.js
@@ -12,9 +12,6 @@ This class is largely a wrapper for the sql-tiddler-database.js class, adding th
 * Handling large tiddlers as attachments
 
 \*/
-
-(function() {
-
 /*
 Create a tiddler store. Options include:
 
@@ -434,5 +431,3 @@ SqlTiddlerStore.prototype.getRecipeBags = function(recipe_name) {
 };
 
 exports.SqlTiddlerStore = SqlTiddlerStore;
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/store/tests-sql-tiddler-database.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/store/tests-sql-tiddler-database.js
@@ -6,8 +6,6 @@ tags: [[$:/tags/test-spec]]
 Tests the SQL tiddler database layer
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -108,5 +106,3 @@ function runSqlDatabaseTests(engine) {
 }
 
 }
-
-})();

--- a/plugins/tiddlywiki/multiwikiserver/modules/store/tests-sql-tiddler-store.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/store/tests-sql-tiddler-store.js
@@ -6,8 +6,6 @@ tags: [[$:/tags/test-spec]]
 Tests the SQL tiddler store layer
 
 \*/
-(function(){
-
 /*jslint node: true, browser: true */
 /*global $tw: false */
 "use strict";
@@ -146,5 +144,3 @@ function runSqlStoreTests(engine) {
 }
 
 }
-
-})();


### PR DESCRIPTION
This PR removes the function-wrapper according to you comment at: https://github.com/TiddlyWiki/TiddlyWiki5/pull/7596#issuecomment-1787134501

>[. . .] Thinking about it, I thought we had decided to remove the function wrappers from modules in any case? In which case that should be done first as a separate PR?

We need to start somewhere. IMO MWS would be a good starting point to prepare for a future code formatting setup.