### PR TITLE
Fixes variables in functions so they do not pollute upstream widgets

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -335,7 +335,7 @@ Widget.prototype.makeFakeWidgetWithVariables = function(variables) {
 				};
 			} else {
 				opts = opts || {};
-				opts.variables = $tw.utils.extend(variables,opts.variables);
+				opts.variables = $tw.utils.extend({},variables,opts.variables);
 				return self.getVariableInfo(name,opts);
 			};
 		},

--- a/editions/test/tiddlers/tests/data/functions/FunctionFilterrunVariables4.tid
+++ b/editions/test/tiddlers/tests/data/functions/FunctionFilterrunVariables4.tid
@@ -1,0 +1,20 @@
+title: Functions/FunctionFilterrunVariables4
+description: Nested functions in filter runs that set variables should not pollute upstream widget tree
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\function .a() [.b[]]
+\function .b() [all[]] :map[subtract[1].c[]]
+\function .c() [all[]] :map[subtract[1].d[]]
+\function .d() [all[]] :map[subtract[1].e[]]
+\function .e() [all[]] :map[subtract[1]]
+
+
+<$text text={{{ [[10]] :map:flat[.a[]then<currentTiddler>] }}}/>
+
++
+title: ExpectedResult
+
+10


### PR DESCRIPTION
This fixes a bug introduced in #8233, which allowed functions to resolve filter run variables but also polluted the parent widget tree variable values. 

Test added, which fails on current master and TW v5.3.5