### PR TITLE
[DOCS] Update commands in "Generating Static Sites with TiddlyWiki" to use render command

### DIFF
--- a/editions/tw5.com/tiddlers/commands/RenderTiddlerCommand.tid
+++ b/editions/tw5.com/tiddlers/commands/RenderTiddlerCommand.tid
@@ -1,6 +1,9 @@
-title: RenderTiddlerCommand
-tags: Commands
 caption: rendertiddler
+created: 20241007001432813
+modified: 20241007001436537
+tags: Commands $:/deprecated
+title: RenderTiddlerCommand
+type: text/vnd.tiddlywiki
 
 <<.deprecated-since "5.1.15" "RenderCommand">>.
 

--- a/editions/tw5.com/tiddlers/commands/RenderTiddlersCommand.tid
+++ b/editions/tw5.com/tiddlers/commands/RenderTiddlersCommand.tid
@@ -1,6 +1,9 @@
-title: RenderTiddlersCommand
-tags: Commands
 caption: rendertiddlers
+created: 20241007001456103
+modified: 20241007001458097
+tags: Commands $:/deprecated
+title: RenderTiddlersCommand
+type: text/vnd.tiddlywiki
 
 <<.deprecated-since "5.1.15" "RenderCommand">>.
 

--- a/editions/tw5.com/tiddlers/commands/SaveTiddlerCommand.tid
+++ b/editions/tw5.com/tiddlers/commands/SaveTiddlerCommand.tid
@@ -1,8 +1,9 @@
-title: SaveTiddlerCommand
-tags: Commands
-created: 20131218121606089
-modified: 20131218121606089
 caption: savetiddler
+created: 20131218121606089
+modified: 20241007001528652
+tags: Commands $:/deprecated
+title: SaveTiddlerCommand
+type: text/vnd.tiddlywiki
 
 <<.deprecated-since "5.1.15" "SaveCommand">>.
 

--- a/editions/tw5.com/tiddlers/commands/SaveTiddlersCommand.tid
+++ b/editions/tw5.com/tiddlers/commands/SaveTiddlersCommand.tid
@@ -1,8 +1,9 @@
-title: SaveTiddlersCommand
-tags: Commands
-created: 20140609121606089
-modified: 20140609121606089
 caption: savetiddlers
+created: 20140609121606089
+modified: 20241007001543405
+tags: Commands $:/deprecated
+title: SaveTiddlersCommand
+type: text/vnd.tiddlywiki
 
 <<.deprecated-since "5.1.15" "SaveCommand">>.
 

--- a/editions/tw5.com/tiddlers/howtos/Generating Static Sites with TiddlyWiki.tid
+++ b/editions/tw5.com/tiddlers/howtos/Generating Static Sites with TiddlyWiki.tid
@@ -1,5 +1,5 @@
 created: 20130828190200000
-modified: 20200421003440463
+modified: 20241007003103647
 tags: [[TiddlyWiki on Node.js]]
 title: Generating Static Sites with TiddlyWiki
 type: text/vnd.tiddlywiki
@@ -16,13 +16,13 @@ You can explore a static representation of the main TiddlyWiki site at https://t
 
 The following commands are used to generate the sample static version of the TiddlyWiki5 site:
 
-```
-tiddlywiki wikipath --rendertiddlers '[!is[system]]' $:/core/templates/static.tiddler.html static text/plain
-tiddlywiki wikipath --rendertiddler $:/core/templates/static.template.html static.html text/plain
-tiddlywiki wikipath --rendertiddler $:/core/templates/static.template.css static/static.css text/plain
+```sh
+tiddlywiki wikipath --render '[!is[system]]' '[encodeuricomponent[]addprefix[static/]]' text/plain $:/core/templates/static.tiddler.html
+tiddlywiki wikipath --render $:/core/templates/static.template.html static.html text/plain
+tiddlywiki wikipath --render $:/core/templates/static.template.css static/static.css text/plain
 ```
 
-The first RenderTiddlersCommand generates the HTML representations of individual tiddlers, the second RenderTiddlerCommand saves the static version of the DefaultTiddlers, and the final RenderTiddlerCommand saves the stylesheet. (All the files are placed in the `output` folder of the wiki folder).
+The first RenderCommand generates the HTML representations of individual tiddlers, `[encodeuricomponent[]addprefix[static/]]` applies URI encoding to each title, and then adds the prefix `static/`. The second RenderCommand saves the static version of the DefaultTiddlers, and the final RenderCommand saves the stylesheet. (All the files are placed in the `output` folder of the wiki folder).
 
 ! Wiki Snapshot with Internal Links
 
@@ -33,5 +33,5 @@ For example: https://tiddlywiki.com/alltiddlers.html
 The example is built by the following commands:
 
 ```
---rendertiddler $:/core/templates/alltiddlers.template.html alltiddlers.html text/plain
+--render $:/core/templates/alltiddlers.template.html alltiddlers.html text/plain
 ```


### PR DESCRIPTION
Update commands in "Generating Static Sites with TiddlyWiki" to use render command, and add `$:/deprecated` tag to deprecated commands.