### PR TITLE
Fix github fork ribbon plugin marked as deprecated & add it back to f…

### DIFF
--- a/editions/full/tiddlywiki.info
+++ b/editions/full/tiddlywiki.info
@@ -7,6 +7,7 @@
 		"tiddlywiki/classictools",
 		"tiddlywiki/codemirror",
 		"tiddlywiki/comments",
+		"tiddlywiki/github-fork-ribbon",
 		"tiddlywiki/help",
 		"tiddlywiki/highlight",
 		"tiddlywiki/innerwiki",

--- a/plugins/tiddlywiki/github-fork-ribbon/plugin.info
+++ b/plugins/tiddlywiki/github-fork-ribbon/plugin.info
@@ -4,5 +4,5 @@
 	"description": "GitHub-inspired corner ribbon",
 	"author": "Simon Whitaker",
 	"list": "readme usage",
-	"stability": "STABILITY_0_DEPRECATED"
+	"stability": "STABILITY_2_STABLE"
 }


### PR DESCRIPTION
…ull edition.

See [this comment](https://github.com/TiddlyWiki/TiddlyWiki5/pull/8639#discussion_r1781130148).