### PR TITLE
Fix tag pill wrong foreground

### DIFF
--- a/core/wiki/macros/tag.tid
+++ b/core/wiki/macros/tag.tid
@@ -50,7 +50,7 @@ color:$(foregroundColor)$;
 		<$macrocall $name="tag-pill-body"
 			tag=<<__tag__>>
 			icon={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerIconFilter]!is[draft]get[text]] }}}
-			colour={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}}
+			colour={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] :or[{$:/palette}getindex[tag-background]] :and[limit[1]] }}}
 			palette={{$:/palette}}
 			element-tag=<<__element-tag__>>
 			element-attributes=<<__element-attributes__>>


### PR DESCRIPTION
I found the problem when I was updating Flexoki palette. It was caused by the tag macro's not using the default color to pass it to `contrastcolour` macro.

This PR should fix it.

![图片](https://github.com/user-attachments/assets/b8f1dbb3-7aa2-4f31-8668-4b09293bc43f)
