### PR TITLE
[DOCS] Rename: Hidden Setting: Import Content Types for Editor

### DIFF
--- a/editions/tw5.com/tiddlers/Hidden Setting_ Import Content Types for Editor.tid
+++ b/editions/tw5.com/tiddlers/Hidden Setting_ Import Content Types for Editor.tid
@@ -1,7 +1,7 @@
 created: 20210519155910219
 modified: 20210519160221219
 tags: [[Hidden Settings]]
-title: Hidden Settings: Import Content Types for Editor
+title: Hidden Setting: Import Content Types for Editor
 type: text/vnd.tiddlywiki
 
 <<.from-version "5.2.0">>


### PR DESCRIPTION
Remove the "s" from "Hidden Setting(s)"<-- to make the tiddler title consistent

See: https://talk.tiddlywiki.org/t/how-to-deal-with-search-text-too-short-warning/11087/7 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>