### PR TITLE
Make recent tab limit configurable

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -175,6 +175,8 @@ Settings/NavigationPermalinkviewMode/UpdateAddressBar/Description: Update addres
 Settings/PerformanceInstrumentation/Caption: Performance Instrumentation
 Settings/PerformanceInstrumentation/Hint: Displays performance statistics in the browser developer console. Requires reload to take effect
 Settings/PerformanceInstrumentation/Description: Enable performance instrumentation
+Settings/RecentLimit/Caption: Recent Tab Limit 
+Settings/RecentLimit/Hint: Maximum number of tiddlers to be displayed under the sidebar "Recent" tab
 Settings/ToolbarButtonStyle/Caption: Toolbar Button Style
 Settings/ToolbarButtonStyle/Hint: Choose the style for toolbar buttons:
 Settings/ToolbarButtonStyle/Styles/Borderless: Borderless

--- a/core/ui/ControlPanel/Settings/RecentLimit.tid
+++ b/core/ui/ControlPanel/Settings/RecentLimit.tid
@@ -1,0 +1,10 @@
+title: $:/core/ui/ControlPanel/Settings/RecentLimit
+tags: $:/tags/ControlPanel/Settings
+caption: {{$:/language/ControlPanel/Settings/RecentLimit/Caption}}
+
+\whitespace trim
+\procedure lingo-base() $:/language/ControlPanel/Settings/RecentLimit/
+<<lingo Hint>>
+
+|tc-table-no-border|k
+|<$link to="$:/config/RecentLimit"><<lingo Caption>></$link> |<$edit-text tiddler="$:/config/RecentLimit" tag="input" type="number"/> |

--- a/core/ui/SideBar/Recent.tid
+++ b/core/ui/SideBar/Recent.tid
@@ -2,4 +2,4 @@ title: $:/core/ui/SideBar/Recent
 tags: $:/tags/SideBar
 caption: {{$:/language/SideBar/Recent/Caption}}
 
-<$macrocall $name="timeline" format={{$:/language/RecentChanges/DateFormat}}/>
+<$transclude $variable="timeline" format={{$:/language/RecentChanges/DateFormat}} limit={{$:/config/RecentLimit}}/>

--- a/core/wiki/config/RecentLimit.tid
+++ b/core/wiki/config/RecentLimit.tid
@@ -1,0 +1,3 @@
+title: $:/config/RecentLimit
+
+100


### PR DESCRIPTION
Make maxium number of tiddlers under the "Recent" tab configurable in the `$:/config/RecentLimit` tiddler. UI for configuring this option is also added under the "Settings" tab.

![图片](https://github.com/user-attachments/assets/f1fbeb83-3b41-47e7-94b0-9009487d7844)
