### PR TITLE
[ja_JP] Japanese translation update

### DIFF
--- a/editions/ja-JP/tiddlers/Hidden Setting_ Import Content Types for Editor.tid
+++ b/editions/ja-JP/tiddlers/Hidden Setting_ Import Content Types for Editor.tid
@@ -1,0 +1,13 @@
+created: 20210519155910219
+modified: 20241128113941852
+original-modified: 20210519160221219
+tags: [[Hidden Settings]]
+title: Hidden Setting: Import Content Types for Editor
+ja-title: 隠し設定: エディターのインポートコンテンツタイプ
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.2.0">>
+
+$:/config/Editor/ImportContentTypesFilter
+
+このフィルターは、エディターにドラッグアンドドロップしてインポートできる`contentTypes`を決定します。これは、`contentTypesFilter`属性のために、エディターを囲むDropzoneWidgetによって使用されます。

--- a/editions/ja-JP/tiddlers/customising/Alternative page layouts.tid
+++ b/editions/ja-JP/tiddlers/customising/Alternative page layouts.tid
@@ -1,0 +1,48 @@
+created: 20201123172925848
+modified: 20241111112628221
+original-modified: 20240801020629394
+tags: [[Customise TiddlyWiki]]
+title: Alternative page layouts
+ja-title: ページレイアウトを変更する
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.23">>複数のページレイアウトを用意し、切り替えることができます。使用可能なレイアウトのリストを表示し、レイアウトを切り替えるには、キーボードショートカット<kbd><<displayshortcuts ((layout-switcher))>></kbd>を使用します
+
+!ページレイアウトの作成
+
+代替のレイアウトを作成すると、デフォルトのインターフェイスである[[標準レイアウト|$:/core/ui/PageTemplate]]に[[機能の追加・削除|Customising TiddlyWiki's user interface]]だけでなく、まったく新しいレイアウトを作成することもできます。
+
+代替のページレイアウトを作成し、切り替えることができるようにするには、[[SystemTag: $:/tags/Layout]]を使用して代替ページテンプレートTiddlerを作成します。
+
+この代替ページテンプレートは、[[デフォルトのページテンプレート|$:/core/ui/PageTemplate]]を、微調整して修正したバージョンであることも、まったく異なるものを作成することもできます。レイアウト切り替えメカニズムでは、ページテンプレートTiddlerに`name`と`description` 
+フィールドが必要です。これらのフィールドは、ユーザーインターフェイス切り替えのリストで使用されます。
+
+!! 共通レイアウト設定
+
+```tid
+\whitespace trim
+\import [subfilter{$:/core/config/GlobalImportFilter}]
+\define containerClasses()
+tc-page-container tc-language-$(languageTitle)$ your-plugin-name-container
+\end
+\procedure redirected-navigate-actions()
+  <$action-setfield $tiddler="$:/layout" text="" $timestamp="no" />
+  <$action-navigate $to=<<event-navigateTo>> $scroll="yes" />
+\end
+
+<$navigator story="$:/StoryList" history="$:/HistoryList" openLinkFromInsideRiver={{$:/config/Navigation/openLinkFromInsideRiver}} openLinkFromOutsideRiver={{$:/config/Navigation/openLinkFromOutsideRiver}} relinkOnRename={{$:/config/RelinkOnRename}}>
+	<$messagecatcher $tm-navigate=<<redirected-navigate-actions>>>
+		{{$:/core/ui/CommandPaletteTemplate}}
+		<div class=<<containerClasses>>>
+			<!-- Your layout content here -->
+		</div>
+	</$messagecatcher>
+</$navigator>
+```
+
+以下を含んでいます
+
+# 標準レイアウトでグローバルに使用できるマクロをインポートすると、標準レイアウトで機能するWikiテキストが独自レイアウトでも機能します。
+# トップレベルのCSSクラスを定義します。一部のスタイルはそれに依存する場合があります。ここで、CSSクラスにプラグインの名前を追加できます。
+# リンクをクリックしたときにナビゲーションを処理します。レイアウトにストーリービューが含まれていない場合(たとえば、カレンダーやホワイトボードレイアウトを作成している場合)、`redirected-navigate-actions` `$navigator`と`$messagecatcher`の組み合わせにより、ユーザーは標準レイアウトにリダイレクトされ、そこでTiddlerが表示されます。
+# 独自レイアウト上に、たとえば、`$:/core/ui/CommandPaletteTemplate`や`$:/core/ui/PageTemplate/sidebar`などを配置したい場合は、[[PageTemplate|$:/tags/PageTemplate]]を再度追加します。

--- a/editions/ja-JP/tiddlers/customising/Configuring startup tiddlers.tid
+++ b/editions/ja-JP/tiddlers/customising/Configuring startup tiddlers.tid
@@ -1,0 +1,29 @@
+created: 20180305174809089
+modified: 20241112113136035
+original-modified: 20180306161405033
+tags: [[Customise TiddlyWiki]]
+title: Configuring startup tiddlers
+ja-title: スタートアップTiddlerを構成する
+type: text/vnd.tiddlywiki
+
+[[デフォルトTiddler|DefaultTiddlers]]メカニズムを使用して、一つ、もしくは、複数のTiddlerを起動時に表示するように、~TiddlyWikiを設定できます。
+
+コントロールパネルの情報タブの下には、「このファイルを開いたときに初期表示されるTiddlerを設定してください」という説明のある入力フィールドがあります。起動時に表示したいTiddlerを列挙します。スペースを含むタイトルには二重角括弧を使用します。例えば: 
+
+```
+FirstTiddler
+SecondTiddler
+[[Third Tiddler]]
+```
+
+[[フィルター式|Filter Expression]]を使用して、複数のTiddlerを開くこともできます。例えば: 
+
+```
+[tag[HelloThere]]
+```
+
+は、<<tag HelloThere>>でタグ付けされたすべてのTiddlerを表示します。
+
+[[開いているtiddlerを起動時に保持する|Preserving open tiddlers at startup]]のテクニックを使用することもできます。
+
+起動時の動作をより高度に制御するには、[[起動時アクション|StartupActions]]も参照してください。

--- a/editions/ja-JP/tiddlers/customising/Creating new toolbar buttons.tid
+++ b/editions/ja-JP/tiddlers/customising/Creating new toolbar buttons.tid
@@ -1,0 +1,37 @@
+created: 20211124205415217
+modified: 20241114113201979
+original-modified: 20230803050345698
+tags: [[Customise TiddlyWiki]]
+title: Creating new toolbar buttons
+ja-title: ツールバーボタンを新しく作成する
+type: text/vnd.tiddlywiki
+
+'レシピテンプレート'というスケルトンTiddlerを使って、オンデマンドで新しいレシピTiddlerを作成するためにViewToolbar Tiddlerで使用できるボタンを用意したいとします。これには次の手順が必要になります:
+
+# ボタンには画像が必要になります。コアイメージ($:/core/images/で始まる名前のシャドウTiddler)がどれも適合しない場合は、SVGイメージ(たとえば、 http://flaticon.com にあるイメージの一つ)をファイルにドラッグしてTiddlerにし、Tiddlerを編集して高さと幅がを22pxに調整します。
+# そのTiddlerを含むTiddlerを作成するとよいでしょう。Tiddlerを作成し、タイトルを付け、ボタンのコードを追加します(例として、下記のコードを参照してください。変更が必要な箇所にはヒントが含まれています)。[[$:/tags/ViewToolbar]]のタグを付けます。
+# ボタンをツールバーに表示するか非表示にするかをTiddlyWikiに伝えるTiddlerを作成する必要があります。[[$:/config/ViewToolbarButtons/Visibility/Recipe]]というタイトルにします。テキスト領域に`show`と入力して保存します。非表示にしたい場合は、テキスト領域に`hide`と入力して保存します。このボタンには、''コントロールパネル : 外観 : ツールバー : 閲覧画面''タブからもアクセスできます。
+# ボタンを適切な位置に配置する場合は、$:/tags/ViewToolbar Tiddlerを開き、ボタンTiddlerのタイトルをリストフィールドの適切な場所に挿入します。
+
+```
+\define newHereButtonTags()
+[[$(currentTiddler)$]]
+\end
+\define newHereButton()
+<$button class=<<tv-config-toolbar-class>>>
+<$action-sendmessage
+  $message="tm-new-tiddler"
+$param="TITLE OF YOUR SKELETON BUTTON"
+title="New tiddler"
+  tags=<<newHereButtonTags>> />
+<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+{{TITLE OF YOUR SVG IMAGE TIDDLER}}
+</$list>
+<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<span class="tc-btn-text"><$text text="CAPTION FOR YOUR BUTTON"/></span>
+</$list>
+</$button>
+\end
+
+<<newHereButton>>
+```

--- a/editions/ja-JP/tiddlers/customising/Customise TiddlyWiki.tid
+++ b/editions/ja-JP/tiddlers/customising/Customise TiddlyWiki.tid
@@ -1,0 +1,12 @@
+created: 20140904101600000
+list: [[Adding a table of contents to the sidebar]] [[Alternative page layouts]] [[Configuring startup tiddlers]] [[Configuring the default TiddlerInfo tab]] [[Creating a custom export format]] [[Creating a splash screen]] [[Creating new toolbar buttons]] [[Customising search results]] [[Customising TiddlyWiki's user interface]] [[Hidden Settings]] [[How to add a new tab to the sidebar]] [[How to apply custom styles]] [[How to create a custom story tiddler template]] [[How to create a custom tiddler icon rule]] [[How to create a custom tiddler colour rule]] [[How to create keyboard shortcuts]] [[How to turn off camel case linking]] [[How to widen tiddlers (aka storyriver)]] [[Making a custom journal button]] [[Preserving open tiddlers at startup]] [[Setting a favicon]] [[Setting a page background image]] [[Using Stylesheets]]
+modified: 20241110115757128
+original-modified: 20211206162235300
+tags: TableOfContents
+title: Customise TiddlyWiki
+ja-title: TiddlyWikiのカスタマイズ
+type: text/vnd.tiddlywiki
+
+TiddlyWikiのカスタマイズに関する情報。採用されているメカニズムの概要については、[[TiddlyWikiのユーザーインターフェイスをカスタマイズする|Customising TiddlyWiki's user interface]]を参照してください。
+
+<<list-links "[tag[Customise TiddlyWiki]]">>

--- a/editions/ja-JP/tiddlers/customising/Customising TiddlyWiki's user interface.tid
+++ b/editions/ja-JP/tiddlers/customising/Customising TiddlyWiki's user interface.tid
@@ -1,0 +1,77 @@
+created: 20211127084727217
+modified: 20241115113055145
+original-modified: 20211204120054422
+tags: [[Customise TiddlyWiki]]
+title: Customising TiddlyWiki's user interface
+ja-title: TiddlyWikiのユーザーインターフェイスのカスタマイズ
+type: text/vnd.tiddlywiki
+
+TiddlyWikiのユーザーインターフェイスは、高度に拡張できるように設計されています。すべての要素は、追加、削除、または再配置することができます
+
+これを実現するために、いくつかの異なるメカニズムが使用されます: 
+
+* 特殊フィールド
+* 特殊タイトル
+* 特殊タグ
+* カスケード
+
+これらのメカニズムの概要と、それらがどのように相互に関連しているかを説明します
+
+!! 特殊フィールド
+
+特殊フィールドは、個々のTiddlerに外観や動作を割り当てるために使用されます。これらは、適用されるTiddlerを直接制御するフラグや値と考えることができます
+
+例:
+
+* `icon`フィールドは、Tiddlerのアイコンとして使用する画像Tiddlerのタイトルを設定します
+* `color`フィールドは、Tiddlerに関連付けられたアイコンとタグマークのCSSカラーを設定します
+* `hide-body`フィールドは、`yes` にすると、Tiddlerのビューテンプレートのボディを非表示にします
+
+すべての特別フィールドの詳細については、[[Tiddlerフィールド|TiddlerFields]]を参照してください
+
+!! 特殊タイトル
+
+特定の特殊タイトルは、TiddlyWikiの外観や動作をカスタマイズする設定用のTiddlerです。これらは、Wiki全体に影響するグローバル設定と考えることができます
+
+例:
+
+* $:/DefaultTiddlersは、起動時に表示されるTiddlerのタイトルを生成するフィルターです
+* $:/SiteTitleは、Wikiタイトルのテキストを指定します
+* $:/config/Tags/MinLengthは、タグのオートコンプリートをトリガーする最小文字数を制御します
+
+TiddlyWikiの設定に関するTiddlerの多くは、[[$:/ControlPanel]]にオプションとして表示されます。あまり一般的には使用されない設定用のTiddlerにはユーザーインターフェイスがありませんが、[[隠し設定|Hidden Settings]]に文書化されています
+
+!! 特殊タグ
+
+特殊タグは、それらが適用されるすべてのTiddlerに特別な動作や外観を割り当てます。これらは、特定の方法で処理される、または、表示されるTiddlerの順序付きリストを確立すると考えることができます
+
+例:
+
+* $:/tags/Globalにより、Tiddler内の定義がグローバルに有効になります
+* $:/tags/Stylesheetにより、TiddlerがCSSスタイルシートとして解釈されます
+* $:/tags/SideBarにより、Tiddlerがサイドバーのタブとして表示されます
+
+すべての特殊タグの詳細については、[[システムタグ|SystemTags]]を参照してください
+
+TiddlyWikiのユーザーインターフェース全体は、特殊システムタグから形成されたリストから構築されています
+
+これらのリストの順序は、[[タグ付けされたTiddlerの順序|Order of Tagged Tiddlers]]ルールによって決まります。ユーザーは、タグドロップダウン内でドラッグアンドドロップを使用してタグを並べ替えることができます
+
+!! カスケード
+
+カスケードは、柔軟で拡張可能な基準に基づいて複数の値の1つを選択する手段を提供します。これらは、条件の1つが一致するまで順番に評価される条件のリストと考えることができます
+
+例えば、コアは表示モードではテンプレート$:/core/ui/ViewTemplateを使用してTiddlerを表示し、編集モードではテンプレート$:/core/ui/EditTemplateを使用して Tiddlerを表示します。カスケードは、特定のTiddlerに使用するテンプレートを選択するために使用されます
+
+# Tiddlerがドラフトの場合は、$:/core/ui/EditTemplateを使用します
+# それ以外の場合は、$:/core/ui/ViewTemplateを使用します
+
+条件のリストは特殊タグを介して定義されるため、リスト内の任意の場所に追加の条件を挿入できます
+
+例えば、プラグインは追加のルールを挿入することで、タグ[[$:/tags/Map]]を持つTiddler用の特別なテンプレート$:/plugins/example/map-templateを追加できます: 
+
+# Tiddlerがドラフトの場合は、$:/core/ui/EditTemplateを使用します
+# @@background: yellow; Tiddlerに$:/tags/Mapタグが付けられている場合は、$:/plugins/example/map-templateを使用します@@
+# それ以外の場合は、$:/core/ui/ViewTemplateを使用します
+
+詳細については、[[カスケード|Cascades]]を参照してください

--- a/editions/ja-JP/tiddlers/customising/Customising search results.tid
+++ b/editions/ja-JP/tiddlers/customising/Customising search results.tid
@@ -1,0 +1,51 @@
+created: 20141027151552783
+modified: 20241115112411640
+original-modified: 20201207181116804
+tags: [[Customise TiddlyWiki]]
+title: Customising search results
+ja-title: 検索結果のカスタマイズ
+type: text/vnd.tiddlywiki
+
+デフォルトでは、サイドバーの検索ボックスの結果は、Tiddlerタイトルの単純なリストとして表示されます。検索結果は、さまざまな方法でプラグイン視覚エフェクトを追加することでカスタマイズできます(追加の検索結果の視覚エフェクトが検出された場合、タブが自動的に表示されます)
+
+検索結果の視覚エフェクトは、[[$:/tags/SearchResults]]タグが付いたTiddlerに保存されます。デフォルトの検索結果リストは、システムTiddler[[$:/core/ui/DefaultSearchResultList]]に実装されています
+
+新しい検索結果の視覚エフェクトを作成するには:
+
+# [[$:/tags/SearchResults]]タグを付けた新しいTiddlerを作成します
+# ウィジェット変数''searchTiddler''を使用して、現在の検索用語を含むTiddlerのタイトルにアクセスします
+
+新しい視覚エフェクトをデフォルトにしたい場合は、デフォルトで表示したい検索視覚エフェクトを含むTiddlerのタイトルを含む[[$:/config/SearchResults/Default]]という名前のTiddlerを作成します
+
+以下は、結果を時系列の逆順に表示する別の視覚エフェクトの例です: 
+
+```
+\define searchResults()
+<$set name="resultCount" value="""<$count filter="[!is[system]search{$(searchTiddler)$}]"/>""">
+
+{{$:/language/Search/Matches}}
+
+</$set>
+<<timeline subfilter:"!is[system]search{$(searchTiddler)$}">>
+\end
+<<searchResults>>
+```
+
+<<.from-version 5.1.23>>サイドバー検索に、キーボードショートカット<kbd><<displayshortcuts ((input-down))>></kbd>と<kbd><<displayshortcuts ((input-up))>></kbd>を使用して検索結果をナビゲートできる、より洗練された検索メカニズムが導入します
+
+# <<tag-pill "$:/tags/SearchResults">>のタグ付けされたTiddlerは、<<.var configTiddler>>変数を通じてアクセスできます
+# 検索フィールドへのユーザ入力には、<<.var userInput>>変数を通じてアクセスできます
+# フィールド<<.field first-search-filter>>とフィールド<<.field second-search-filter>>を使用して、検索結果に使用されるフィルターを保存します。詳細については、Tiddler $:/core/ui/DefaultSearchResultListを参照してください
+# ナビゲートされた検索結果が強調表示されるように次のフォームを使用し、ニーズに合わせて変更します:
+
+```
+<$list filter="[<userInput>minlength[1]]" variable="ignore">
+<$list filter={{{ [<configTiddler>get[first-search-filter]] }}}>
+<span class={{{[<currentTiddler>addsuffix[-primaryList]] -[<searchListState>get[text]] +[then[]else[tc-list-item-selected]] }}}>
+<$transclude tiddler="$:/core/ui/ListItemTemplate"/>
+</span>
+</$list>
+</$list>
+```
+
+<$macrocall $name=".tip" _="<<.var searchTiddler>>変数には、検索結果の並べ替えに使用されるTiddlerの名前がまだ含まれていることに注意してください。<<.var editTiddler>>変数には、編集中のTiddlerの名前が含まれます"/>

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting Content to be displayed for empty story.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting Content to be displayed for empty story.tid
@@ -1,0 +1,14 @@
+created: 20240811052854726
+modified: 20241116102931084
+original-modified: 20240811053649554
+tags: [[Hidden Settings]]
+title: Hidden Setting: Content to be displayed for empty story
+ja-title: 隠し設定: 空のストーリーに表示されるコンテンツ
+
+ストーリーが空のときにコンテンツを表示するには、$:/config/EmptyStoryMessageを作成し、必要なコンテンツを入力します。
+
+以下は、すべてのTiddlerが閉じられている場合に、GettingStarted Tiddlerを表示します。
+
+```
+{{GettingStarted||$:/core/ui/ViewTemplate}}
+```

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting Default Story Ordering.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting Default Story Ordering.tid
@@ -1,0 +1,5 @@
+title: Hidden Setting: Retain Story ordering
+ja-title: 隠し設定: 保存時の表示を維持
+tags: [[Hidden Settings]]
+
+Tiddler $:/config/ControlPanel/Basics/DefaultTiddlers/RetainStoryには、$:/ControlPanelの''情報'' -> ''基本''タブの"保存時の表示を維持"ボタンをクリックしたときに$:/DefaultTiddlersに割り当てられる値が含まれています。

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting Default Tiddler Colour.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting Default Tiddler Colour.tid
@@ -1,0 +1,9 @@
+created: 20240907042443909
+modified: 20241116104031988
+original-modified: 20240907042629405
+tags: [[Hidden Settings]]
+title: Hidden Setting: Default Tiddler Colour
+ja-title: 隠し設定: TIddlerのデフォルト色
+type: text/vnd.tiddlywiki
+
+デフォルトのTiddler色は、$:/config/DefaultTiddlerColourというTiddlerを作成し、CSSの色の値を含むことによって指定できます。

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting EditTabIndex.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting EditTabIndex.tid
@@ -1,0 +1,10 @@
+title: Hidden Setting: Tab Index for Edit-Inputs
+ja-title: 隠し設定: 編集入力のタブインデックス
+tags: [[Hidden Settings]]
+created: 20190702074846206
+modified: 20241126104700035
+original-modified: 20190702074846206
+
+編集中のTiddlerの入力フィールドには、''タブインデックス''値(1が望ましい)を割り当てることができるので、<kbd>Tab</kbd>キーを使用して、フォーカスを1つの入力から次の入力へ、または<kbd>shift-Tab</kbd>で後方へ直接移動することができます。
+
+$:/config/EditTabIndex

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting HtmlParserDisableSandbox.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting HtmlParserDisableSandbox.tid
@@ -1,0 +1,16 @@
+created: 20210411100148461
+modified: 20241123115717620
+original-modified: 20210411100148461
+tags: [[Hidden Settings]]
+title: Hidden Setting: HTML Parser Sandbox
+ja-title: 隠し設定: HTMLパーサーのサンドボックス
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.2.0">> デフォルトでは、`text/html`タイプのTiddlerは、[[サンドボックス属性|https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox]]が空の文字列に設定されたiframe内に表示されます。これにより、すべてのセキュリティ制限が適用され、JavaScript、ダウンロード、外部ファイル参照などの多くの機能が無効になります。これは最も安全な設定です。
+
+サンドボックスをグローバルに無効にするには、$:/config/HtmlParser/DisableSandbox Tiddlerを`yes`に設定します。これにより、iframe内のコードがTiddlyWikiの内部に完全にアクセスできるようになり、悪意のあるHTMLページがプライベートwikiからデータを盗み出す可能性があります。
+
+サンドボックスを維持しながら適用される制限を制御するには、$:/config/HtmlParser/DisableSandboxが`yes`に設定されていないことを確認してから、$:/config/HtmlParser/SandboxTokensに[[MDNドキュメント|https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox]]
+にあるトークンのリストを設定します。
+
+これらはグローバル設定であることに注意してください。個々のTiddlerごとにサンドボックスを制御するには、カスタム`<iframe>`を使用する必要があります。

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting NewImageType.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting NewImageType.tid
@@ -1,0 +1,11 @@
+created: 20211116222524148
+modified: 20241124111223981
+original-modified: 20211116222535549
+tags: [[Hidden Settings]]
+title: Hidden Setting: New-Image Type
+ja-title: 隠し設定: 新しい画像タイプ
+type: text/vnd.tiddlywiki
+
+デフォルトでは、新しい画像は`jpeg`画像タイプで作成されます
+
+$:/config/NewImageTypeの隠し設定は、新しい画像Tiddlerに使用される別の画像タイプ、例えば`png`を設定できます。

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting SaveWikiButton Filename.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting SaveWikiButton Filename.tid
@@ -1,0 +1,13 @@
+created: 20181215154811835
+modified: 20241117104725880
+original-modified: 20190122000000000
+tags: [[Hidden Settings]]
+title: Hidden Setting: Filename for Save Wiki Button
+ja-title: 隠し設定: Wiki保存ボタンのファイル名
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.19">> <<.button save-wiki>>ボタンを使用して~TiddlyWikiを保存する場合、保存に使用されるデフォルトのファイル名は、[[コントロールパネル|$:/ControlPanel]]に入力された~TiddlyWikiのタイトルを使用して作成され、Tiddler [[$:/SiteTitle]]に記録されます。
+
+使用される値は`{{$:/SiteTitle}}.html`の形式です。これにより、ファイル名は`.html`拡張子付きのサイトタイトルから作成されます。
+
+[[$:/config/SaveWikiButton/Filename]]という名前のTiddlerが作成されると、そのTiddler内のテキストが~TiddlyWikiを保存するために使用されるデフォルトのファイル名として使用されます。

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting SaveWikiButton Template.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting SaveWikiButton Template.tid
@@ -1,0 +1,15 @@
+created: 20181215154811835
+modified: 20241127111942680
+original-modified: 20181215154811835
+tags: [[Hidden Settings]]
+title: Hidden Setting: Template for Save Wiki Button
+ja-title: 隠し設定: Wiki保存ボタンのテンプレート
+type: text/vnd.tiddlywiki
+
+"Wikiを保存します"ページコントロールボタンを使用して保存するときに使用するテンプレートを決定します。
+
+デフォルトは`$:/core/save/all`です。
+
+この設定を変更して、"Wikiを保存します"ボタンをクリックしたときに保存される内容を選択できます。
+
+$:/config/SaveWikiButton/Template

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting Search-NavigateOnEnter.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting Search-NavigateOnEnter.tid
@@ -1,0 +1,9 @@
+title: Hidden Setting: Navigate on Enter
+ja-title: 隠し設定: Enterキーでナビゲート
+tags: [[Hidden Settings]]
+created: 20201108104956516
+modified: 20241124105904502
+original-modified: 20201108104956516
+
+設定Tiddler $:/config/Search/NavigateOnEnter/enableを使用すると、さまざまな検索入力フィールドで<kbd>{{$:/config/shortcuts/input-accept}}</kbd>のあと<kbd>{{$:/config/shortcuts/input-accept-variant}}</kbd>をヒットしたときに、欠落しているTiddlerへのナビゲーションと作成を、(''yes''に設定により)有効にすることができます。
+

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting SearchMinLength.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting SearchMinLength.tid
@@ -1,0 +1,13 @@
+created: 20161011074235805
+modified: 20241125110155182
+original-modified: 20161011074235805
+tags: [[Hidden Settings]]
+title: Hidden Setting: Search Minimum Length
+ja-title: 隠し設定: 検索の最小文字数
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.14">> 結果が表示される検索文字列の最小長を制御します。
+
+デフォルトは"3"です。
+
+$:/config/Search/MinLength

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting ShowEditPreviewPerTiddler.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting ShowEditPreviewPerTiddler.tid
@@ -1,0 +1,12 @@
+created: 20211028083211182
+modified: 20241125110559718
+original-modified: 20211029090311444
+tags: [[Hidden Settings]]
+title: Hidden Setting: Show Edit Preview per Tiddler
+ja-title: 隠し設定: Tiddlerごとの編集プレビュー表示
+
+[[テキストプレビュー|Text preview]]をグローバルに制御するか(デフォルト)、Tiddlerごとに制御するかを制御します。
+
+Tiddlerごとのモードを有効にするには、次の値を''yes''に設定します。
+
+$:/config/ShowEditPreview/PerTiddler

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting Sync System Tiddlers From Server.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting Sync System Tiddlers From Server.tid
@@ -1,0 +1,15 @@
+created: 20220909094340097
+modified: 20241126103915330
+original-modified: 20220909094340097
+title: Hidden Setting: Sync System Tiddlers From Server
+ja-title: 隠し設定: システムTiddlerをサーバーから同期する
+tags: [[Hidden Settings]]
+
+<<.from-version "5.1.23">> Node.jsでシステムTiddlerをサーバーから同期するかどうかを決定します。(これは一方向の設定であることに注意してください。システムTiddlerは常にサーバー//へ//同期されます)。
+
+* `no` -- システムTiddlerはサーバーから同期されません(デフォルト)
+* `yes` -- システムTiddlerはサーバーから同期されます
+
+システムTiddlerの同期を有​​効にすると、$:/StoryListや$:/HistoryListなどのTiddlerが同期されるため、複数のユーザーが同時に同じサーバーに接続したときに予期しない結果が生じる可能性があります(ストーリーシーケンスがすべてのユーザー間で同期されることになります)。
+
+$:/config/SyncSystemTiddlersFromServer

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting SyncLogging.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting SyncLogging.tid
@@ -1,0 +1,15 @@
+created: 20190903192324700
+modified: 20241125111612397
+original-modified: 20190903192324700
+tags: [[Hidden Settings]]
+title: Hidden Setting: Sync Logging
+ja-title: 隠し設定: ログの同期
+type: text/vnd.tiddlywiki
+
+[[Syncadaptor|https://tiddlywiki.com/dev/#Syncadaptor]]がブラウザのデベロッパーコンソールに情報を記録するかどうかを指定します。
+
+デフォルトは`yes`です。ログ記録を無効にするには`no`に設定します。
+
+変更を有効にするには再起動が必要です。
+
+$:/config/SyncLogging

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting SyncPollingInterval.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting SyncPollingInterval.tid
@@ -1,0 +1,15 @@
+created: 20190903192324700
+modified: 20241126103517604
+original-modified: 20190903192324700
+tags: [[Hidden Settings]]
+title: Hidden Setting: Sync Polling Interval
+ja-title: 隠し設定: 同期ポーリング間隔
+type: text/vnd.tiddlywiki
+
+[[Syncadaptor|https://tiddlywiki.com/dev/#Syncadaptor]]がサーバーとブラウザ間でTiddlerを同期する間隔を指定します。
+
+デフォルトは"60000" (60 * 1000ミリ秒 = 1分)です。
+
+変更を有効にするには再起動が必要です。
+
+$:/config/SyncPollingInterval

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting TagsMinLength.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting TagsMinLength.tid
@@ -1,0 +1,13 @@
+created: 201712032331
+modified: 20241127111343096
+original-modified: 201712032331
+tags: [[Hidden Settings]]
+title: Hidden Setting: Tags Minimum Length
+ja-title: 隠し設定: タグの最小長さ
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.16">> タグのドロップダウン: 結果が表示される前の入力文字列の最小長を制御します。
+
+デフォルトは"0"です。
+
+$:/config/Tags/MinLength

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting ViewTemplate and EditTemplate.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting ViewTemplate and EditTemplate.tid
@@ -1,0 +1,8 @@
+title: Hidden Setting: ViewTemplate and EditTemplate
+ja-title: 隠し設定: ViewTemplateとEditTemplate
+tags: [[Hidden Settings]]
+created: 20190704053532718
+modified: 20241128113035943
+original-modified: 20190704053532718
+
+設定Tiddler $:/config/ui/ViewTemplateと$:/config/ui/EditTemplateで、[[ストーリーのページテンプレート|$:/core/ui/PageTemplate/story]]で使用される''~ViewTemplate''と''~EditTemplate''を変更できます。

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Default Tiddler Icon.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Default Tiddler Icon.tid
@@ -1,0 +1,9 @@
+created: 20200306145004925
+modified: 20241116104809059
+original-modified: 20200306145004925
+tags: [[Hidden Settings]]
+title: Hidden Setting: Default Tiddler Icon
+ja-title: 隠し設定: Tiddlerのデフォルトアイコン
+type: text/vnd.tiddlywiki
+
+デフォルトのTiddlerアイコンは、$:/config/DefaultTiddlerIconというTiddlerを作成し、そのアイコンを含むTiddlerのタイトルを含むことで設定できます。

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Disable Drag and Drop.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Disable Drag and Drop.tid
@@ -1,0 +1,21 @@
+created: 20200315143638556
+modified: 20241116105232874
+original-modified: 20210519155433742
+tags: [[Hidden Settings]]
+title: Hidden Setting: Disable Drag and Drop
+ja-title: 隠し設定: ドラッグアンドドロップの無効化
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.22">>コア機能として組み込まれたドラッグアンドドロップ操作をすべて無効にするには、次のTiddlerを"no"に設定します。
+
+$:/config/DragAndDrop/Enable
+
+[[list-tagged-draggableマクロ|list-tagged-draggable Macro]]や[[list-links-draggableマクロ|list-links-draggable Macro]]のインスタンスでドラッグアンドドロップを選択的に再有効化するには、マクロ呼び出しのスコープにおいて、変数`tv-enable-drag-and-drop`に`yes`をセットします。たとえば、$:/config/DragAndDrop/Enableに"no"が設定されていても、このリスト内でドラッグアンドドロップを使用できることに注目してください。
+
+<$macrocall $name="wikitext-example-without-html" src="""<$set name="tv-enable-drag-and-drop" value="yes">
+
+<<list-tagged-draggable tag:"HelloThere">>
+
+</$set>"""/>
+
+DropzoneWidgetとDroppableWidgetを直接使用する場合、''enable''属性はグローバル設定とは独立して機能することに注意してください。

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Disable Lazy Loading.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Disable Lazy Loading.tid
@@ -1,0 +1,11 @@
+created: 20191025100113266
+modified: 20241116105821092
+original-modified: 20191025100113266
+tags: [[Hidden Settings]]
+title: Hidden Setting: Disable Lazy Loading
+ja-title: 隠し設定: 遅延ロードの無効化
+type: text/vnd.tiddlywiki
+
+[[遅延ロード|LazyLoading]]は、下記の値を`yes`に設定すると無効にできます
+
+$:/config/SyncDisableLazyLoading

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Enable File Import in Editor_1.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Enable File Import in Editor_1.tid
@@ -1,0 +1,14 @@
+created: 20210519155447339
+modified: 20241117103103808
+original-modified: 20210519160010708
+tags: [[Hidden Settings]]
+title: Hidden Setting: Enable File Import in Editor
+ja-title: 隠し設定: エディターでファイルのインポートを有効にする
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.2.0">>
+
+$:/config/Editor/EnableImportFilter
+
+このフィルターは、特定のTiddlerでエディター内でのファイルのドラッグアンドドロップが機能するかどうかを決定します。結果が空でない場合、そのTiddlerのエディター内でのドラッグアンドドロップが有効になります。
+このフィルターは、グローバルなドラッグアンドドロップ設定を尊重して使用されます。

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ More Tabs Horizontal.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ More Tabs Horizontal.tid
@@ -1,0 +1,9 @@
+created: 20221128092648000
+modified: 20241124105614116
+original-modified: 20221128092903706
+tags: [[Hidden Settings]]
+title: Hidden Setting: More Tabs Horizontal
+ja-title: 隠し設定: 「詳しく」タブの水平化
+type: text/vnd.tiddlywiki
+
+詳しく -> タブ を水平方向に揃えるには、$:/config/ui/SideBar/More/horizontal Tiddlerをyesに設定します。

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Scroll Top Adjustment.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Scroll Top Adjustment.tid
@@ -1,0 +1,12 @@
+created: 20180816105911495
+modified: 20241124112441126
+original-modified: 20180816110627713
+tags: [[Hidden Settings]]
+title: Hidden Setting: Scroll Top Adjustment
+ja-title: 隠し設定: スクロールトップの調整
+type: text/vnd.tiddlywiki
+
+Tiddlerへの移動の一環として、TiddlyWikiはページをスクロールして、Tiddlerの上部がブラウザウィンドウの上部と揃うようにします。つまり、ウィンドウの上部にあるカスタム`position:fixed`ツールバーを使用すると、Tiddlerの上部が見えなくなる可能性があります
+
+ツールバーに合わせてスクロール位置を調整するには、ツールバーにCSSクラス`tc-adjust-top-of-scroll`を追加します。TiddlyWikiのスクロールメカニズムにより、その要素の高さに応じてスクロール位置が動的に調整されます。
+

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Search AutoFocus.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Search AutoFocus.tid
@@ -1,0 +1,11 @@
+created: 20150619162518761
+modified: 20241125105614310
+original-modified: 20150619162605652
+tags: [[Hidden Settings]]
+title: Hidden Setting: Search AutoFocus
+ja-title: 隠し設定: 検索へのオートフォーカス
+type: text/vnd.tiddlywiki
+
+TiddlyWikiがブラウザで開かれると、デフォルトで自動的に検索ボックスにフォーカスされます。これで問題が発生する場合は、次の値を''true''から''false''に変更してデフォルトを変えます: 
+
+$:/config/Search/AutoFocus

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Typin Refresh Delay.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Setting_ Typin Refresh Delay.tid
@@ -1,0 +1,15 @@
+created: 20150619162409306
+modified: 20241128112152516
+original-modified: 20191014091803518
+tags: [[Hidden Settings]]
+title: Hidden Setting: Typing Refresh Delay
+ja-title: 隠し設定: 入力更新の遅延
+type: text/vnd.tiddlywiki
+
+TiddlyWikiは、タイムアウトが経過するまで、ドラフトTiddlerとプレフィックス`$:/temp/volatile/`付きのTiddlerへの変更の処理を延期します(これをスロットリングと呼びます)。このメカニズムは、`throttle.refresh`フィールドを追加することで他のTiddlerに拡張できます。詳細については、RefreshThrottlingを参照してください。
+
+デフォルト値の400ミリ秒は、ほとんどの場合、応答性のバランスが良好ですが、低電力のモバイルデバイスでは必ずしも最適ではありません。
+
+次の値(ミリ秒)を変更することで、タイムアウトを変更できます: 
+
+$:/config/Drafts/TypingTimeout

--- a/editions/ja-JP/tiddlers/hiddensettings/Hidden Settings.tid
+++ b/editions/ja-JP/tiddlers/hiddensettings/Hidden Settings.tid
@@ -1,0 +1,13 @@
+created: 20150619162223882
+modified: 20241116102451779
+original-modified: 20150619162405141
+tags: [[Customise TiddlyWiki]]
+title: Hidden Settings
+ja-title: 隠し設定
+type: text/vnd.tiddlywiki
+
+TiddlyWikiの有益な構成設定は[[コントロールパネル|$:/ControlPanel]]に表示されますが、より高度な設定の一部にはユーザーインターフェイスがありません。その代わり、基礎となる構成Tiddlerを直接編集します。
+
+空のTiddlyWikiでこれらの設定を変更するには、個々の設定TiddlerへのリンクをこのWikiから自分のWikiにドラッグします。
+
+<<list-links "[tag[Hidden Settings]]">>

--- a/editions/ja-JP/tiddlers/howtos/Adding_a_table_of_contents_to_the_sidebar.tid
+++ b/editions/ja-JP/tiddlers/howtos/Adding_a_table_of_contents_to_the_sidebar.tid
@@ -1,0 +1,27 @@
+created: 20160424150551727
+modified: 20241111111307811
+original-modified: 20181106224128548
+tags: [[Customise TiddlyWiki]]
+title: Adding a table of contents to the sidebar
+ja-title: サイドバーに目次を追加する
+type: text/vnd.tiddlywiki
+
+目次を作成するための~TiddlyWikiの標準メカニズムは、"toc"[[マクロ|Macros]]です。(マクロの詳細については、リンクをクリックしてください。)Tiddlerを目次の見出しとして扱うようにする手段として`タグ付け`を使用します。タグ付けについては[[タグ付け|Tagging]]Tiddlerを参照してください。
+
+以下のステップで、サイドバーにカスタマイズできる[[目次|Table-of-Contents Macros]]を追加できます:
+
+# [[TableOfContents]]という名前のTiddlerを作成します
+# ''~$:/tags/SideBar''というタグを付けます
+# テキストに次のように入力します <div><pre><code><$text text="""
+<div class="tc-table-of-contents">
+
+<<toc-selective-expandable 'TableOfContents'>>
+
+</div>"""/></code></pre></div>
+# ''目次''という値を持つ''caption''フィールドを追加します
+#  ''~$:/core/ui/SideBar/Open''という値を持つ''list-after''フィールドを追加します
+
+''TableOfContents''というタグを持つTiddlerを作成することで目次にエントリを追加します。より簡単な方法としては、''TableOfContents''TiddlerのTiddlerツールバーの<<.icon $:/core/images/new-here-button>> ''タグ付きTiddlerの作成''を選択します。
+(''タグ付きTiddlerの作成''ボタンが表示されない場合は、下向き矢印<<.icon $:/core/images/down-arrow>>をクリックしてその他メニューを表示します。)
+
+子Tiddler(他のTiddlerの下にあるTiddler)を作成するには、親Tiddlerの名前を子Tiddlerにタグ付けします。

--- a/editions/ja-JP/tiddlers/howtos/Configuring the default TiddlerInfo tab.tid
+++ b/editions/ja-JP/tiddlers/howtos/Configuring the default TiddlerInfo tab.tid
@@ -1,0 +1,19 @@
+created: 20140828080837703
+modified: 20241112113549386
+original-modified: 20140912145908651
+tags: [[Customise TiddlyWiki]]
+title: Configuring the default TiddlerInfo tab
+ja-title: Tiddler情報タブのデフォルトを構成する
+type: text/vnd.tiddlywiki
+
+設定用Tiddler[[$:/config/TiddlerInfo/Default]]は、Tiddler情報タブのデフォルトとなるTiddlerのタイトルが含まれています。
+
+デフォルト値は''項目''タブに対応する`$:/core/ui/TiddlerInfo/Fields`です。他に構成可能な値は次のとおりです。: 
+
+<ul>
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/TiddlerInfo]!has[draft.of]]">
+<li>
+<$view field="title"/>
+</li>
+</$list>
+</ul>

--- a/editions/ja-JP/tiddlers/howtos/Creating a custom export format.tid
+++ b/editions/ja-JP/tiddlers/howtos/Creating a custom export format.tid
@@ -1,0 +1,23 @@
+title: Creating a custom export format
+ja-title: カスタムエクスポートフォーマットを作成する
+modified: 20241113113601051
+original-modified: 20141124173526227
+created: 20141124173526227
+tags: [[Customise TiddlyWiki]]
+
+TiddlerをRAWデータテキストとしてエクスポートするカスタムエクスポートフォーマットを作成するには: 
+
+# 次のフィールドを持つTiddlerを作成します。
+#* ''tags'': [[$:/tags/Exporter]]
+#* ''description'': このエクスポートフォーマットの説明
+#* ''extension'': このエクスポートフォーマットのデフォルトのファイル拡張子(ドットを含む、たとえば`.tid`)
+# 以下の内容を設定します。: 
+
+```
+\define renderContent()
+{{{ $(exportFilter)$ ||$:/core/templates/plain-text-tiddler}}}
+\end
+<<renderContent>>
+```
+
+変数`exportFilter`には、どのTiddlerをエクスポートするのかを定義するフィルターが含まれています。

--- a/editions/ja-JP/tiddlers/howtos/Creating a splash screen.tid
+++ b/editions/ja-JP/tiddlers/howtos/Creating a splash screen.tid
@@ -1,0 +1,36 @@
+created: 20180927081216605
+modified: 20241114112009202
+original-modified: 20180927084436111
+tags: [[Customise TiddlyWiki]]
+title: Creating a splash screen
+ja-title: スプラッシュ画面を作成する
+type: text/vnd.tiddlywiki
+
+デフォルトでは、TiddlyWikiはロード中に空白の画面を表示します。Wikiのロード中に表示される特別な"スプラッシュ画面"を追加できます。
+
+大きなTiddlyWikiファイルや、遅いネットワーク接続を介してロードされるファイルは、ロードに少し時間がかかる場合があります。完全にロードされると、ブラウザ内ですべてが実行されるため、パフォーマンスが向上します。スプラッシュ画面を使用すると、読み込みプロセスが行われていることをユーザーが認識できるため、ページから離れる可能性が低くなります。
+
+TiddlyWikiが初期化や[[復号化|Encryption]]の前にスプラッシュ画面を表示するには、TiddlyWiki HTMLファイル内に静的HTML/CSSとして埋め込まれます。これは、[[SystemTag: $:/tags/RawMarkupWikified/TopBody]]、または$:/tags/RawMarkupで始まるシステムタグで行われます。
+
+Wikiの読み込みが完了したときにスプラッシュ画面を削除するには、HTMLを特別なクラス`tc-remove-when-wiki-loaded`を持つコンテナ内に包み込む必要があります。このクラスを持つDOM要素は、Wikiがロードされるとコア機能によって自動的に削除されます。
+
+以下は、//Loading//というテキストを表示するだけの単純なスプラッシュ画面の例です。これを使用するには、このテキストを新しいTiddlerにコピーし、タイプ"text/plain"とタグ"$:/tags/RawMarkupWikified/TopBody"を指定します。: 
+
+```
+<div class="tc-remove-when-wiki-loaded">
+Loading...
+</div>
+```
+
+TiddlerにWikiTextタイプ`text/vnd.tiddlywiki`が指定されている場合、ファイルの保存時にコンテンツがwiki化されるので、トランスクルージョンなども可能になります。たとえば、ロード時メッセージでサイトのタイトルを引用する例を次に示します。これを使用するには、このテキストを新しいTiddlerにコピーし、タイプ"text/vnd.tiddlywiki"とタグ"$:/tags/RawMarkupWikified/TopBody"を指定します。: 
+
+```
+\rules only filteredtranscludeinline transcludeinline
+<div class="tc-remove-when-wiki-loaded">
+Please wait while {{$:/SiteTitle}} is loading
+</div>
+```
+
+この`\rules`命令は、認識されるWikiText構文を2つの形式のインライントランスクルージョンに制限するために使用されます。これにより、Tiddlerコンテンツの誤ったWiki化が回避できます。
+
+このWikiには、CSSアニメーションと画像を使用した複雑なスプラッシュ画面の例があります: $:/SplashScreenを参照してください。

--- a/editions/ja-JP/tiddlers/howtos/Custom Styles FAQ.tid
+++ b/editions/ja-JP/tiddlers/howtos/Custom Styles FAQ.tid
@@ -1,0 +1,11 @@
+modified: 20241120105817756
+original-modified: 201804111739
+created: 201804111739
+title: Custom Styles FAQ
+ja-title: カスタムスタイルに関するよくある質問
+tags: [[How to apply custom styles]] FAQ-group
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.16">>
+
+<<list-links "[tag[Custom Styles FAQ]]">>

--- a/editions/ja-JP/tiddlers/howtos/Custom Styles by title.tid
+++ b/editions/ja-JP/tiddlers/howtos/Custom Styles by title.tid
@@ -1,0 +1,41 @@
+created: 201804111739
+modified: 20241119112922446
+original-modified: 201804111739
+tags: [[How to apply custom styles]]
+title: Custom styles by data-tiddler-title
+ja-title: data-tiddler-titleによるカスタムスタイル
+type: text/vnd.tiddlywiki
+
+! 属性: data-tiddler-title
+
+<<.from-version "5.1.16">>
+
+~TiddlyWikiのコアでは、レンダリングされたコンテンツにいくつかの`属性`を追加します。これらの属性を使用すると、カスタムスタイルをTiddlerコンテンツに適用できます
+
+例えば、この"{{!!title}}"という名前のTiddlerには、次のような属性になります: 
+
+```
+data-tiddler-title="Custom styles by data-tiddler-title"
+```
+
+!! 例
+
+次のCSSは[[Custom data-styles]]で定義されており、まさにこのTiddlerに青い境界線を作成します
+
+```
+[data-tiddler-title="Custom styles by data-tiddler-title"] {
+  border: 1px solid blue;
+}
+```
+
+システムTiddlerと呼ばれる`$:/`で始まるすべてのTiddlerに緑色の境界線を作成するには、次のようにCSSを使用する必要があります: (ここでは適用されていませんが、試してみることはできます!)
+
+```
+[data-tiddler-title^="$:/"] {
+  border: 1px solid green;
+}
+```
+
+!! その他の記述方法
+
+{{Attribute Selectors}}

--- a/editions/ja-JP/tiddlers/howtos/Custom Styles by userClass.tid
+++ b/editions/ja-JP/tiddlers/howtos/Custom Styles by userClass.tid
@@ -1,0 +1,28 @@
+created: 201804111739
+modified: 20241119113521083
+original-modified: 201804111739
+title: Custom styles by user-class
+ja-title: user-classによるカスタムスタイル
+tags: [[How to apply custom styles]]
+type: text/vnd.tiddlywiki
+
+''Tiddlerフィールド: `class`'' <<.from-version "5.1.16">>
+
+[[タグの管理|$:/TagManager]]を使用すると、"タグピル"の色を定義するために使用される`color`フィールドをTiddlerに設定できます。<<.from-version "5.1.16">>されたため、[[ViewTemplate|$:/core/ui/ViewTemplate]]に直接挿入され、スタイル設定に使用できる`class`フィールドを定義できます: 
+
+"""
+title: `anyName`
+tags: `$:/tags/Stylesheet`
+class: `myClass`
+"""
+
+`class`フィールドを持つすべてのTiddlerは次のようにスタイル設定できます!
+
+```
+.myClass {
+  border: 2px solid blue;
+}
+
+```
+
+詳細については、[[カスタムスタイルを適用する方法|How to apply custom styles]]を参照してください。

--- a/editions/ja-JP/tiddlers/howtos/Custom tag pill styles.tid
+++ b/editions/ja-JP/tiddlers/howtos/Custom tag pill styles.tid
@@ -1,0 +1,34 @@
+created: 20230608121519758
+modified: 20241120111032165
+original-modified: 20230608123444591
+tags: [[How to apply custom styles]]
+title: Custom tag pill styles
+ja-title: タグピルのカスタムスタイル
+type: text/vnd.tiddlywiki
+
+! 属性: data-tag-title
+
+<<.from-version "5.2.0">> この属性<<.attr data-tag-title>>は、Tiddlerの表示用テンプレートに表示されるタグピルに追加されました。
+
+<<.from-version "5.3.0">> この属性は、標準の~TiddlyWiki UIに表示されるすべてのタグピルに追加されました。特に、編集用テンプレートのタグリスト、タグピッカーのドロップダウン、右側のサイドバー -> 詳しく -> タグ別タブ、そして、$:/TagManagerに追加されています
+
+HTML属性<<.attr data-tag-title>>には、タグピルに表示されるタグタイトルのみが含まれます。これを使用して、タグピルのスタイルを設定できます。
+
+Tiddler全体にスタイルを設定したい場合は、[[data-tiddler-titleによるカスタムスタイル|Custom styles by data-tiddler-title]]を参照してください。
+
+!! 例
+
+新しい `$:/tags/Stylesheet`タグ付きTiddlerで次のCSSを使用すると、`#`で始まるすべてのタグに新しい境界線の丸角半径が設定されます。そのため、これらのタグはデフォルトのタグとは対照的に目立ちます。
+
+既存のTW UI内のすべてのタグピルを捕捉するには、既存のUI構造のため、''両方のCSSルールを定義する必要があります''。
+
+```
+[data-tag-title^="#"] .tc-tag-label,
+[data-tag-title^="#"].tc-tag-label {
+   border-radius: 3px;
+}
+```
+
+!! さらに可能な設定
+
+{{Attribute Selectors}}

--- a/editions/ja-JP/tiddlers/howtos/Custom_Attribute_Selectors.tid
+++ b/editions/ja-JP/tiddlers/howtos/Custom_Attribute_Selectors.tid
@@ -1,0 +1,33 @@
+created: 20170126152839462
+modified: 20241119110659035
+original-modified: 201804111739
+tags: [[Custom data-styles]]
+title: Attribute Selectors
+ja-title: 属性セレクタ
+type: text/vnd.tiddlywiki
+
+;[attr]
+:属性attrを持つ要素を表します。
+
+;[attr="value"]
+:属性attrの値が"value"である要素を表します。
+
+;[attr~="value"]
+:属性attrの値が、空白で区切られた単語のリストで、そのうちの1つが"value"である要素を表します。
+
+;[attr|="value"]
+:属性attrの値が、“value”か、“value”の後に“-” (U+002D)が続く値である要素を表します。言語サブコードの一致に使用できます。
+
+;[attr^="value"]
+:属性attrの値の先頭に"value"が付く要素を表します。
+
+;[attr$="value"]
+:属性attrの値の末尾に"value"が付く要素を表します。
+
+;[attr*="value"]
+:属性attrの値に文字列"value"が部分文字列として少なくとも1回含まれる要素を表します。
+
+;[attr "operator value" i]
+:閉じ括弧の前にi(またはI)を追加すると、値は大文字と小文字を区別せずに比較されます(ASCII範囲内の文字の場合)。
+
+詳細は[[CSSの属性セレクタ|https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors]]や[[CSS仕様書|https://www.w3.org/TR/CSS22/selector.html#attribute-selectors]]を参照してください

--- a/editions/ja-JP/tiddlers/howtos/Custom_styles_by_data-tags.tid
+++ b/editions/ja-JP/tiddlers/howtos/Custom_styles_by_data-tags.tid
@@ -1,0 +1,62 @@
+created: 20170124132500000
+modified: 20241119105640364
+original-modified: 201804111739
+tags: example-test [[How to apply custom styles]]
+title: Custom styles by data-tags
+ja-title: data-tagsによるカスタムスタイル
+type: text/vnd.tiddlywiki
+
+! 属性: data-tags
+
+<<.from-version "5.1.16">>
+
+~TiddlyWikiのコアでは、レンダリングされたコンテンツにいくつかの`属性`を追加します。これらの属性を使用すると、カスタムスタイルをTiddlerコンテンツに適用できます
+
+例えば、この<<tag "How to apply custom styles">>と<<tag "example-test">>でタグ付けされたTiddlerには、次のような属性になります:
+
+```
+data-tags="[[How to apply custom styles]] example-test"
+```
+
+''重要: ''Tiddlerタグはソートされて''いない''ため、レンダリングされた出力の順序は異なる場合があります!
+
+!! 例
+
+次のCSSは[[Custom data-styles]]で定義されており、`example-test`でタグ付けされたすべてのTiddler(これを含む)にピンクの境界線を作成します
+
+```
+[data-tags*="example-test"] {
+  border: 2px solid pink;
+}
+```
+
+!!! スタイルシートのスタイリング
+
+`data-tags-styles`でタグ付けされたTiddlerを表示するには、適切な方法で、次のコードを使用できます(`$:/tags/Stylesheet`を使用することもできますが、このWiki 内のすべてのスタイルシートに影響を与えることになり、意図したものではありません。)
+
+''重要:'' `.tc-tiddler-body`を指定することも忘れないでください。指定しないと、タイトルを含むTiddler全体が変更されます! 参照: [[Custom data-styles]]
+
+```
+[data-tags*="data-tags-styles"] .tc-tiddler-body {
+  display: block;
+  padding: 14px;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  word-break: normal;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  background-color: #f5f5f5;
+  border: 1px solid #cccccc;
+  padding: 0 3px 2px;
+  border-radius: 3px;
+  font-family: Monaco, Consolas, "Lucida Console", "DejaVu Sans Mono", monospace;
+}
+```
+
+!! 強制改行
+
+この仕組みは、散文的な文章を書きたいユーザーにとっては便利です。参照: [[CSSを使用した強制改行|Hard Linebreaks with CSS]]
+
+!! その他の記述方法
+
+{{Attribute Selectors}}

--- a/editions/ja-JP/tiddlers/howtos/Debugging Stylesheets.tid
+++ b/editions/ja-JP/tiddlers/howtos/Debugging Stylesheets.tid
@@ -1,0 +1,13 @@
+created: 20211125175712017
+modified: 20241118113249073
+original-modified: 20211125175906085
+tags: [[Using Stylesheets]]
+title: Debugging Stylesheets
+ja-title: スタイルシートのデバッグ
+type: text/vnd.tiddlywiki
+
+コアの隠しTiddler $:/snippets/DebugStylesheetsには、括弧の不一致やその他の入れ子構造に関する特定の問題を追跡するための簡単なツールが含まれています
+
+以下のリストでは、エラーを含むスタイルシートには赤いバツ印が付いています: 
+
+{{$:/snippets/DebugStylesheets}}

--- a/editions/ja-JP/tiddlers/howtos/How to apply custom styles by tag.tid
+++ b/editions/ja-JP/tiddlers/howtos/How to apply custom styles by tag.tid
@@ -1,0 +1,62 @@
+caption: {{!!ja-title}} - ^^非推奨^^
+created: 20141001132300000
+modified: 20241121113613599
+original-modified: 20220704174221300
+tags: [[How to apply custom styles]] $:/deprecated
+title: How to apply custom styles by tag
+ja-title: タグでカスタムスタイルを適用する方法
+type: text/vnd.tiddlywiki
+
+<<.deprecated-since "5.1.16" "Custom styles by data-tags">>. [[カスタムスタイルを適用する方法|How to apply custom styles]]も参照してください
+
+----
+
+`tc-tagged-<Tag Name>`という名前のCSSクラスを定義することで、特定のタグを持つTiddlerにカスタムスタイルを適用できます。
+
+たとえば、"NightReader"というタグが付けられたTiddlerを夜の読書に適した特別な配色で表示するには、次のようにクラス`tc-tagged-NightReader`を定義する[[スタイルシートを作成|Using Stylesheets]]します:
+
+```
+.tc-tagged-NightReader {
+	background-color:black;
+	color: orange;
+	padding: 35px 35px;
+}
+
+.tc-tagged-NightReader .tc-tiddler-body {
+	font-size: 1.5em;
+}
+```
+
+クラス`tc-tagged-NightReader`は、Tiddlerのテキスト部分だけでなく、Tiddler全体に適用されます。Tiddlerのより小さな部分をターゲットにしたい場合は、この`.tc-tagged-NightReader .tc-tiddler-body`のようにCSSセレクターを修飾します。
+
+Note that tags containing spaces or non-alphanumeric characters will be converted using URI encoding, making the generated CSS classname hard to predict. For example:
+スペースや英数字以外の文字を含むタグはURIエンコーディングを使用して変換されるため、生成されるCSSクラス名を予測することが困難になることに注意してください。例:
+
+|!Tag |!Generated Class Name |
+|`$:/mytag` |`tc-tagged-%24%3A%2Fmytag` |
+|`Doctor Who` |`tc-tagged-Doctor%20Who` |
+|`£35.23` |`tc-tagged-%C2%A335.23` |
+
+~TiddlyWikiはこれらのタグを生成しますが、実際にCSSで使用するには、次のようにスタイルシートでパーセント文字をエスケープする必要があります: 
+
+```
+.tc-tagged-Doctor\%20Who {
+    background-image: url(./tardis_back.svg);
+    background-repeat: no-repeat;
+    background-position: right;
+    color:#FBFBFB;
+}
+```
+
+変換を実行するためのユーティリティ関数がJavaScriptで利用できます: 
+
+```
+$tw.utils.tagToCssSelector("$:/tags/Stylesheet")
+```
+
+次の出力を生成します: 
+
+```
+tc-tagged-\%24\%3A\%2Ftags\%2FStylesheet
+```
+

--- a/editions/ja-JP/tiddlers/howtos/How to apply custom styles.tid
+++ b/editions/ja-JP/tiddlers/howtos/How to apply custom styles.tid
@@ -1,0 +1,12 @@
+created: 20141001132300000
+list: [[Custom styles by data-tags]] [[Custom styles by data-tiddler-title]]
+modified: 20241117105127872
+original-modified: 201804111740
+tags: [[Customise TiddlyWiki]]
+title: How to apply custom styles
+ja-title: カスタムスタイルを適用する方法
+type: text/vnd.tiddlywiki
+
+カスタムスタイルを適用するにはいくつかの方法があります
+
+<<list-links filter:"[tag[How to apply custom styles]]">>

--- a/editions/ja-JP/tiddlers/howtos/Making a custom journal button.tid
+++ b/editions/ja-JP/tiddlers/howtos/Making a custom journal button.tid
@@ -1,0 +1,43 @@
+created: 20160424150551727
+modified: 20241117105431939
+original-modified: 20171114215846324
+tags: [[Customise TiddlyWiki]]
+title: Making a custom journal button
+ja-title: カスタムジャーナルボタンの作成
+type: text/vnd.tiddlywiki
+
+独自の''//カスタム//''ジャーナルボタンを取得するには、まず[[新しいジャーナル|$:/core/ui/Buttons/new-journal]]ボタンを複製します
+
+次に、独自の設定用Tiddlerを作成します。例: 
+
+* ``$:/config/myNewTiddler/Tags``と... 
+* ``$:/config/myNewTiddler/Title``と... 
+* ``$:/config/myNewTiddler/Text``
+
+カスタムボタンを編集し、設定用Tiddler名を"検索して置換"します
+
+Tiddlerの終わり近くにある次の行を修正します
+
+修正前
+
+```
+<$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>
+<$set name="journalTags" value={{$:/config/NewJournal/Tags}}>
+<$set name="journalText" value={{$:/config/NewJournal/Text}}>
+```
+
+修正後
+
+```
+<$set name="journalTitleTemplate" value={{$:/config/myNewTiddler/Title}}>
+<$set name="journalTags" value={{$:/config/myNewTiddler/Tags}}>
+<$set name="journalText" value={{$:/config/myNewTiddler/Text}}>
+```
+
+サイドバーで使用したい場合は、設定用Tiddlerを次のようにします: 
+
+```
+<$set name="journalTitleTemplate" value={{config/myNewTiddler/Title}}>
+<$set name="journalTags" value={{config/myNewTiddler/Tags}}>
+<$set name="journalText" value={{config/myNewTiddler/Text}}>
+```

--- a/editions/ja-JP/tiddlers/howtos/Preserving open tiddlers at startup.tid
+++ b/editions/ja-JP/tiddlers/howtos/Preserving open tiddlers at startup.tid
@@ -1,0 +1,17 @@
+created: 20140101192052333
+modified: 20241117105837064
+original-modified: 20140912142248706
+tags: [[Customise TiddlyWiki]]
+title: Preserving open tiddlers at startup
+ja-title: 開いているTiddlerを起動時に保持する
+type: text/vnd.tiddlywiki
+
+通常、TiddlyWikiは起動時にTiddler[[$:/DefaultTiddlers]]でフィルターとして指定されたTiddlerを表示します
+
+ファイルを保存したときに開いていたTiddlerを再度開くと便利な場合があります。これを行うには、[[$:/DefaultTiddlers]]に次のフィルタを設定します: 
+
+```
+[list[$:/StoryList]]
+```
+
+このフィルタは、[[$:/StoryList]]Tiddlerで指定されたTiddlerを返します。これは、TiddlyWikiが現在のストーリーのTiddlerのシーケンスを保存するために使用するシステムTiddlerです

--- a/editions/ja-JP/tiddlers/howtos/Setting a favicon.tid
+++ b/editions/ja-JP/tiddlers/howtos/Setting a favicon.tid
@@ -1,0 +1,19 @@
+created: 20131224074240979
+modified: 20241117110141506
+original-modified: 20200510115704738
+tags: [[Customise TiddlyWiki]]
+title: Setting a favicon
+ja-title: faviconを設定する
+type: text/vnd.tiddlywiki
+
+"favicon"は、Webサイトを区別できるようにするために、主なブラウザで表示される小さなアイコンです。すべてのブラウザはビットマップ画像形式をサポートしていますが、SVG画像形式のアイコンをサポートしているのは特定の最新ブラウザだけであることに注意してください。
+
+! ブラウザのfavicon
+
+TiddlyWikiがブラウザで起動すると、[[$:/favicon.ico]]というTiddlerが検索され、ページのfaviconとして動的に使用されます。画像を変更すると、faviconが即座に変更され、反映されます。
+
+<<.from-version "5.1.23">> 外部画像をfaviconとして設定するには、[[$:/favicon.ico]]Tiddlerの''_canonical_uri''フィールドにURLを割り当てます。
+
+! サーバ上のfavicon
+
+サーバ上では、ServerCommandがパス`/favicon.ico`に[[$:/favicon.ico]]Tiddlerを提供します。

--- a/editions/ja-JP/tiddlers/howtos/Setting a page background image.tid
+++ b/editions/ja-JP/tiddlers/howtos/Setting a page background image.tid
@@ -1,0 +1,19 @@
+created: 20150417155912612
+modified: 20241117110849866
+original-modified: 20230803044412567
+tags: [[Customise TiddlyWiki]]
+title: Setting a page background image
+ja-title: ページの背景画像を設定する
+type: text/vnd.tiddlywiki
+
+# 画像をTiddlerとしてインポートします([[WikiTextでの画像|Images in WikiText]]を参照)
+#* [[外部の画像|ExternalImages]]も使用できます
+# [[コントロールパネル|$:/ControlPanel]]<<.icon $:/core/images/options-button>>を開き、''外観''/''Theme Tweaks''タブに切り替えます
+# "Page background image"というラベルのドロップダウンリストから画像を選択します
+# "Page background image attachment"を"Fixed to window"に設定すると、背景が固定され、コンテンツがその上でスクロールします。また、"Scroll with tiddlers"に設定すると背景も移動します(iPhone/iPadではパフォーマンス上の理由から[[Fixed設定はサポートされない|http://stackoverflow.com/a/20444219]]ことに注意してください)
+# "Page background image size"を以下のように設定します: 
+#* ''Auto''は、ページの背景に背景画像が並べて表示されます
+#* ''Cover''は、背景画像がページを完全に覆うようにサイズ調整されます。画像の端が切り取られる場合があります
+#* ''Contain''は、背景画像がページ内に収まるようにサイズ変更されます
+
+[[DarkPhotos|ColourPalettes]]パレットは、暗い背景画像でサイドバーを読みやすくするために提供されていることに注意してください。

--- a/editions/ja-JP/tiddlers/howtos/Using Stylesheets.tid
+++ b/editions/ja-JP/tiddlers/howtos/Using Stylesheets.tid
@@ -1,0 +1,82 @@
+created: 20140305091244145
+modified: 20241118112833362
+original-modified: 20211125175708977
+tags: [[Customise TiddlyWiki]]
+title: Using Stylesheets
+ja-title: スタイルシートの使用
+type: text/vnd.tiddlywiki
+
+\define tv-config-toolbar-text() yes
+
+\define openCpTheme()
+<$action-setfield $tiddler="$:/state/tab-1749438307" $value="$:/core/ui/ControlPanel/Appearance"/>
+<$action-setfield $tiddler="$:/state/tab--1963855381" $value="$:/core/ui/ControlPanel/Theme"/>
+<$action-navigate $to="$:/ControlPanel"/>
+\end
+
+! テーマとカラーパレット
+
+~TiddlyWikiの外観を変更するための最初の手順は、以下を選択して適用することです: 
+
+* 利用可能なテーマの1つ: {{$:/core/ui/Buttons/theme}}
+* カラーパレットの変更: {{$:/core/ui/Buttons/palette}}
+* <$button actions=<<openCpTheme>> class="tc-btn-invisible"><<.icon $:/core/images/options-button>>コントロールパネル</$button>で試す
+
+! スタイルシートの動き
+
+コントロールパネルに加えて、Tiddlerに`$:/tags/Stylesheet`タグを付けることでカスタムスタイルを定義できます。ページの背景色を赤に変更するには、次の内容でカスタムスタイルシートを作成します: 
+
+```
+body.tc-body {
+	background: red;
+}
+```
+
+その後、[[WikiTextで独自のスタイルとクラス|Styles and Classes in WikiText]]を使用します。
+
+!! 追加リソース
+
+* [[カスケーディングスタイルシート(CSS) (mozillaサイト)|https://developer.mozilla.org/en-US/docs/Web/CSS]]
+* [[カスケーディングスタイルシート(CSS) (w3scoolsサイト)|http://www.w3schools.com/css]]
+
+! テーマ設定の上書き
+
+カスタムスタイルシートは、テーマスタイルシートとは独立して適用されます。そのため、カスタムスタイルシートのCSSルールは、上書きするテーマのCSSルールよりも具体的にする必要があります。たとえば、`html body.tc-body`は`body.tc-body`よりも具体的です。
+
+<<.tip """常に、最も具体的でない値から始めます!""">>
+
+! スタイルシートの種類
+
+通常、スタイルシートの種類には`text/css`を使用するのが最適です。これにより、プレーンなスタイルシートとして扱われ、~TiddlyWikiがWi​​ki処理を適用しないことが保証されます。
+
+If you wish to use macros and transclusions in your stylesheets you should instead use the default WikiText type `text/vnd.tiddlywiki`. This allows full ~WikiText processing to be performed. Here is an example:
+スタイルシートでマクロやトランスクルージョンを使用したい場合は、代わりにデフォルトの種類であるWikiText `text/vnd.tiddlywiki`を使用します。これにより、完全な~WikiText処理を実行できます。次に例を示します。
+
+```
+\rules only filteredtranscludeinline transcludeinline macrodef macrocallinline html
+
+body.tc-body pre {
+	<<box-shadow "inset 0 1px 0 #fff">>
+}
+```
+
+ティドラーの先頭にある`\rules`プラグマは、~WikiTextがマクロとトランスクルージョンのみを許可するように制限します。これにより、誤って不要な~WikiText処理がトリガーされることを回避できます。
+
+スタイルシートTiddlerは、まずWiki化され、次に出力のテキスト部分が抽出されてCSSとして適用されるように処理されます。したがって、スタイルシートで使用しているHTMLタグはすべて無視されます。たとえば、RevealWidgetによって生成されたHTML要素は出力に影響しません。次の例のように、CSSルールを`<pre>`タグで囲んで、内部マクロの処理などの処理に影響を与えることなく、コードブロックとして表示できます。
+
+```
+\rules only filteredtranscludeinline transcludeinline macrodef macrocallinline html
+
+<pre>body.tc-body pre {
+	<<box-shadow "inset 0 1px 0 #fff">>
+}
+</pre>
+```
+
+!! スタイルシートマクロ
+
+~TiddlyWikiコアは、[[スタイルシートの構築に役立つグローバルマクロ|Stylesheet Macros]]を提供します。
+
+!! 参照
+
+<<list-links "[tag[Using Stylesheets]]">>

--- a/editions/ja-JP/tiddlers/howtos/faq/csFAQ_dynamic_stylesheet.tid
+++ b/editions/ja-JP/tiddlers/howtos/faq/csFAQ_dynamic_stylesheet.tid
@@ -1,0 +1,10 @@
+created: 201804111739
+modified: 20241120110107221
+original-modified: 201804111739
+title: Q: Is there a way to create dynamic stylesheets?
+ja-title: Q: 動的スタイルシートを作成する方法はありますか?
+tags: [[Custom Styles FAQ]]
+
+''回答:'' <<.from-version "5.1.16">>
+
+はい、[[Q: カスタムフィールドを使用してTiddlerのスタイルを設定するにはどうすればよいですか?|Q: How can I use a custom field to style a tiddler?]]を参照してください

--- a/editions/ja-JP/tiddlers/howtos/faq/csFAQ_how_can_i_use_custom_field.tid
+++ b/editions/ja-JP/tiddlers/howtos/faq/csFAQ_how_can_i_use_custom_field.tid
@@ -1,0 +1,31 @@
+created: 201804111739
+modified: 20241120110107221
+original-modified: 201804111739
+title: Q: How can I use a custom field to style a tiddler?
+ja-title: Q: カスタムフィールドを使用してTiddlerのスタイルを設定するにはどうすればよいですか?
+tags: [[Custom Styles FAQ]]
+
+''次のユースケースを考えてみましょう:'' <<.from-version "5.1.16">>
+
+`rank`という名前のフィールドがあります。このフィールドには、例えば`species`のようなさまざまな値を保持できます
+
+''回答:''
+
+ここでのアイデアは、スタイルシートを動的に作成するということです。スタイルシートは次のようになります: 
+
+"""
+title: `myStyles`
+tags: `$:/tags/Stylesheet`
+"""
+
+```
+<$list filter="[rank[species]]"> 
+[data-tiddler-title^="<$view field=title/>"] .tc-tiddler-body {
+    column-count: 2;
+}
+</$list> 
+```
+
+これにより、フィールド`rank`と値`species`を持つすべてのTiddlerタイトルのCSSルールが作成されます
+
+[[利用できる属性についての詳細はこちらをご覧ください!|Attribute Selectors]]

--- a/editions/ja-JP/tiddlers/howtos/faq/csFAQ_what_if_tiddler_has_no_tags.tid
+++ b/editions/ja-JP/tiddlers/howtos/faq/csFAQ_what_if_tiddler_has_no_tags.tid
@@ -1,0 +1,21 @@
+created: 201804111739
+modified: 20241120110107221
+original-modified: 201804111739
+title: Q: What if a tiddler has no tags?
+ja-title: Q: Tiddlerにタグがない場合はどうしますか?
+tags: [[Custom Styles FAQ]]
+
+''回答:'' <<.from-version "5.1.16">>
+
+* Tiddlerにタグがないが、スタイル設定が必要な場合は、CSSセレクターとして`data-tiddler-title`を使用します
+** Tiddlerは一つのみです
+
+* ユーザーがシステムTiddlerのスタイルをカスタム設定したい場合: セレクターとして`[data-tiddler-title^="$:"/]`を使用します
+** TW名前空間機能を使用する
+
+* ユーザーがタグ付けされたTiddlerに対して特別な動作を設定したい場合。例: Learning
+** CSSセレクターとして`[data-tags*="Learning"]`を使用します
+
+私が使用している名前は、既存のWikiを変更することなく、ドキュメント目的でのみ使用されます。ドキュメントに副作用があることは望ましくありません
+
+[[利用できる属性についての詳細はこちらをご覧ください!|Attribute Selectors]]

--- a/editions/ja-JP/tiddlers/howtos/faq/csFAQ_what_this_and_that_tag.tid
+++ b/editions/ja-JP/tiddlers/howtos/faq/csFAQ_what_this_and_that_tag.tid
@@ -1,0 +1,34 @@
+created: 201804111739
+modified: 20241120110107221
+original-modified: 201804111739
+title: Q: How can I style a tiddler if it has "this" AND "that" tag?
+ja-title: Q: "this"タグと"that"タグの両方を持つTiddlerのスタイルを設定するにはどうすればよいですか?
+tags: [[Custom Styles FAQ]]
+
+''回答: '' <<.from-version "5.1.16">>
+
+Tiddlerに`this`と`that`の両方のタグがある場合、オレンジ色の境界線が作成されます
+
+```
+[data-tags*="bar"][data-tags*="froz"] {
+  border: 2px solid orange;
+}
+```
+
+''CSSが次のような場合: ''
+
+```
+[data-tags~="this"] {
+  border: 2px solid blue;
+}
+
+[data-tags~="that"] {
+  border: 2px solid red;
+}
+```
+
+`this`は青い境界線を作成します
+`that`は赤青い境界線を作成します
+位置を入れ替えると、逆になります
+
+[[利用できる属性についての詳細はこちらをご覧ください!|Attribute Selectors]]

--- a/editions/ja-JP/tiddlers/howtos/faq/csFAQ_what_this_or_that_tag.tid
+++ b/editions/ja-JP/tiddlers/howtos/faq/csFAQ_what_this_or_that_tag.tid
@@ -1,0 +1,19 @@
+created: 201804111739
+modified: 20241120110107221
+original-modified: 201804111739
+title: Q: How can I style a tiddler if it has "this" OR "that" tag?
+ja-title: Q: "this"タグと"that"タグのどちらかを持つTiddlerのスタイルを設定するにはどうすればよいですか?
+tags: [[Custom Styles FAQ]]
+
+''回答: '' <<.from-version "5.1.16">>
+
+`this`または`that`のいずれかのタグがある場合、赤い境界線を作成します
+
+```
+[data-tags~="this"],
+[data-tags~="that"] {
+  border: 2px solid red;
+}
+```
+
+[[利用できる属性についての詳細はこちらをご覧ください!|Attribute Selectors]]

--- a/editions/ja-JP/tiddlers/wikitext/Styles and Classes in WikiText.tid
+++ b/editions/ja-JP/tiddlers/wikitext/Styles and Classes in WikiText.tid
@@ -1,0 +1,75 @@
+caption: スタイルとクラス
+created: 20131205160532119
+modified: 20241123111135825 
+original-modified: 20230726105744098
+tags: WikiText [[How to apply custom styles]]
+title: Styles and Classes in WikiText
+ja-title: WikiTextでのスタイルとクラス
+type: text/vnd.tiddlywiki
+
+CSSスタイルとクラスは、`@@二重のアットマーク@@`で囲まれたインラインコンテンツまたはブロックコンテンツに適用できます。クラスは、特定のブロックWikiText要素に適用できます。
+
+スタイルやクラスを指定せずに`@@二重のアットマーク@@`でラップされた//インラインコンテンツ//には、`tc-inline-style`クラスが割り当てられ、ハイライトされたテキストとして表示されます。ハイライトされたテキストの前景色と背景色は、現在のパレットで`highlight-background`と`highlight-foreground`として定義されている色が使われます。
+
+<<wikitext-example src:"@@ハイライトされたテキスト@@">>
+
+!! スタイル
+
+複数のスタイル属性(例: `color`)は、各属性の後にセミコロン`;`をつけ、開始の`@@`の直後に、スペースを入れずに、記述します。
+
+<<wikitext-example src:"@@color:steelblue;background-color:lightcyan;カスタムスタイルのテキスト@@">>
+
+同様に、//ブロックコンテンツ//にもスタイルを適用できます。スタイルやクラスを指定せずに`@@`内にブロック コンテンツをラップしても効果はありません。
+
+<<wikitext-example src:"@@background-color:lightcyan;
+* アイテム 1
+* アイテム 2
+@@
+">>
+
+!! クラス
+
+次のTiddlerでは、デモンストレーションの目的で`coloured-text`クラスと`coloured-bg`クラスが定義されています: 
+
+
+```
+.coloured-text {color: darkkhaki;}
+.coloured-bg {background-color: cornsilk;}
+```
+
+<style>
+.coloured-text {color: darkkhaki;}
+.coloured-bg {background-color: cornsilk;}
+</style>
+
+複数のクラス(それぞれ`.`のプレフィックス付き)は、開始の`@@`の直後にスペース` `を空けて記述します。これは、インラインコンテンツとブロックコンテンツの両方で機能します: 
+
+<<wikitext-example src:"@@.coloured-text.coloured-bg 2つのクラスが割り当てられたインラインコンテンツ@@">>
+
+<<wikitext-example src:"@@.coloured-bg
+* ブロックコンテンツ
+* 1つのクラスを割り当て
+@@">>
+
+複数のクラスとスタイルを同時に適用できます。インラインコンテンツの場合は、最初にスタイルを定義し、その後にクラスを定義する必要があります。
+
+<<wikitext-example src:"@@font-size:1.5em;.coloured-text.coloured-bg カスタムスタイルとクラスを持つテキスト@@">>
+
+ブロックコンテンツの場合、スタイルとクラスは、インラインコンテンツの場合と同じように開始`@@`の後の1行で定義することも、それぞれ`@@`で始まる別々の行で定義することもできます: 
+
+<<wikitext-example src:"@@font-size:1.5em;
+@@.coloured-text
+@@.coloured-bg
+* ブロックコンテンツ
+* カスタムスタイルとクラス
+@@">>
+
+同様に、行の先頭の文字によって導入されるブロックWikiText要素に、スタイルではなくクラスを適用できます。プレフィックス`.`が付くクラスは、特殊文字の直後に記述され、その後にスペース` `が続きます。
+
+<<wikitext-example src:"!!!.coloured-bg カスタム背景クラスを使用した見出し。
+
+* 標準のリスト要素。
+*.coloured-bg カスタム背景色を持つリスト要素。
+*.coloured-text カスタムテキスト色を持つリスト要素。
+*.coloured-bg.coloured-text 両方のカスタムクラスを持つリスト要素。
+">>


### PR DESCRIPTION
[ja_JP] Update of Japanese translations, mainly on the 'Customise TiddlyWiki' section tiddlers of tiddlywiki.com.