### PR TITLE
Fixes syntax issues with checking target branch for CLA signatures

### DIFF
--- a/.github/workflows/cla-signed.yml
+++ b/.github/workflows/cla-signed.yml
@@ -23,8 +23,8 @@ jobs:
       pull-requests: write
     steps:
     - run: |
-        if ! $BRANCH == "tiddlywiki-com"; then
-          echo "This CLA signature targets the wrong branch"
+        if [[ "$BRANCH" != "tiddlywiki-com" ]]; then
+          echo "This CLA signature targets the wrong branch: $BRANCH"
           gh pr comment "$NUMBER" -b "@$AUTHOR Signatures to the CLA must target the 'tiddlywiki-com' branch."
         fi
       env:


### PR DESCRIPTION
Fixes syntax issues with checking target branch for CLA signatures, surprisingly this was tested as working before we moved repositories. The new syntax should be more robust.