### PR TITLE
Add basic view-widget tests

### DIFF
--- a/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-format-text-doubleurlencoded.tid
+++ b/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-format-text-doubleurlencoded.tid
@@ -1,0 +1,22 @@
+title: Widgets/ViewWidget/Parameter/field-format-doubleurlencoded
+description: Test view-widget parameters tiddler, field and format=*
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: input
+
+Some text > "aaa"
++
+title: Output
+
+<$view tiddler="input" field="text" format="doubleurlencoded"/>
+---
+<$view tiddler="input" field="text"/>
+
++
+title: ExpectedResult
+
+<p>Some%2520text%2520%253E%2520%2522aaa%2522
+—
+Some text &gt; "aaa"
+</p>

--- a/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-format-text-htmlencoded.tid
+++ b/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-format-text-htmlencoded.tid
@@ -1,0 +1,21 @@
+title: Widgets/ViewWidget/Parameter/field-format-htmlencoded
+description: Test view-widget parameters tiddler, field and format=*
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: input
+
+Some text > "aaa"
+
++
+title: Output
+
+<$view tiddler="input" field="text" format="htmlencoded"/>
+
+<$view tiddler="input" field="text"/>
+
++
+title: ExpectedResult
+
+Some text &amp;gt; &amp;quot;aaa&amp;quot;
+Some text &gt; "aaa"

--- a/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-format-text-htmltextencoded.tid
+++ b/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-format-text-htmltextencoded.tid
@@ -1,0 +1,21 @@
+title: Widgets/ViewWidget/Parameter/field-format-htmltextencoded
+description: Test view-widget parameters tiddler, field and format=*
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: input
+
+Some text > "aaa"
+
++
+title: Output
+
+<$view tiddler="input" field="text" format="htmltextencoded"/>
+
+<$view tiddler="input" field="text"/>
+
++
+title: ExpectedResult
+
+Some text &amp;gt; "aaa"
+Some text &gt; "aaa"

--- a/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-format-text-urlencoded.tid
+++ b/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-format-text-urlencoded.tid
@@ -1,0 +1,22 @@
+title: Widgets/ViewWidget/Parameter/field-format-urlencoded
+description: Test view-widget parameters tiddler, field and format=*
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: input
+
+Some text > "aaa"
++
+title: Output
+
+<$view tiddler="input" field="text" format="urlencoded"/>
+---
+<$view tiddler="input" field="text"/>
+
++
+title: ExpectedResult
+
+<p>Some%20text%20%3E%20%22aaa%22
+—
+Some text &gt; "aaa"
+</p>

--- a/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-format-text.tid
+++ b/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-format-text.tid
@@ -1,0 +1,19 @@
+title: Widgets/ViewWidget/Parameter/field-format-text
+description: Test view-widget parameters tiddler, field and format=*
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: input
+caption: [[HelloThere]]
+
+Some text
++
+title: Output
+
+<$view tiddler="input" field="caption" format="text"/>
+
+<$view tiddler="input" field="caption"/>
++
+title: ExpectedResult
+
+[[HelloThere]]<p>[[HelloThere]]</p>

--- a/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-index.tid
+++ b/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-index.tid
@@ -1,0 +1,28 @@
+title: Widgets/ViewWidget/Parameter/field-index
+description: Test view-widget parameters index type=application/json and type=application/x-tiddler-dictionary
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: input
+type: application/x-tiddler-dictionary
+
+01: value 01
+02: value 02
++
+title: input-json
+type: application/json
+
+{
+	"01": "value 01",
+	"02": "value 02"
+}
++
+title: Output
+
+<$view tiddler="input-json" index="01"/>
+
+<$view tiddler="input" index="02"/>
++
+title: ExpectedResult
+
+value 01<p>value 02</p>

--- a/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-text.tid
+++ b/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-text.tid
@@ -1,0 +1,18 @@
+title: Widgets/ViewWidget/Parameter/field-text
+description: Test view-widget parameters tiddler and field=text
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: input
+
+Some text
++
+title: Output
+
+<$view tiddler="input" field="text"/>
+
+<$view tiddler="input" />
++
+title: ExpectedResult
+
+Some text<p>Some text</p>

--- a/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-title.tid
+++ b/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-field-title.tid
@@ -1,0 +1,17 @@
+title: Widgets/ViewWidget/Parameter/field-title
+description: Test view-widget parameters tiddler and field=title
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: input
+
+Some text
++
+title: Output
+
+<$view tiddler="input" field="title"/>
+
++
+title: ExpectedResult
+
+input

--- a/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-format-date-template.tid
+++ b/editions/test/tiddlers/tests/data/widgets/view/ViewWidget-format-date-template.tid
@@ -1,0 +1,20 @@
+title: Widgets/ViewWidget/Parameter/format-data-template
+description: Test view-widget parameters format, date and template
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: input
+modified: 20240920162221000
+
+Some text
++
+title: Output
+
+<!-- This can not be tested atm, since test-server timezone can be different
+<$view tiddler="input" field="modified" format="date"/>
+-->
+<$view tiddler="input" field="modified" format="date" template="[UTC]DDth MMM YYYY at hh12:0mmam"/>
++
+title: ExpectedResult
+
+<p>20th September 2024 at 4:22pm</p>


### PR DESCRIPTION
This PR adds some basic view-widget tests. 

@Jermolene -- They should all pass with the current view-widget code. 

This is the first batch - There will need to be more of them to cover more code paths. 

Those tests should be finished prior to merge new view-widget code.