### PR TITLE
[DOCS] DEV-edition fix GitHub ribbon

### DIFF
--- a/editions/dev/tiddlers/$__github-ribbon.tid
+++ b/editions/dev/tiddlers/$__github-ribbon.tid
@@ -1,0 +1,9 @@
+code-body: yes
+created: 20241205094051389
+modified: 20241205094051389
+tags: $:/tags/PageTemplate
+title: $:/github-ribbon
+type: text/vnd.tiddlywiki
+
+\whitespace trim
+<$transclude $tiddler="$:/plugins/tiddlywiki/github-fork-ribbon/template" top="30px" fixed=fixed color="green"/>


### PR DESCRIPTION
This PR fixes the DEV-edition GitHub ribbon

Currently it looks like this: 

![image](https://github.com/user-attachments/assets/0d8b1fb5-42d3-4723-8f3d-82925d664ce8)

With this PR it looks like this

![image](https://github.com/user-attachments/assets/1c259299-6179-4a0b-ae9a-906fc16d5478)
