### PR TITLE
Small fix for en-PH language

### DIFF
--- a/editions/full/tiddlywiki.info
+++ b/editions/full/tiddlywiki.info
@@ -33,7 +33,7 @@
 		"de-AT",
 		"de-DE",
 		"el-GR",
-    "en-PH",
+		"en-PH",
 		"en-US",
 		"es-ES",
 		"fa-IR",

--- a/languages/en-PH/plugin.info
+++ b/languages/en-PH/plugin.info
@@ -2,7 +2,7 @@
 	"title": "$:/languages/en-PH",
 	"name": "en-PH",
 	"plugin-type": "language",
-	"description": "English (PH)",
+	"description": "English (Philippines)",
 	"author": "JC John Sese Cuneta",
 	"core-version": ">=5.3.5"
 }


### PR DESCRIPTION
A small fix for two problems introduced in #8669.

* Two tab should be used to indent instead of four spaces in `tiddlywiki.info` in full edition.
* Changed description for `en-PH`. Since "PH" isn't a country name like "US", it should be "Philippines".