### PR TITLE
Make HTTP Basic Auth aware of path-prefix

### DIFF
--- a/core/modules/server/routes/get-login-basic.js
+++ b/core/modules/server/routes/get-login-basic.js
@@ -25,7 +25,7 @@ exports.handler = function(request,response,state) {
 		response.end();
 	} else {
 		// Redirect to the root wiki if login worked
-		var location = ($tw.syncadaptor && $tw.syncadaptor.host)? $tw.syncadaptor.host: "/";
+		var location = ($tw.syncadaptor && $tw.syncadaptor.host)? $tw.syncadaptor.host: `${state.pathPrefix}/`;
 		response.writeHead(302,{
 			Location: location
 		});


### PR DESCRIPTION
As documented in #8788, if a user combines a `path-prefix` and `readers=(anon)` for the Node.js server, manual HTTP Basic Authentication via "/login-basic" will redirect the authenticated user to the server root "/" instead of the correct URI including the path prefix.

This PR makes a small change to prefix the default redirection URL with the value of the path prefix.

It appears that the server boot process will set state.pathPrefix to "" if it is not configured, so it *should* be safe to simply reference the value in a string template without an additional conditional check at the moment of use. I have tested this change both with and without the `path-prefix` server parameter and was correctly redirected after authentication in both configurations.