### PR TITLE
Fix mediatype Typo in excise.js

### DIFF
--- a/core/modules/editor/operations/text/excise.js
+++ b/core/modules/editor/operations/text/excise.js
@@ -13,7 +13,7 @@ Text editor operation to excise the selection to a new tiddler
 "use strict";
 
 function isMarkdown(mediaType) {
-	return mediaType === 'text/markdown' || mediatype === 'text/x-markdown';
+	return mediaType === 'text/markdown' || mediaType === 'text/x-markdown';
 }
 
 exports["excise"] = function(event,operation) {


### PR DESCRIPTION
This fixes the typo "mediatype" instead of "mediaType" causing a RSOE