### PR TITLE
Gather all the plugins' settings page under the control panel's "Settings" tab.

### DIFF
--- a/plugins/tiddlywiki/browser-storage/settings.tid
+++ b/plugins/tiddlywiki/browser-storage/settings.tid
@@ -1,4 +1,6 @@
 title: $:/plugins/tiddlywiki/browser-storage/settings
+caption: Browser Storage
+tags: $:/tags/ControlPanel/SettingsTab
 
 ! Disable
 

--- a/plugins/tiddlywiki/comments/config.tid
+++ b/plugins/tiddlywiki/comments/config.tid
@@ -1,4 +1,6 @@
 title: $:/plugins/tiddlywiki/comments/config
+caption: Comments
+tags: $:/tags/ControlPanel/SettingsTab
 
 \define select(description,filter)
 <$button>

--- a/plugins/tiddlywiki/consent-banner/config.tid
+++ b/plugins/tiddlywiki/consent-banner/config.tid
@@ -1,4 +1,6 @@
 title: $:/plugins/tiddlywiki/consent-banner/config
+caption: Consent Banner
+tags: $:/tags/ControlPanel/SettingsTab
 
 ! [[Greeting Message|$:/config/plugins/tiddlywiki/consent-banner/greeting-message]]
 

--- a/plugins/tiddlywiki/dynaview/config.tid
+++ b/plugins/tiddlywiki/dynaview/config.tid
@@ -1,4 +1,6 @@
 title: $:/plugins/tiddlywiki/dynaview/config
+caption: Dynaview
+tags: $:/tags/ControlPanel/SettingsTab
 
 <$checkbox tiddler="$:/config/DynaView/ViewportDimensions" field="text" checked="yes" unchecked="no" default="no"> Enable dynamic saving of the viewport [[width|$:/state/DynaView/ViewportDimensions/Width]] and [[height|$:/state/DynaView/ViewportDimensions/Height]]</$checkbox>
 

--- a/plugins/tiddlywiki/external-attachments/settings.tid
+++ b/plugins/tiddlywiki/external-attachments/settings.tid
@@ -1,4 +1,6 @@
 title: $:/plugins/tiddlywiki/external-attachments/settings
+caption: External Attachments
+tags: $:/tags/ControlPanel/SettingsTab
 
 When used on platforms that provide the necessary support (such as ~TiddlyDesktop), you can optionally import binary files as external tiddlers that reference the original file via the ''_canonical_uri'' field.
 

--- a/plugins/tiddlywiki/freelinks/settings.tid
+++ b/plugins/tiddlywiki/freelinks/settings.tid
@@ -1,4 +1,6 @@
 title: $:/plugins/tiddlywiki/freelinks/settings
+caption: Freelinks
+tags: $:/tags/ControlPanel/SettingsTab
 
 Filter defining tiddlers to which freelinks are made: <$edit-text tiddler="$:/config/Freelinks/TargetFilter" tag="input" placeholder="Filter expression..." default=""/>
 

--- a/plugins/tiddlywiki/geospatial/settings.tid
+++ b/plugins/tiddlywiki/geospatial/settings.tid
@@ -1,4 +1,6 @@
 title: $:/plugins/tiddlywiki/geospatial/settings
+caption: Geospatial
+tags: $:/tags/ControlPanel/SettingsTab
 
 ! Geospatial Plugin Settings
 

--- a/plugins/tiddlywiki/googleanalytics/settings.tid
+++ b/plugins/tiddlywiki/googleanalytics/settings.tid
@@ -1,4 +1,6 @@
 title: $:/plugins/tiddlywiki/googleanalytics/settings
+caption: Google Analytics
+tags: $:/tags/ControlPanel/SettingsTab
 
 ''[[Google Analytics Measurement ID|$:/GoogleAnalyticsMeasurementID]]'': (mandatory) a code of the form `G-XXXXXXXXXX` where X are digits or uppercase letters<br/><$edit-text tiddler="$:/GoogleAnalyticsMeasurementID" default="" tag="input"/>
 

--- a/plugins/tiddlywiki/katex/config.tid
+++ b/plugins/tiddlywiki/katex/config.tid
@@ -1,4 +1,6 @@
 title: $:/plugins/tiddlywiki/katex/config
+caption: KaTeX
+tags: $:/tags/ControlPanel/SettingsTab
 
 <div class="tc-control-panel">
 

--- a/plugins/tiddlywiki/savetrail/settings.tid
+++ b/plugins/tiddlywiki/savetrail/settings.tid
@@ -1,5 +1,6 @@
 title: $:/plugins/tiddlywiki/savetrail/settings
-
+caption: Save Trail
+tags: $:/tags/ControlPanel/SettingsTab
 
 <$checkbox tiddler="$:/config/SaveTrailPlugin/enable" field="text" checked="yes" unchecked="no"> Enable automatic saving of modified tiddlers</$checkbox>
 

--- a/plugins/tiddlywiki/share/settings.tid
+++ b/plugins/tiddlywiki/share/settings.tid
@@ -1,4 +1,6 @@
 title: $:/plugins/tiddlywiki/share/settings
+caption: Share
+tags: $:/tags/ControlPanel/SettingsTab
 
 !! Base sharing URL
 

--- a/plugins/tiddlywiki/tour/settings.tid
+++ b/plugins/tiddlywiki/tour/settings.tid
@@ -1,4 +1,6 @@
 title: $:/plugins/tiddlywiki/tour/settings
+caption: Tour
+tags: $:/tags/ControlPanel/SettingsTab
 
 \import [[$:/plugins/tiddlywiki/tour/variables]]
 \procedure button-expand-collapse-all(caption,text)


### PR DESCRIPTION
Add `$:/tags/ControlPanel/SettingsTab` tag to all the plugins' setting page, so that they are accessible under the "Setting" tab in control panel.

