### PR TITLE
fix modified alignment in tiddler subtitle

### DIFF
--- a/core/ui/ViewTemplate/subtitle/default.tid
+++ b/core/ui/ViewTemplate/subtitle/default.tid
@@ -4,7 +4,7 @@ title: $:/core/ui/ViewTemplate/subtitle/default
 <$reveal type="nomatch" stateTitle=<<folded-state>> text="hide" tag="div" retain="yes" animate="yes">
 <div class="tc-subtitle tc-clearfix">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewTemplate/Subtitle]!has[draft.of]]" variable="subtitleTiddler">
-<$transclude tiddler=<<subtitleTiddler>> mode="inline"/><$list-join>&nbsp;</$list-join>
+<$transclude tiddler=<<subtitleTiddler>> mode="inline"/>
 </$list>
 </div>
 </$reveal>

--- a/core/ui/ViewTemplate/subtitle/modifier.tid
+++ b/core/ui/ViewTemplate/subtitle/modifier.tid
@@ -1,4 +1,4 @@
 title: $:/core/ui/ViewTemplate/subtitle/modifier
 tags: $:/tags/ViewTemplate/Subtitle
 
-<$link to={{!!modifier}}/>
+<%if [{!!modifier}!is[blank]] %><$link to={{!!modifier}}/><%endif%>

--- a/editions/test/tiddlers/tests/data/tiddler-subtitle/subtitle-modified.tid
+++ b/editions/test/tiddlers/tests/data/tiddler-subtitle/subtitle-modified.tid
@@ -1,0 +1,23 @@
+title: Subtitle/modified
+description: Tiddler ViewTemplate Subtitle modified only
+type: text/vnd.tiddlywiki-multiple
+import: [all[shadows+tiddlers]tag[$:/tags/ViewTemplate/Subtitle]!has[draft.of]] $:/core/ui/ViewTemplate/subtitle/default
+tags: $:/tags/wiki-test-spec
+
+title: $:/language/Tiddler/DateFormat
+
+[UTC]DDth MMM YYYY at hh12:0mmam
++
+title: Output
+
+\whitespace trim
+{{test||$:/core/ui/ViewTemplate/subtitle/default}}
++
+title: test
+modified: 20241003111606000
+
+text
++
+title: ExpectedResult
+
+<p><div class=" tc-reveal"><div class="tc-subtitle tc-clearfix">3rd October 2024 at 11:16am</div></div></p>

--- a/editions/test/tiddlers/tests/data/tiddler-subtitle/subtitle-modifier-modified.tid
+++ b/editions/test/tiddlers/tests/data/tiddler-subtitle/subtitle-modifier-modified.tid
@@ -1,0 +1,24 @@
+title: Subtitle/modifier-modified
+description: Tiddler ViewTemplate Subtitle. Show modifier and modified in UTC format
+type: text/vnd.tiddlywiki-multiple
+import: [all[shadows+tiddlers]tag[$:/tags/ViewTemplate/Subtitle]!has[draft.of]] $:/core/ui/ViewTemplate/subtitle/default
+tags: $:/tags/wiki-test-spec
+
+title: $:/language/Tiddler/DateFormat
+
+[UTC]DDth MMM YYYY at hh12:0mmam
++
+title: Output
+
+\whitespace trim
+{{test||$:/core/ui/ViewTemplate/subtitle/default}}
++
+title: test
+modifier: test-user
+modified: 20241003111606000
+
+text
++
+title: ExpectedResult
+
+<p><div class=" tc-reveal"><div class="tc-subtitle tc-clearfix"><a class="tc-tiddlylink tc-tiddlylink-missing" href="#test-user">test-user</a>3rd October 2024 at 11:16am</div></div></p>


### PR DESCRIPTION
Fix modified alignment in tiddler subtitle. This PR fixes

- #8657
- It adds 2 new test that fail atm 

The tests fail imo because: https://github.com/pmario/TiddlyWiki5/blob/9372c030711a03849319699b5c96180997130fac/plugins/tiddlywiki/jasmine/run-wiki-based-tests.js#L7 does not know about the new Testcase `import` parameter. 

@Jermolene -- Can you add the import handling?