### PR TITLE
Fix timeline macro showing long list of tiddlers created the same day.

### DIFF
--- a/core/wiki/macros/timeline.tid
+++ b/core/wiki/macros/timeline.tid
@@ -1,25 +1,25 @@
-created: 20141212105914482
-modified: 20141212110330815
-tags: $:/tags/Macro
+tags: $:/tags/Macro $:/tags/Global
 title: $:/core/macros/timeline
 
 <!-- Override one or both of the following two macros with a global or local macro of the same name 
 if you need to change how titles are displayed on a timeline -->
 
-\define timeline-title() <$view field="title"/>
-\define timeline-link() <$link to={{!!title}}><<timeline-title>></$link>
-\define timeline(limit:"100",format:"DDth MMM YYYY",subfilter:"",dateField:"modified")
+\procedure timeline-title() <$view field="title"/>
+\procedure timeline-link() <$link to={{!!title}}><<timeline-title>></$link>
+\procedure timeline(limit:"100",format:"DDth MMM YYYY",subfilter:"",dateField:"modified")
 \whitespace trim
 <div class="tc-timeline">
-<$list filter="[!is[system]$subfilter$has[$dateField$]!sort[$dateField$]limit[$limit$]eachday[$dateField$]]">
+<$set name="tv-tids" filter=`[!is[system]$(subfilter)$has<dateField>!sort<dateField>limit<limit>]`>
+<$list filter="[enlist<tv-tids>eachday<dateField>]">
 <div class="tc-menu-list-item">
-<$view field="$dateField$" format="date" template="$format$"/>
-<$list filter="[sameday:$dateField${!!$dateField$}!is[system]$subfilter$!sort[$dateField$]]">
+<$view field=<<dateField>> format="date" template=<<format>>/>
+<$list filter=`[enlist<tv-tids>sameday:$(dateField)${!!$(dateField)$}]`>
 <div class="tc-menu-list-subitem">
 <<timeline-link>>
 </div>
 </$list>
 </div>
 </$list>
+</$set>
 </div>
 \end


### PR DESCRIPTION
Attempt to fix #8127 and migrate it to use new syntax.

Since the two timestamp fields is strange in core macros, I removed them.