### PR TITLE
fix: allow overwrite plugin that don't have plugin-priority

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1475,9 +1475,9 @@ $tw.Wiki = function(options) {
 			if("plugin-priority" in a.fields && "plugin-priority" in b.fields) {
 				return a.fields["plugin-priority"] - b.fields["plugin-priority"];
 			} else if("plugin-priority" in a.fields) {
-				return -1;
-			} else if("plugin-priority" in b.fields) {
 				return +1;
+			} else if("plugin-priority" in b.fields) {
+				return -1;
 			} else if(a.fields.title < b.fields.title) {
 				return -1;
 			} else if(a.fields.title === b.fields.title) {

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1475,13 +1475,13 @@ $tw.Wiki = function(options) {
 			var priorityA = "plugin-priority" in a.fields ? a.fields["plugin-priority"] : 1;
 			var priorityB = "plugin-priority" in b.fields ? b.fields["plugin-priority"] : 1;
 			if (priorityA !== priorityB) {
-					return priorityA - priorityB;
+				return priorityA - priorityB;
 			} else if (a.fields.title < b.fields.title) {
-					return -1;
+				return -1;
 			} else if (a.fields.title === b.fields.title) {
-					return 0;
+				return 0;
 			} else {
-					return +1;
+				return +1;
 			}
 		});
 		// Now go through the plugins in ascending order and assign the shadows

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1470,20 +1470,18 @@ $tw.Wiki = function(options) {
 	// Unpack the currently registered plugins, creating shadow tiddlers for their constituent tiddlers
 	this.unpackPluginTiddlers = function() {
 		var self = this;
-		// Sort the plugin titles by the `plugin-priority` field
-		pluginTiddlers.sort(function(a,b) {
-			if("plugin-priority" in a.fields && "plugin-priority" in b.fields) {
-				return a.fields["plugin-priority"] - b.fields["plugin-priority"];
-			} else if("plugin-priority" in a.fields) {
-				return +1;
-			} else if("plugin-priority" in b.fields) {
-				return -1;
-			} else if(a.fields.title < b.fields.title) {
-				return -1;
-			} else if(a.fields.title === b.fields.title) {
-				return 0;
+		// Sort the plugin titles by the `plugin-priority` field, if this field is missing, default to 1
+		pluginTiddlers.sort(function(a, b) {
+			var priorityA = "plugin-priority" in a.fields ? a.fields["plugin-priority"] : 1;
+			var priorityB = "plugin-priority" in b.fields ? b.fields["plugin-priority"] : 1;
+			if (priorityA !== priorityB) {
+					return priorityA - priorityB;
+			} else if (a.fields.title < b.fields.title) {
+					return -1;
+			} else if (a.fields.title === b.fields.title) {
+					return 0;
 			} else {
-				return +1;
+					return +1;
 			}
 		});
 		// Now go through the plugins in ascending order and assign the shadows


### PR DESCRIPTION
@pmario 's palette switcher plugin contains default dark/light palette setting, I hope I can overwrite it in my plugin. My plugin is a config-pack plugin for TidGi, to make sure user can upgrade basic UX through plugin, instead of having to upgrade TidGi app.

But palette switcher plugin don't have a `plugin-priority` field, in current logic it means its priority is Infinity, no one can overwrite it, I think this is incorrect. If an author forget to add `plugin-priority` field, this should means its priority is 0 (or maybe 1, so it is load later than the core). This make sure any plugin author can patch other author's plugin.

BTW: @pmario could you please add this field?