### PR TITLE
Improve package json new scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,41 +1,69 @@
 {
-  "name": "tiddlywiki",
-  "preferGlobal": "true",
-  "version": "5.3.6-prerelease",
-  "author": "Jeremy Ruston <jeremy@jermolene.com>",
-  "description": "a non-linear personal web notebook",
-  "contributors": [
-    {
-      "name": "Jeremy Ruston",
-      "email": "jeremy@jermolene.com"
-    }
-  ],
-  "bin": {
-    "tiddlywiki": "./tiddlywiki.js"
-  },
-  "main": "./boot/boot.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/TiddlyWiki/TiddlyWiki5.git"
-  },
-  "keywords": [
-    "tiddlywiki",
-    "tiddlywiki5",
-    "wiki"
-  ],
-  "devDependencies": {
-    "eslint": "^9.12.0",
-    "@eslint/js": "^9.12.0"
-  },
-  "bundleDependencies": [],
-  "license": "BSD",
-  "engines": {
-    "node": ">=0.8.2"
-  },
-  "scripts": {
-    "dev": "node ./tiddlywiki.js ./editions/tw5.com-server --listen",
-    "test": "node ./tiddlywiki.js ./editions/test --verbose --version --build index",
-    "lint:fix": "eslint . --fix",
-    "lint": "eslint ."
-  }
+	"name": "tiddlywiki",
+	"preferGlobal": "true",
+	"version": "5.3.6-prerelease",
+	"author": "Jeremy Ruston <jeremy@jermolene.com>",
+	"description": "a non-linear personal web notebook",
+	"contributors": [
+		{
+			"name": "Jeremy Ruston",
+			"email": "jeremy@jermolene.com"
+		}
+	],
+	"bin": {
+		"tiddlywiki": "./tiddlywiki.js"
+	},
+	"main": "./boot/boot.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/TiddlyWiki/TiddlyWiki5.git"
+	},
+	"keywords": [
+		"tiddlywiki",
+		"tiddlywiki5",
+		"wiki"
+	],
+	"devDependencies": {
+		"eslint": "^9.12.0",
+		"@eslint/js": "^9.12.0"
+	},
+	"bundleDependencies": [],
+	"license": "BSD",
+	"engines": {
+		"node": ">=20.17.0"
+	},
+	"scripts": {
+		"start": "node ./tiddlywiki.js ./editions/tw5.com-server --listen",
+		"test": "node ./tiddlywiki.js ./editions/test --verbose --version --build index",
+
+		"watch:info": "echo \"npm run watch\" needs Node.js V20.x to work",
+		"watch": "node --watch-path=./core --watch-preserve-output ./tiddlywiki.js ./editions/tw5.com-server --listen",
+
+		"wiki:info": "echo \"use: npm run wiki --edition=<wiki> [empty, prerelease, dev, tour, tw.org, upgrade, full]\"",
+		"wiki": "node ./tiddlywiki.js +plugins/tiddlywiki/filesystem +plugins/tiddlywiki/tiddlyweb ./editions/%npm_config_edition% --listen",
+
+		"edition:info": "echo \"use: npm run edition --edition=tw5.com [de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
+		"edition": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen",
+
+		"lazy:info": "echo \"use: npm run lazy --edition=tw5.com [de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
+		"lazy": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen root-tiddler=$:/core/save/lazy-all",
+
+		"server": "node ./tiddlywiki.js ./editions/server --listen",
+		"server-external-js": "node ./tiddlywiki.js ./editions/server-external-js --listen",
+
+		"library:info": "echo \"use: npm run library\" && echo \"IMPORTANT: It starts on port:8888\"",
+		"library": "node ./tiddlywiki.js ./editions/pluginlibrary --build test-server",
+
+		"help": "node ./tiddlywiki.js --help",
+
+		"lint": "eslint .",
+		"lint:fix": "eslint . --fix",
+
+		"prewiki": "npm run wiki:info -s",
+		"postwiki:info" : "echo \"or: [translators, aws, classicparserdemo, codemirrordemo, d3demo, dynaviewdemo, geospatialdemo, highlightdemo, innerwikidemo, introduction, ja-JP, katexdemo, markdowndemo, prerelease, resumebuilder, share, tw5.com-docs, text-slicer, twitter-archivist, zh-Hans, zh-Hant\"",
+
+		"preedition": "npm run edition:info -s",
+		"pre:lazy": "npm run edition:lazy:info -s",
+		"prelibrary": "npm run library:info -s"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -36,20 +36,27 @@
 		"start": "node ./tiddlywiki.js ./editions/tw5.com-server --listen",
 		"test": "node ./tiddlywiki.js ./editions/test --verbose --version --build index",
 
-		"edition:info": "echo \"use: npm run edition --edition=<wiki> [tw5.com, de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
-		"wiki:info": "echo \"use: npm run wiki --edition=<wiki> [empty, prerelease, dev, tour, tw.org, upgrade, full]\"",
-		"lazy:info": "echo \"use: npm run lazy --edition=tw5.com [de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
+		"server:info": "echo \"use: npm run server --edition=<name> [tw5.com, de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
+		"wiki:info": "echo \"use: npm run wiki --edition=<name> [empty, prerelease, dev, tour, tw.org, upgrade, full]\"",
+		"lazy:info": "echo \"use: npm run lazy --edition=<name> [tw5.com, de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
 		"library:info": "echo \"use: npm run library\" && echo \"IMPORTANT: It starts on port:8888\"",
-		"watch:info": "echo \"npm run watch\" needs Node.js V20.x to work",
 
-		"edition": "export npm_config_edition=tw5.com || set npm_config_edition=tw5.com && node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen",
+		"watch:info": "echo \"npm run watch\" needs Node.js V20.x to work",
+		"build:info": "echo \"use: npm run build --edition=<name> [tw5.com, de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
+
+		"server": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen",
 		"wiki": "node ./tiddlywiki.js +plugins/tiddlywiki/filesystem +plugins/tiddlywiki/tiddlyweb ./editions/%npm_config_edition% --listen",
 		"lazy": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen root-tiddler=$:/core/save/lazy-all",
+
 		"library": "node ./tiddlywiki.js ./editions/pluginlibrary --build test-server",
 		"watch": "node --watch-path=./core --watch-preserve-output ./tiddlywiki.js ./editions/tw5.com-server --listen",
 
-		"server": "node ./tiddlywiki.js ./editions/server --listen",
+		"server-empty": "node ./tiddlywiki.js ./editions/server --listen",
 		"server-external-js": "node ./tiddlywiki.js ./editions/server-external-js --listen",
+
+		"build": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --build index",
+		"build:all": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --build",
+
 		"help": "node ./tiddlywiki.js --help",
 
 		"lint": "eslint .",
@@ -58,8 +65,9 @@
 		"prewiki": "npm run wiki:info -s",
 		"postwiki:info" : "echo \"or: [translators, aws, classicparserdemo, codemirrordemo, d3demo, dynaviewdemo, geospatialdemo, highlightdemo, innerwikidemo, introduction, ja-JP, katexdemo, markdowndemo, prerelease, resumebuilder, share, tw5.com-docs, text-slicer, twitter-archivist, zh-Hans, zh-Hant\"",
 
-		"preedition": "npm run edition:info -s",
-		"pre:lazy": "npm run edition:lazy:info -s",
-		"prelibrary": "npm run library:info -s"
+		"preserver": "npm run server:info -s",
+		"prelazy": "npm run lazy:info -s",
+		"prelibrary": "npm run library:info -s",
+		"prebuild": "npm run build:info -s"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -36,19 +36,20 @@
 		"start": "node ./tiddlywiki.js ./editions/tw5.com-server --listen",
 		"test": "node ./tiddlywiki.js ./editions/test --verbose --version --build index",
 
-		"watch:info": "echo \"npm run watch\" needs Node.js V20.x to work",
-		"wiki:info": "echo \"use: npm run wiki --edition=<wiki> [empty, prerelease, dev, tour, tw.org, upgrade, full]\"",
 		"edition:info": "echo \"use: npm run edition --edition=tw5.com [de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
+		"wiki:info": "echo \"use: npm run wiki --edition=<wiki> [empty, prerelease, dev, tour, tw.org, upgrade, full]\"",
 		"lazy:info": "echo \"use: npm run lazy --edition=tw5.com [de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
 		"library:info": "echo \"use: npm run library\" && echo \"IMPORTANT: It starts on port:8888\"",
+		"watch:info": "echo \"npm run watch\" needs Node.js V20.x to work",
 
-		"watch": "node --watch-path=./core --watch-preserve-output ./tiddlywiki.js ./editions/tw5.com-server --listen",
-		"wiki": "node ./tiddlywiki.js +plugins/tiddlywiki/filesystem +plugins/tiddlywiki/tiddlyweb ./editions/%npm_config_edition% --listen",
 		"edition": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen",
+		"wiki": "node ./tiddlywiki.js +plugins/tiddlywiki/filesystem +plugins/tiddlywiki/tiddlyweb ./editions/%npm_config_edition% --listen",
 		"lazy": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen root-tiddler=$:/core/save/lazy-all",
+		"library": "node ./tiddlywiki.js ./editions/pluginlibrary --build test-server",
+		"watch": "node --watch-path=./core --watch-preserve-output ./tiddlywiki.js ./editions/tw5.com-server --listen",
+
 		"server": "node ./tiddlywiki.js ./editions/server --listen",
 		"server-external-js": "node ./tiddlywiki.js ./editions/server-external-js --listen",
-		"library": "node ./tiddlywiki.js ./editions/pluginlibrary --build test-server",
 		"help": "node ./tiddlywiki.js --help",
 
 		"lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -37,23 +37,18 @@
 		"test": "node ./tiddlywiki.js ./editions/test --verbose --version --build index",
 
 		"watch:info": "echo \"npm run watch\" needs Node.js V20.x to work",
-		"watch": "node --watch-path=./core --watch-preserve-output ./tiddlywiki.js ./editions/tw5.com-server --listen",
-
 		"wiki:info": "echo \"use: npm run wiki --edition=<wiki> [empty, prerelease, dev, tour, tw.org, upgrade, full]\"",
-		"wiki": "node ./tiddlywiki.js +plugins/tiddlywiki/filesystem +plugins/tiddlywiki/tiddlyweb ./editions/%npm_config_edition% --listen",
-
 		"edition:info": "echo \"use: npm run edition --edition=tw5.com [de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
-		"edition": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen",
-
 		"lazy:info": "echo \"use: npm run lazy --edition=tw5.com [de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
-		"lazy": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen root-tiddler=$:/core/save/lazy-all",
+		"library:info": "echo \"use: npm run library\" && echo \"IMPORTANT: It starts on port:8888\"",
 
+		"watch": "node --watch-path=./core --watch-preserve-output ./tiddlywiki.js ./editions/tw5.com-server --listen",
+		"wiki": "node ./tiddlywiki.js +plugins/tiddlywiki/filesystem +plugins/tiddlywiki/tiddlyweb ./editions/%npm_config_edition% --listen",
+		"edition": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen",
+		"lazy": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen root-tiddler=$:/core/save/lazy-all",
 		"server": "node ./tiddlywiki.js ./editions/server --listen",
 		"server-external-js": "node ./tiddlywiki.js ./editions/server-external-js --listen",
-
-		"library:info": "echo \"use: npm run library\" && echo \"IMPORTANT: It starts on port:8888\"",
 		"library": "node ./tiddlywiki.js ./editions/pluginlibrary --build test-server",
-
 		"help": "node ./tiddlywiki.js --help",
 
 		"lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -36,38 +36,21 @@
 		"start": "node ./tiddlywiki.js ./editions/tw5.com-server --listen",
 		"test": "node ./tiddlywiki.js ./editions/test --verbose --version --build index",
 
-		"server:info": "echo \"use: npm run server --edition=<name> [tw5.com, de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
-		"wiki:info": "echo \"use: npm run wiki --edition=<name> [empty, prerelease, dev, tour, tw.org, upgrade, full]\"",
-		"lazy:info": "echo \"use: npm run lazy --edition=<name> [tw5.com, de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
-		"library:info": "echo \"use: npm run library\" && echo \"IMPORTANT: It starts on port:8888\"",
-
-		"watch:info": "echo \"npm run watch\" needs Node.js V20.x to work",
-		"build:info": "echo \"use: npm run build --edition=<name> [tw5.com, de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
-
-		"server": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen",
-		"wiki": "node ./tiddlywiki.js +plugins/tiddlywiki/filesystem +plugins/tiddlywiki/tiddlyweb ./editions/%npm_config_edition% --listen",
-		"lazy": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen root-tiddler=$:/core/save/lazy-all",
-
-		"library": "node ./tiddlywiki.js ./editions/pluginlibrary --build test-server",
+		"lazy": "node ./tiddlywiki.js ./editions/tw5.com-server --listen root-tiddler=$:/core/save/lazy-all",
 		"watch": "node --watch-path=./core --watch-preserve-output ./tiddlywiki.js ./editions/tw5.com-server --listen",
 
-		"server-empty": "node ./tiddlywiki.js ./editions/server --listen",
-		"server-external-js": "node ./tiddlywiki.js ./editions/server-external-js --listen",
+		"dev": "node ./tiddlywiki.js +plugins/tiddlywiki/filesystem +plugins/tiddlywiki/tiddlyweb ./editions/dev --listen",
 
-		"build": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --build index",
-		"build:all": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --build",
+		"library:info": "echo The Warning below: \"Plugin(s) required for client-server operation are missing\" is INTENTIONAL, so no files will be saved back.",
+		"library": "node ./tiddlywiki.js ./editions/pluginlibrary --build test-server",
+
+		"build": "node ./tiddlywiki.js ./editions/tw5.com --build",
 
 		"help": "node ./tiddlywiki.js --help",
 
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
 
-		"prewiki": "npm run wiki:info -s",
-		"postwiki:info" : "echo \"or: [translators, aws, classicparserdemo, codemirrordemo, d3demo, dynaviewdemo, geospatialdemo, highlightdemo, innerwikidemo, introduction, ja-JP, katexdemo, markdowndemo, prerelease, resumebuilder, share, tw5.com-docs, text-slicer, twitter-archivist, zh-Hans, zh-Hant\"",
-
-		"preserver": "npm run server:info -s",
-		"prelazy": "npm run lazy:info -s",
-		"prelibrary": "npm run library:info -s",
-		"prebuild": "npm run build:info -s"
+		"prelibrary": "npm run library:info -s"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
 		"start": "node ./tiddlywiki.js ./editions/tw5.com-server --listen",
 		"test": "node ./tiddlywiki.js ./editions/test --verbose --version --build index",
 
-		"edition:info": "echo \"use: npm run edition --edition=tw5.com [de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
+		"edition:info": "echo \"use: npm run edition --edition=<wiki> [tw5.com, de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
 		"wiki:info": "echo \"use: npm run wiki --edition=<wiki> [empty, prerelease, dev, tour, tw.org, upgrade, full]\"",
 		"lazy:info": "echo \"use: npm run lazy --edition=tw5.com [de-AT, es-ES, fr-FR, ko-KR, xlsx-utils]\"",
 		"library:info": "echo \"use: npm run library\" && echo \"IMPORTANT: It starts on port:8888\"",
 		"watch:info": "echo \"npm run watch\" needs Node.js V20.x to work",
 
-		"edition": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen",
+		"edition": "export npm_config_edition=tw5.com || set npm_config_edition=tw5.com && node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen",
 		"wiki": "node ./tiddlywiki.js +plugins/tiddlywiki/filesystem +plugins/tiddlywiki/tiddlyweb ./editions/%npm_config_edition% --listen",
 		"lazy": "node ./tiddlywiki.js ./editions/%npm_config_edition%-server --listen root-tiddler=$:/core/save/lazy-all",
 		"library": "node ./tiddlywiki.js ./editions/pluginlibrary --build test-server",


### PR DESCRIPTION
A second try to add some more developer commands to the package.json file. 

The new commands should also give a nice introduction to what's possible with TW command parameters.

@Jermolene -- if the "echo" command would be implemented into tiddlywiki.info, I can remove `library:info` and `prelibrary` from the scripts section in this PR: