### PR TITLE
Adjust multi-columns CSS class to switch earlier for smaller displays

### DIFF
--- a/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
+++ b/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
@@ -117,9 +117,16 @@ type: text/vnd.tiddlywiki
 	-webkit-column-gap: 1em;
 }
 
-@media (max-width: {{$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint}}) {
+/* Switch to 2 columns for 780x1280 displays which is 780p */
+@media (max-width: 1279px) {
 	.multi-columns {
 		column-count: 2;
+	}
+}
+
+@media (max-width: {{$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint}}) {
+	.multi-columns {
+		column-count: 1;
 	}
 }
 


### PR DESCRIPTION
Related to PR #8684 -- This PR switches the `multi-columns` class 2 times.

- <1280 ... to 2 columns
- <960 ... to 1 column
