### PR TITLE
Update docs for makeqr macro in qrcode plugin

### DIFF
--- a/plugins/tiddlywiki/qrcode/docs/makeqr.tid
+++ b/plugins/tiddlywiki/qrcode/docs/makeqr.tid
@@ -11,7 +11,7 @@ The ''makeqr'' [[macro|Macros]] converts text data into an image of the correspo
 ;size
 : The size of the image in pixels (defaults to 500)
 ;errorCorrectLevel
-: Determines the amount of error correction applied to the image; see below (defaults to "M").
+: Determines the amount of error correction applied to the image (see below, defaults to "M")
 ;fallback
 : The fallback image to be returned in case of an error (see below)
 
@@ -19,26 +19,30 @@ The conversion will fail if the text is too long and/or complex and the macro wi
 
 The error correction level is a [[QR code feature|http://www.qrcode.com/en/about/error_correction.html]]:
 
-<<<
-QR Code has error correction capability to restore data if the code is dirty or damaged. ... Level Q or H may be selected for factory environment where QR Code get dirty, whereas Level L may be selected for clean environment with the large amount of data. Typically, Level M (15%) is most frequently selected.
-<<<
+|errorCorrectLevel |Redundancy |Use cases |h
+|L | 7%|Clean environment, large amount of data |
+|M | 15%|Default value, most common choice |
+|Q | 25%|Dirty environment, small amount of data |
+|H | 30%|~|
 
 !! Examples
 
-Making a QR code for a simple string of text:
+Making a QR code data URI for a simple string of text:
 
 ```
 <<makeqr "Hello there!">>
 ```
 
-Making a QR code for the URL field of the current tiddler:
+Displaying a QR code for a simple string of text:
 
 ```
-<$macrocall $name="makeqr" text={{!!url}}/>
+<img src=<<makeqr "Hello there!">> />
 ```
 
-Making a QR code for the URL of the current wiki:
+Displaying a QR code for a transcluded value (URL of the current wiki):
 
 ```
-<$macrocall $name="makeqr" text={{$:/info/url/full}}/>
+\define qr(content) <img src=<<makeqr text:"""$content$""">> />
+
+<$transclude $variable="qr" content={{$:/info/url/full}} />
 ```


### PR DESCRIPTION
---
name: Update docs for makeqr macro in qrcode plugin
about: Make the docs of the makeqr macro more practical by directly providing relevant context and usage examples
---

**Is your PR related to a problem? Please describe.**
The current docs for makeqr macro do not explain how to display a QR code, only how to generate data URI of an image.
The possible error correction levels are mentioned in a quote from external resource, without comprehensive explanation of what they do.

**Describe the solution you are proposing**
Add two examples of how to display an image with the QR code, instead of just generating a data URI.
Remove two old examples that wouldn't bring much now.
Add a table describing the error correction levels.
Remove the quote from external documentation site (but leave a link to it).

**Describe alternatives you've considered**
Other examples or a more elegant way of displaying a QR with dynamic content are always a possibility, I haven't come up with anything better.

**Additional context**
Screenshot of docs before changes:
![image](https://github.com/user-attachments/assets/5b6040fd-293e-4f84-aab3-817706c68bb4)


Screenshot of docs after changes:
![image](https://github.com/user-attachments/assets/1f8cf82d-a74a-416e-9bd8-eabf79b2f574)



Handling of the base64 data URI might not be obvious to users less familiar with html.
I think it's practical to have a description of the correction levels directly in the plugin docs.
The macro/text substitution method of displaying a QR code with transcluded content is taken from `$:/plugins/tiddlywiki/qrcode/make/MakeGenericQR`.

## Checklist before requesting a review

- [x] Illustrate any visual changes (however minor) with before/after screenshots
- [x] Self-review of code
- [x] Documentation updates (for user-visible changes)
- [ ] Tests (for core code changes)
- [ ] Complies with coding style guidelines (for JavaScript code) -- N/A, no JS changes
