### PR TITLE
Add dir attribute to simple inputs and framed inputs

### DIFF
--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -81,6 +81,9 @@ function FramedEngine(options) {
 	if(this.widget.isDisabled === "yes") {
 		this.domNode.setAttribute("disabled",true);
 	}
+	if(this.widget.editDirection) {
+		this.domNode.setAttribute("dir",this.widget.editDirection);
+	}
 	// Copy the styles from the dummy textarea
 	this.copyStyles();
 	// Add event listeners

--- a/core/modules/editor/engines/simple.js
+++ b/core/modules/editor/engines/simple.js
@@ -58,6 +58,9 @@ function SimpleEngine(options) {
 	if(this.widget.isDisabled === "yes") {
 		this.domNode.setAttribute("disabled",true);
 	}
+	if(this.widget.editDirection) {
+		this.domNode.setAttribute("dir",this.widget.editDirection);
+	}
 	// Add an input event handler
 	$tw.utils.addEventListeners(this.domNode,[
 		{name: "focus", handlerObject: this, handlerMethod: "handleFocusEvent"},

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -187,6 +187,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		this.editInputActions = this.getAttribute("inputActions");
 		this.editRefreshTitle = this.getAttribute("refreshTitle");
 		this.editAutoComplete = this.getAttribute("autocomplete");
+		this.editDirection = this.document.getElementsByTagName("html")[0].getAttribute("dir") || "ltr";
 		this.isDisabled = this.getAttribute("disabled","no");
 		this.isFileDropEnabled = this.getAttribute("fileDrop","no") === "yes";
 		// Get the default editor element tag and type


### PR DESCRIPTION
This PR makes the simple and framed inputs inherit the `dir` attribute from the `html` element
While the simple inputs should already inherit the direction from the context, the framed engine does not