### PR TITLE
[DOCS] Fix Tiddler Info Tab Default Description

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/Configuring the default TiddlerInfo tab.tid
+++ b/editions/tw5.com/tiddlers/howtos/Configuring the default TiddlerInfo tab.tid
@@ -1,12 +1,12 @@
 created: 20140828080837703
-modified: 20140912145908651
+modified: 20241103152604059
 tags: [[Customise TiddlyWiki]]
 title: Configuring the default TiddlerInfo tab
 type: text/vnd.tiddlywiki
 
 The configuration tiddler [[$:/config/TiddlerInfo/Default]] contains the title of the tiddler containing the default tiddler info tab.
 
-The default value is `$:/core/ui/TiddlerInfo/Tools` corresponding to the ''Tools'' tab. Other possible values are:
+The default value is `$:/core/ui/TiddlerInfo/Fields` corresponding to the ''Fields'' tab. Other possible values are:
 
 <ul>
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/TiddlerInfo]!has[draft.of]]">

--- a/editions/tw5.com/tiddlers/howtos/Configuring the default TiddlerInfo tab.tid
+++ b/editions/tw5.com/tiddlers/howtos/Configuring the default TiddlerInfo tab.tid
@@ -1,5 +1,5 @@
 created: 20140828080837703
-modified: 20241103152604059
+modified: 20140912145908651
 tags: [[Customise TiddlyWiki]]
 title: Configuring the default TiddlerInfo tab
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
This PR fixes the tiddler Info Tab default description 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>