### PR TITLE
Make All Hex Color Code Consistent in Vanilla Palette

### DIFF
--- a/core/palettes/Vanilla.tid
+++ b/core/palettes/Vanilla.tid
@@ -32,7 +32,7 @@ dragger-background: <<colour foreground>>
 dragger-foreground: <<colour background>>
 dropdown-background: <<colour background>>
 dropdown-border: <<colour muted-foreground>>
-dropdown-tab-background-selected: #fff
+dropdown-tab-background-selected: #ffffff
 dropdown-tab-background: #ececec
 dropzone-background: rgba(0,200,0,0.7)
 external-link-background-hover: inherit
@@ -54,7 +54,7 @@ modal-border: #999999
 modal-footer-background: #f5f5f5
 modal-footer-border: #dddddd
 modal-header-border: #eeeeee
-muted-foreground: #bbb
+muted-foreground: #bbbbbb
 network-activity-foreground: #448844
 notification-background: #ffffdd
 notification-border: #999999
@@ -98,7 +98,7 @@ tab-foreground: #666666
 table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
-tag-background: #ec6
+tag-background: #eecc66
 tag-foreground: #ffffff
 testcase-accent-level-1: #c1eaff
 testcase-accent-level-2: #E3B740
@@ -132,11 +132,11 @@ toolbar-done-button:
 untagged-background: #999999
 very-muted-foreground: #888888
 wikilist-background: #e5e5e5
-wikilist-item: #fff
-wikilist-info: #000
-wikilist-title: #666
+wikilist-item: #ffffff
+wikilist-info: #000000
+wikilist-title: #666666
 wikilist-title-svg: <<colour wikilist-title>>
-wikilist-url: #aaa
+wikilist-url: #aaaaaa
 wikilist-button-open: #4fb82b
 wikilist-button-open-hover: green
 wikilist-button-reveal: #5778d8
@@ -144,7 +144,7 @@ wikilist-button-reveal-hover: blue
 wikilist-button-remove: #d85778
 wikilist-button-remove-hover: red
 wikilist-toolbar-background: #d3d3d3
-wikilist-toolbar-foreground: #888
+wikilist-toolbar-foreground: #888888
 wikilist-droplink-dragover: rgba(255,192,192,0.5)
 wikilist-button-background: #acacac
-wikilist-button-foreground: #000
+wikilist-button-foreground: #000000


### PR DESCRIPTION
This PR is the first in the set of PRs make palette hex color code 6 digits everywhere.
It ONLY touches those color value which are
1. hex code
2. and three chars

So, every color value in hex will have 6 digits. If a color code uses alpha channel, it already has 8 chars (two for alpha channel).

If this one merged, I will look at the other palette to make all consistent. At the next stage I would like to change rgb and rgba value to hex value.