### PR TITLE
Fix: disable the storyview scroll in the "Open" tab

### DIFF
--- a/core/modules/storyviews/classic.js
+++ b/core/modules/storyviews/classic.js
@@ -27,7 +27,7 @@ ClassicStoryView.prototype.navigateTo = function(historyInfo) {
 	var listItemWidget = this.listWidget.children[listElementIndex],
 		targetElement = listItemWidget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE || listItemWidget.getVariable("tv-inherit-storyview-scroll") === "yes") {
 		return;
 	}
 	// Scroll the node into view

--- a/core/modules/storyviews/pop.js
+++ b/core/modules/storyviews/pop.js
@@ -24,7 +24,7 @@ PopStoryView.prototype.navigateTo = function(historyInfo) {
 	var listItemWidget = this.listWidget.children[listElementIndex],
 		targetElement = listItemWidget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE || listItemWidget.getVariable("tv-inherit-storyview-scroll") === "yes") {
 		return;
 	}
 	// Scroll the node into view

--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -52,7 +52,7 @@ ZoominListView.prototype.navigateTo = function(historyInfo) {
 	var listItemWidget = this.listWidget.children[listElementIndex],
 		targetElement = listItemWidget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement) {
+	if(!targetElement || listItemWidget.getVariable("tv-inherit-storyview-scroll") === "yes") {
 		return;
 	} else if (targetElement.nodeType === Node.TEXT_NODE) {
 		this.logTextNodeRoot(targetElement);

--- a/core/ui/SideBar/Open.tid
+++ b/core/ui/SideBar/Open.tid
@@ -23,6 +23,7 @@ $button$
 </$droppable>
 \end
 
+<$set name="tv-inherit-storyview-scroll" value="yes">
 <div class="tc-sidebar-tab-open">
 <$list filter="[list<tv-story-list>]" history=<<tv-history-list>> storyview="pop">
 <div class="tc-sidebar-tab-open-item">
@@ -35,3 +36,4 @@ $button$
 </div>
 </$tiddler>
 </div>
+</$set>


### PR DESCRIPTION
This PR adds a variable `tv-disable-storyview-scroll` that, if set, disables the scrolling to the target element.
This is useful in the sidebar's "Open" tab for example, where under certain circumstances it can cause the sidebar to scroll when opening a new tiddler or the control panel