### PR TITLE
[DOCS] Box colour change -- TiddlyWiki Privacy and Security

### DIFF
--- a/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
+++ b/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
@@ -1,5 +1,5 @@
 created: 20200507002727378
-modified: 20220719132112414
+modified: 20241121163155272
 tags: $:/tags/Stylesheet
 title: $:/_tw5.com-styles
 type: text/vnd.tiddlywiki
@@ -140,10 +140,11 @@ type: text/vnd.tiddlywiki
 .tc-grid-columns.tc-grid-columns-2 > div {
 	border-radius: 1em;
 	padding: 1em;
-	background-color: <<colour alert-background>>;
+	color: <<colour diff-insert-foreground>>;
+	background-color: <<colour diff-insert-background>>;
 }
 
-.tc-grid-columns.tc-grid-columns-2 > div:nth-child(odd) {
+.tc-grid-columns.tc-grid-columns-2 > div:nth-child(even) {
 	color: <<colour diff-delete-foreground>>;
 	background-color: <<colour diff-delete-background>>;
 }


### PR DESCRIPTION
This PR changes the box-colors for "Single file Wiki" and "Node.js Wiki" box. 
It uses `diff-insert-*` and `diff-delete-*` colour definitions

```
.tc-grid-columns.tc-grid-columns-2 > div {
	border-radius: 1em;
	padding: 1em;
	color: <<colour diff-insert-foreground>>;
	background-color: <<colour diff-insert-background>>;
}

.tc-grid-columns.tc-grid-columns-2 > div:nth-child(even) {
	color: <<colour diff-delete-foreground>>;
	background-color: <<colour diff-delete-background>>;
}
``` 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>