### PR TITLE
Update font stacks

### DIFF
--- a/themes/tiddlywiki/vanilla/settings.multids
+++ b/themes/tiddlywiki/vanilla/settings.multids
@@ -1,6 +1,6 @@
 title: $:/themes/tiddlywiki/vanilla/settings/
 
-fontfamily: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"
-codefontfamily: ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace
+fontfamily: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"
+codefontfamily: ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace
 backgroundimageattachment: fixed
 backgroundimagesize: auto

--- a/themes/tiddlywiki/vanilla/settings.multids
+++ b/themes/tiddlywiki/vanilla/settings.multids
@@ -1,6 +1,6 @@
 title: $:/themes/tiddlywiki/vanilla/settings/
 
-fontfamily: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji
-codefontfamily: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace
+fontfamily: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"
+codefontfamily: ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace
 backgroundimageattachment: fixed
 backgroundimagesize: auto


### PR DESCRIPTION
---
name: Update font stacks
about: Font stacks for regular and monospace font in the vanilla theme
---

**Is your PR related to a problem? Please describe.**
Chrome and its derivatives on Android use a not quite well readable variant of Courier with the current monospace font stack.
The current font stacks are based on GitHub's setup years ago.

**Describe the solution you are proposing**
Update regular and monospace font stacks to use the same ones that GitHub uses right now. In particular, this removes Courier from monospace stack, resulting in a much more readable font being used on Chrome on Android.

**Describe alternatives you've considered**
_The smallest change to achieve a decent font on Chrome/Android without touching other platforms would be to just remove Courier from the monospace font stack._ I'm not aware of any popular platform that would display Courier by default with the current stack (except for Chrome/Android, where it's a very unreadable variant of this font).

**Additional context**
The problem was pointed out in this talk thread https://talk.tiddlywiki.org/t/use-of-courier-in-vanilla-theme/9982 with Jeremy's conclusion "I would be happy for us to tweak the settings if best practice has moved on since then." but no one took up any action after that so far.

For a quick comparison of the current and new font stacks right next to each other, you can visit my demo sie: https://font-stacks.tiddlyhost.com

I tested it on a couple of popular platforms that I was able to:

- Chrome and its derivatives on Windows and macOS - no change.
- Firefox on Windows and Android - no change.
- Chrome on Android - the desired change
![chrome-android](https://github.com/user-attachments/assets/0ac710f6-9a7b-46df-b478-26ad15f8919a)
- Chrome on iOS - a different monospace font is used, I think both are comparably readable
![chrome-ios](https://github.com/user-attachments/assets/47ec7edc-bdd8-4080-8717-b2af806915d6)
- Chrome and Firefox on Fedora - a different sans serif font is used, Noto Sans instead of Nimbus Sans, IMO the new one is slightly better readable
![chromium-fedora](https://github.com/user-attachments/assets/1c9f12de-42bb-4769-ad9c-28b6964847d9)

## Checklist before requesting a review

- [x] Illustrate any visual changes (however minor) with before/after screenshots
- [x] Self-review of code
- [ ] Documentation updates (for user-visible changes)
- [ ] Tests (for core code changes)
- [ ] Complies with coding style guidelines (for JavaScript code)
