### PR TITLE
Further fix content overflow.

### DIFF
--- a/core/ui/TagManager.tid
+++ b/core/ui/TagManager.tid
@@ -62,7 +62,6 @@ color: #bbb
 \end
 
 \whitespace trim
-<div class="tc-table-wrapper">
 <table class="tc-tag-manager-table">
 <tbody>
 	<tr>
@@ -117,4 +116,3 @@ color: #bbb
 	</tr>
 </tbody>
 </table>
-</div>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2793,18 +2793,9 @@ a.tc-tiddlylink.tc-plugin-info:hover > .tc-plugin-info-chunk .tc-plugin-info-sta
 	display: table;
 }
 
-/* Fix overflow in table and toc */
-.tc-tiddler-body .tc-tabbed-table-of-contents {
+/* Fix overflow toc, manager and testcase output */
+.tc-tiddler-body .tc-tabbed-table-of-contents, .tc-manager-list-item-content, .tc-test-case-output {
 	overflow-x: auto;
-}
-
-.tc-tiddler-body > table {
-  display: block;
-  overflow: auto;
-}
-.tc-tiddler-body > table tbody {
-  display: table;
-  width: 100%;
 }
 
 /* A wrapper to fix table overflow */


### PR DESCRIPTION
This reverts fix for all tables. It should fix #8617.

It also adds fix for overflow in `$:/Manager` 's content page, testcase widget output. The fix for overflow `$:/TagManager` is reverted since it caused the dropdown not to display properly.

![图片](https://github.com/user-attachments/assets/d353037f-66a1-4e94-93b9-48a8810df41e)
