### PR TITLE
Dynamic build commands

### DIFF
--- a/core/language/en-GB/Help/echo.tid
+++ b/core/language/en-GB/Help/echo.tid
@@ -1,0 +1,8 @@
+title: $:/language/Help/echo
+description: Displays all the passed arguments
+
+Displays all the passed arguments to a command. Useful for debugging.
+
+```
+--echo <text> *
+```

--- a/core/modules/commander.js
+++ b/core/modules/commander.js
@@ -136,7 +136,7 @@ Commander.prototype.stringifyToken = function(index,callback) {
 			switch(token.type) {
 				case "filter":
 					return callback(null,this.wiki.filterTiddlers(token.text)[0] || "");
-				case "wikified":
+				case "wikify":
 					return callback(null,this.wiki.renderText("text/plain","text/vnd.tiddlywiki",token.text,{
 						parseAsInline: false,
 						parentWidget: $tw.rootWidget

--- a/core/modules/commands/echo.js
+++ b/core/modules/commands/echo.js
@@ -1,0 +1,32 @@
+/*\
+title: $:/core/modules/commands/echo.js
+type: application/javascript
+module-type: command
+
+Command to echo input parameters
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.info = {
+	name: "echo",
+	synchronous: true
+};
+
+var Command = function(params,commander) {
+	this.params = params;
+	this.commander = commander;
+};
+
+Command.prototype.execute = function() {
+	this.commander.streams.output.write(JSON.stringify(this.params,null,4) + "\n");
+	return null;
+};
+
+exports.Command = Command;
+
+})();

--- a/core/modules/startup/commands.js
+++ b/core/modules/startup/commands.js
@@ -29,7 +29,11 @@ exports.startup = function(callback) {
 			callback();
 		},
 		$tw.wiki,
-		{output: process.stdout, error: process.stderr}
+		{
+			output: process.stdout,
+			input: process.stdin,
+			error: process.stderr
+		}
 	);
 	commander.execute();
 };

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -21,6 +21,50 @@ exports.log = function(text,colour) {
 	console.log($tw.node ? exports.terminalColour(colour) + text + exports.terminalColour() : text);
 };
 
+/*
+Prompts the user for input and handles the input using a callback function. Options:
+promptText: Prompt text
+defaultResult: Default result returned if the user types enter
+callback: callback invoked (err,usertext)
+input: optional input stream
+output: optional output stream
+*/
+exports.terminalQuestion = function(options) {
+	var readline = require("readline"),
+		promptText = options.promptText,
+		defaultResult = options.defaultResult,
+		callback = options.callback,
+		inputStream = options.input || process.stdin,
+		outputStream = options.output || process.stdout;
+	var rl = readline.createInterface({
+		input: inputStream,
+		output: outputStream
+	});
+	// Handle errors on the input stream
+	rl.on("error",function(err) {
+		rl.close();
+		callback(err); // Pass the error to the callback
+	});
+	// Prompt user for input
+	var prompt = exports.terminalColourText(promptText,"yellow");
+	if(defaultResult) {
+		prompt += exports.terminalColourText(" (" + defaultResult + ")","blue");
+	}
+	prompt += exports.terminalColourText(": ");
+	rl.question(prompt,function(input) {
+		// Use default value for the empty string
+		if(input === "" && defaultResult) {
+			input = defaultResult;
+		}
+		callback(null,input);  // Pass the input to the callback
+		rl.close();
+	});
+};
+
+exports.terminalColourText = function(text,colour) {
+	return exports.terminalColour(colour) + text + exports.terminalColour("reset");
+};
+
 exports.terminalColour = function(colour) {
 	if(!$tw.browser && $tw.node && process.stdout.isTTY) {
 		if(colour) {
@@ -36,14 +80,24 @@ exports.terminalColour = function(colour) {
 };
 
 exports.terminalColourLookup = {
+	"reset": "0;0",
 	"black": "0;30",
 	"red": "0;31",
 	"green": "0;32",
-	"brown/orange": "0;33",
+	"yellow": "0;33",
+	"brown/orange": "0;33", // Backwards compatbility
 	"blue": "0;34",
 	"purple": "0;35",
 	"cyan": "0;36",
-	"light gray": "0;37"
+	"white": "0;37",
+	"gray": "0;90",
+	"light red": "0;91",
+	"light green": "0;92",
+	"light yellow": "0;93",
+	"light blue": "0;94",
+	"light purple": "0;95",
+	"light cyan": "0;96",
+	"light gray": "0;97"
 };
 
 /*

--- a/editions/tw5.com/tiddlers/commands/EchoCommand.tid
+++ b/editions/tw5.com/tiddlers/commands/EchoCommand.tid
@@ -1,0 +1,8 @@
+caption: echo
+created: 20241019150907690
+modified: 20241019150907690
+tags: Commands
+title: EchoCommand
+type: text/vnd.tiddlywiki
+
+{{$:/language/Help/echo}}

--- a/editions/tw5.com/tiddlers/nodejs/tiddlywiki.info_Files.tid
+++ b/editions/tw5.com/tiddlers/nodejs/tiddlywiki.info_Files.tid
@@ -1,17 +1,17 @@
 created: 20161015114042793
-modified: 20211114101249016
+modified: 20241019145819938
 tags: TiddlyWikiFolders [[TiddlyWiki on Node.js]]
 title: tiddlywiki.info Files
 type: text/vnd.tiddlywiki
 
 [[TiddlyWikiFolders]] are configured with a single `tiddlywiki.info` file in the root of the wiki folder. It should contain a JSON object comprising the following properties:
 
-* ''plugins'' - an array of plugin names to be included in the wiki
-* ''themes'' - an array of theme names to be included in the wiki
-* ''languages'' - an array of language names to be included in the wiki
-* ''includeWikis'' - an array of references to external wiki folders to be included in the wiki
-* ''build'' - a hashmap of named build targets, each defined by an array of command tokens (see BuildCommand)
-* ''config'' - an optional hashmap of configuration options (see below)
+* ''plugins'' - optional array of plugin names to be included in the wiki
+* ''themes'' - optional array of theme names to be included in the wiki
+* ''languages'' - optional array of language names to be included in the wiki
+* ''includeWikis'' - optional array of references to external wiki folders to be included in the wiki
+* ''build'' - optional hashmap of named build targets, each defined by an array of command tokens (see BuildCommand)
+* ''config'' - optional hashmap of configuration options (see below)
 
 !!! ''includeWikis''
 
@@ -22,7 +22,44 @@ The entries in the ''includeWikis'' array can be either a string specifying the 
 
 !!! ''build''
 
+The ''build'' property contains a hashmap of named build targets. Each of the build targets is defined as an array of command tokens.
+
 Note that the build targets of included wikis are merged if a target of that name isn't defined in the current `tiddlywiki.info` file.
+
+Command tokens can be a simple string or a command token object with a ''type'' property. The following types are defined to allow the command token to be dynamically defined:
+
+* ''filter'': the value of the first result of a filter expression specified in the ''text'' property of the command token object
+* ''wikify'': the result of wikifying a text string specified in the ''text'' property of the command token object
+* ''prompt'': the result of prompting the user for a string. The ''prompt'' property of the command token object specifies the textual prompt to be used. The optional ''default'' property specifies a string value to be used if the user presses enter in response to the prompt
+
+The EchoCommand is useful for debugging complex dynamic command tokens.
+
+For example:
+
+```
+"build": {
+	"dynamic": [
+		"--echo","testing",
+		"the following argument is wikified",
+		{
+			"type": "wikify",
+			"text": "<<version>>-prod.html"
+		},
+		"the following argument is a filter result",
+		{
+			"type": "filter",
+			"text": "[<version>!match[5.3.6-prerelease]then[text/html]else[text/plain]]"
+		},
+		"the following argument was provided by the user",
+		{
+			"type": "prompt",
+			"prompt": "Please enter some text and type enter",
+			"default": "Nothing"
+		}
+	],
+...
+```
+
 
 !!! ''config''
 

--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -23,22 +23,23 @@
 	"languages": [
 	],
 	"build": {
-		"dynamic": [
+		"dynamic-example": [
 			"--echo","testing",
+			"the following argument is wikified",
 			{
 				"type": "wikify",
 				"text": "<<version>>-prod.html"
 			},
-			"thingy",
+			"the following argument is a filter result",
 			{
 				"type": "filter",
 				"text": "[<version>!match[5.3.6-prerelease]then[text/html]else[text/plain]]"
 			},
-			"dinghy",
+			"the following argument was provided by the user",
 			{
 				"type": "prompt",
-				"prompt": "Please enter the name of your new wiki",
-				"default": "untitled"
+				"prompt": "Please enter some text and type enter",
+				"default": "Nothing"
 			}
 		],
 		"index": [

--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -33,6 +33,12 @@
 			{
 				"type": "filter",
 				"text": "[<version>!match[5.3.6-prerelease]then[text/html]else[text/plain]]"
+			},
+			"dinghy",
+			{
+				"type": "prompt",
+				"prompt": "Please enter the name of your new wiki",
+				"default": "untitled"
 			}
 		],
 		"index": [

--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -23,6 +23,18 @@
 	"languages": [
 	],
 	"build": {
+		"dynamic": [
+			"--echo","testing",
+			{
+				"type": "wikified",
+				"text": "<<version>>-prod.html"
+			},
+			"thingy",
+			{
+				"type": "filter",
+				"text": "[<version>!match[5.3.6-prerelease]then[text/html]else[text/plain]]"
+			}
+		],
 		"index": [
 			"--savetiddlers","[tag[external-image]]","images",
 			"--render","[tag[external-text]]","[encodeuricomponent[]addprefix[text/]addsuffix[.tid]]","text/plain","$:/core/templates/tid-tiddler",

--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -26,7 +26,7 @@
 		"dynamic": [
 			"--echo","testing",
 			{
-				"type": "wikified",
+				"type": "wikify",
 				"text": "<<version>>-prod.html"
 			},
 			"thingy",


### PR DESCRIPTION
This PR extends the format for build targets in `tiddlywiki.info` files to allow command tokens to be generated dynamically. It currently supports wikification, filter evaluation, and prompting the user for a value.

The hope is that these features will make it possible to for `--build` commands to implement the kind of operations proposed in #8294 instead of using npm commands which have proved difficult to get working across all our supported platforms.

This PR also introduces a new `--echo` command to make it easier to test dynamic command tokens.

Here's a contrived example:

```
"build": {
	"dynamic": [
		"--echo","testing",
		"the following argument is wikified",
		{
			"type": "wikify",
			"text": "<<version>>-prod.html"
		},
		"the following argument is a filter result",
		{
			"type": "filter",
			"text": "[<version>!match[5.3.6-prerelease]then[text/html]else[text/plain]]"
		},
		"the following argument was provided by the user",
		{
			"type": "prompt",
			"prompt": "Please enter some text and type enter",
			"default": "Nothing"
		}
	],
...
```
