### PR TITLE
Make markdown's highlight look the same as tiddlywiki's

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -295,6 +295,13 @@ kbd {
 	color: <<colour highlight-foreground>>;
 }
 
+/* Markdown uses mark element to highlight */
+
+mark {
+	background: <<colour highlight-background>>;
+	color: <<colour highlight-foreground>>;
+}
+
 form.tc-form-inline {
 	display: inline;
 }


### PR DESCRIPTION
A small fix.

Let the `mark` element use the same style as the `tc-inline-style` class, so that markdown's highlight look the same as tiddlywiki's.

![图片](https://github.com/user-attachments/assets/52533f5c-c2e9-43af-859b-43492476689c)
