### PR TITLE
[DOCS] Use Node.js v 22.x.y for our GH build system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - master
       - tiddlywiki-com
 env:
-  NODE_VERSION: "18"
+  NODE_VERSION: "22"
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use Node.js v 22.x.y for our GH build system

We use v18 at the moment, which will be "End of Live" in April 25. So it's time to change that. 

The proposed `--watch-path` in PR: **Improve package json new scripts #8695** needs minimum 20.13.0 which also is in maintenance mode already.  See: https://nodejs.org/en/about/previous-releases