### PR TITLE
[DOCS] Update dev editon

### DIFF
--- a/editions/dev/tiddlers/system/$__editions_tw5.com_wikitext-macros.tid
+++ b/editions/dev/tiddlers/system/$__editions_tw5.com_wikitext-macros.tid
@@ -1,0 +1,89 @@
+code-body: yes
+created: 20150117184156000
+modified: 20240716181836632
+tags: $:/tags/Macro
+title: $:/editions/tw5.com/wikitext-macros
+type: text/vnd.tiddlywiki
+
+\whitespace trim
+
+\procedure activatePluginTab()
+<$action-setfield $tiddler="$:/state/tab-1749438307" text="$:/core/ui/ControlPanel/Plugins"/>
+<$action-navigate $to="$:/ControlPanel"/>
+\end
+
+\procedure activateTiddlerWindow()
+<$action-sendmessage $message="tm-open-window" $param=<<currentTiddler>> windowTitle="Side by Side View" width="800" height="600" />
+\end
+
+\procedure controlPanel-plugin-link()
+<$button actions=<<activatePluginTab>> class="tc-btn-invisible tc-tiddlylink">
+	{{$:/core/images/options-button}} ~ControlPanel
+</$button>
+\end
+
+\procedure open-tiddler-in-window()
+\whitespace notrim
+<$button actions=<<activateTiddlerWindow>> class="tc-btn-invisible tc-tiddlylink">
+	open ''this'' tiddler in a new window
+</$button>
+\end
+
+\procedure activateEditionWindow(url)
+<$action-sendmessage $message="tm-open-external-window" $param=<<url>> windowName="_edition" windowFeatures="width=800 height=600" />
+\end
+
+\procedure open-external-window(url)
+\whitespace notrim
+<$button actions=<<activateEditionWindow <<url>> class="tc-btn-invisible tc-tiddlylink">
+	open the ''example edition'' in a new window
+</$button>
+\end
+
+
+\procedure wikitext-example(src)
+<div class="doc-example">
+	<$macrocall $name="copy-to-clipboard-above-right" src=<<src>>/>
+	<$codeblock code=<<src>>/>
+	<p>
+		That renders as:
+	</p>
+	<$transclude $variable="src" $mode="block"/>
+	<p>
+		... and the underlying HTML is:
+	</p>
+	<$wikify name="html" text=<<src>> output="html">
+		<$codeblock code=<<html>>/>
+	</$wikify>
+</div>
+\end
+
+\procedure wikitext-example-without-html(src)
+<div class="doc-example">
+	<$macrocall $name="copy-to-clipboard-above-right" src=<<src>>/>
+	<$codeblock code=<<src>>/>
+	<p>
+		That renders as:
+	</p>
+	<$transclude $variable="src" $mode="block"/>
+</div>
+\end
+
+\procedure wikitext-example-table-header() <thead><tr><th/><th>wiki text</th><th>renders as</th></tr></thead>
+
+\procedure wikitext-example-table-row(id, code)
+<tr>
+	<th><<id>></th>
+	<td><$codeblock code=<<code>>/></td>
+	<td><$transclude $variable="code" $mode="block"/></td>
+</tr>
+\end
+
+\procedure tw-code(tiddler)
+<$codeblock language={{{ [<tiddler>get[type]] }}} code={{{ [<tiddler>get[text]] }}}/>
+\end
+
+\procedure tw-code-link(tiddler)
+<$link to=<<tiddler>>/>:
+<$transclude $variable=tw-code tiddler=<<tiddler>> />
+\end

--- a/editions/dev/tiddlers/system/doc-macros.tid
+++ b/editions/dev/tiddlers/system/doc-macros.tid
@@ -1,114 +1,237 @@
 created: 20150117152607000
-modified: 201804111739
+modified: 20241205093917150
 tags: $:/tags/Macro
 title: $:/editions/dev/doc-macros
 type: text/vnd.tiddlywiki
 
-\define .concat(1,2,3,4,5) $1$$2$$3$$4$$5$
+\whitespace trim
 
-\define .def(_) <dfn class="doc-def">$_$</dfn>
-\define .em(_) <em class="doc-em">$_$</em>
-\define .strong(_) <strong class="doc-strong">$_$</strong>
-\define .place(_) <code class="doc-place">$_$</code>
-\define .word(_) "$_$"
+\function .concat(1,2,3,4,5) [[$(1)$$(2)$$(3)$$(4)$$(5)$]substitute[]]
+\function .word(_) [["]] [<_>] =[["]] +[join[]]
 
-\define .preamble(_) :.doc-preamble $_$
-\define .note(_)
-@@.doc-note
-;Note
-: $_$
-@@
+\procedure .def(_) <dfn class="doc-def"><<_>></dfn>
+\procedure .em(_) <em class="doc-em"><<_>></em>
+\procedure .strong(_) <strong class="doc-strong"><<_>></strong>
+\procedure .place(_) <code class="doc-place"><<_>></code>
+\procedure .preamble(_) <dl><dd class="doc-preamble"><<_>></dd></dl>
+
+\procedure .tid(_) <code class="doc-tiddler"><<_>></code>
+\procedure .tag(_) <code class="doc-tag"><<_>></code>
+\procedure .field(_) <code class="doc-field"><<_>></code>
+\procedure .value(_) <code class="doc-value"><<_>></code>
+\procedure .op(_) <code class="doc-operator"><<_>></code>
+\procedure .var(_) <code class="doc-var"><<_>></code>
+\procedure .wid(_) <code class="doc-widget"><$macrocall $name=".concat" 1="$" 2=<<_>>/></code>
+\procedure .attr(_) <code class="doc-attr"><<_>></code>
+\procedure .param(_) <code class="doc-param"><<_>></code>
+
+\procedure .tiddler-fields(tiddler)
+<$tiddler tiddler=<<tiddler>>>
+	<div class="doc-tiddler-fields">
+		<h2>
+		<$link>
+			<span class="tc-tiddler-title-icon">{{||$:/core/ui/TiddlerIcon}}</span><$text text=<<currentTiddler>>/>
+		</$link>
+		</h2>
+		<table class="tc-view-field-table">
+			<tbody>
+				<$list filter="[all[current]fields[]sort[title]] -title" template="$:/core/ui/TiddlerFieldTemplate" variable="listItem"/>
+			</tbody>
+		</table>
+	</div>
+</$tiddler>
 \end
 
-\define .tid(_) <code class="doc-tiddler">$_$</code>
-\define .tag(_) <code class="doc-tag">$_$</code>
-\define .field(_) <code class="doc-field">$_$</code>
-\define .value(_) <code class="doc-value">$_$</code>
-\define .op(_) <code class="doc-operator">$_$</code>
-\define .var(_) <code class="doc-var">$_$</code>
-\define .wid(_) <code class="doc-widget">$$_$</code>
-\define .attr(_) <code class="doc-attr">$_$</code>
-\define .param(_) <code class="doc-param">$_$</code>
+\function .mtitle(_) [<_>] Macro +[join[ ]]
+\function .otitle(_) [<_>] Operator +[join[ ]]
+\function .vtitle(_) [<_>] Variable +[join[ ]]
 
-\define .mtitle(_) $_$ Macro
-\define .otitle(_) $_$ Operator
-\define .vtitle(_) $_$ Variable
+\procedure .link(_,to) <$link to=<<to>> ><<_>></$link>
+\procedure .clink(_,to) <span class="doc-clink"><$link to=<<to>>><<_>></$link></span>
 
-\define .link(_,to) <$link to="$to$">$_$</$link>
-\define .clink(_,to) <span class="doc-clink"><<.link """$_$""" "$to$">></span>
-\define .dlink(_,to) <$macrocall $name=".link" _=<<.def "$_$">> to="$to$">/>
-\define .dlink-ex(_,to) <a href="$to$" class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer"><<.def "$_$">></a>
-\define .flink(to) <$macrocall $name=".link" _=<<.field {{$to$!!caption}}>> to="$to$"/>
-\define .mlink(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to=<<.mtitle "$_$">>/>
-\define .mlink2(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to="$to$"/>
-\define .olink(_) <$macrocall $name=".link" _=<<.op "$_$">> to=<<.otitle "$_$">>/>
-\define .olink2(_,to) <$macrocall $name=".link" _=<<.op "$_$">> to=<<.otitle "$to$">>/>
-\define .vlink(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to=<<.vtitle "$_$">>/>
-\define .vlink2(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to="$to$"/>
-\define .wlink(to) <$macrocall $name=".link" _=<<.wid {{$to$!!caption}}>> to="$to$"/>
-\define .wlink2(_,to) <$macrocall $name=".link" _="$_$" to="$to$"/>
+\procedure .dlink(_,to) <$link to=<<to>>><$macrocall $name=".def" _=<<_>>/></$link>
 
-\define .key(_) <span class="doc-key">$_$</span>
-\define .combokey(_) <$macrocall $name=".if" cond="$_$" then=<<.key '$_$'>>/>
-\define .keycombo(1,2,3,4) <<.combokey "$1$">><<.if "$2$" +>><<.combokey "$2$">><<.if "$3$" +>><<.combokey "$3$">><<.if "$4$" +>><<.combokey "$4$">>
+\procedure .dlink-ex(_,to) <a href=<<to>> class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer"><$macrocall $name=".def" _=<<_>>/></a>
+\procedure .flink(to) <$macrocall $name=".link" _=`<<.field {{$(to)$!!caption}}>>` to=<<to>>/>
 
-\define .tab(_) <span class="doc-tab">{{$_$!!caption}}</span>
-\define .sidebar-tab(_) <<.tab "$:/core/ui/SideBar/$_$">>
-\define .more-tab(_) <<.tab "$:/core/ui/MoreSideBar/$_$">>
-\define .info-tab(_) <<.tab "$:/core/ui/TiddlerInfo/$_$">>
-\define .controlpanel-tab(_) <<.tab "$:/core/ui/ControlPanel/$_$">>
-\define .advancedsearch-tab(_) <<.tab "$:/core/ui/AdvancedSearch/$_$">>
-\define .toc-tab() <<.tab "TableOfContents">>
-\define .example-tab(_) <span class="doc-tab">$_$</span>
+\procedure .mlink(_) <$link to={{{ [.mtitle<_>] }}}><$macrocall $name=".var" _=<<_>>/> </$link>
+\procedure .mlink2(_,to) <$link to=<<to>>><$macrocall $name=".var" _=<<_>>/> </$link>
 
-\define .button(_) <span class="doc-button">{{$:/core/ui/Buttons/$_$!!caption}}</span>
+\procedure .olink(_) <$link to={{{ [.otitle<_>] }}}><$macrocall $name=".op" _=<<_>>/> </$link>
+\procedure .olink2(_,to) <$link to={{{ [.otitle<to>] }}}><$macrocall $name=".op" _=<<_>>/> </$link>
 
-\define .tip(_) <div class="doc-icon-block"><div class="doc-block-icon">{{$:/core/images/tip}}</div> $_$</div>
-\define .warning(_) <div class="doc-icon-block"><div class="doc-block-icon">{{$:/core/images/warning}}</div> $_$</div>
+\procedure .vlink(_) <$link to={{{ [.vtitle<_>] }}}><$macrocall $name=".var" _=<<_>>/> </$link>
+\procedure .vlink2(_,to) <$link to=<<to>>><$macrocall $name=".var" _=<<_>>/></$link>
 
-\define .state-prefix() $:/state/editions/tw5.com/
+\procedure .wlink(to) <$link to=<<to>> > <$macrocall $name=".wid" _={{{ [<to>get[caption]] }}}> </$link>
+\procedure .wlink2(_,to) <$link to=<<to>> ><<_>></$link>
 
-\define .lorem()
+\procedure .key(_) <span class="doc-key"><<_>></span>
+\procedure .keys(_) <span class="doc-key"><<_>></span>
+
+\procedure .tab(_) <span class="doc-tab"><$transclude $tiddler=<<_>> $field=caption ><<_>></$transclude></span>
+\procedure .sidebar-tab(_) <$macrocall $name=".tab" _=`$:/core/ui/SideBar/$(_)$`/>
+\procedure .more-tab(_) <$macrocall $name=".tab" _=`$:/core/ui/MoreSideBar/$(_)$`/>
+\procedure .info-tab(_) <$macrocall $name=".tab" _=`$:/core/ui/TiddlerInfo/$(_)$`/>
+\procedure .controlpanel-tab(_) <$macrocall $name=".tab" _=`$:/core/ui/ControlPanel/$(_)$`/>
+\procedure .advancedsearch-tab(_) <$macrocall $name=".tab" _=`$:/core/ui/AdvancedSearch/$(_)$`/>
+\procedure .toc-tab() <$macrocall $name=".tab" _="TableOfContents"/>
+\procedure .example-tab(_) <span class="doc-tab"><<_>></span>
+
+\procedure .doc-tabs()
+<$macrocall $name="tabs"
+    tabsList="[tag<currentTiddler>description[tab]]"
+    default={{{ [tag<currentTiddler>first[]] }}}
+    explicitState={{{ [<currentTiddler>addprefix[$:/state/tab/]] }}}
+    class={{{ [[doc-tabs]] [<currentTiddler>encodeuricomponent[]escapecss[]addprefix[doc-tabs-]] +[join[ ]] }}} />
+\end
+
+\procedure .doc-tab-link(text, target, tooltip:"", class:"")
+<!-- figure out where the addressed doc-tabs are -->
+<$tiddler tiddler={{{ [<currentTiddler>search:text[.doc-tabs]] :else[<currentTiddler>tags[]search:text[.doc-tabs]first[]] :else[<currentTiddler>] }}} >
+<$button class={{{ [[tc-btn-invisible tc-tiddlylink]] [<class>] +[join[ ]] }}}
+    set={{{ [<currentTiddler>addprefix[$:/state/tab/]] }}}
+    setTo=<<target>>
+    tooltip=<<tooltip>>>
+    <<text>>
+    <!-- if tiddler with tabs is open, scroll to tabs, otherwise open that tiddler (relevant from within tab subtiddlers) -->
+    <$list filter="[[$:/StoryList]contains<currentTiddler>]" variable="ignore" emptyMessage="<$action-navigate />">
+        <$action-sendmessage $message="tm-scroll" selector={{{ [<currentTiddler>encodeuricomponent[]addprefix[.doc-tabs-]] }}} />
+    </$list>
+    <$action-sendmessage $message="tm-scroll" selector={{{ [<currentTiddler>encodeuricomponent[]escapecss[]addprefix[.doc-tabs-]] }}} />
+</$button>
+</$tiddler>
+\end
+
+\procedure .widget-attr-link(text, target)
+<$macrocall $name=".doc-tab-link" 
+    text={{{ [[<code class="doc-attr">]] [<text>] [[</code>]] +[join[]] }}}
+    class="doc-tab-link"
+    target=<<target>>
+    tooltip={{{ [[Show more information about the ']] [<text>] [[' attribute]] +[join[]] }}} />
+\end
+
+\procedure .button(_) <span class="doc-button"><$transclude $tiddler=`$:/core/ui/Buttons/$(_)$` $field="caption" ><<_>></$transclude></span>
+
+\procedure .icon(_) <span class="doc-icon"><$transclude $tiddler=<<_>>/></span>
+
+\procedure .infoBox(text:"", title, icon:"$:/core/images/info-button", class, iconSize:"1.4rem")
+\function _f.tipClass() [[doc-icon-block]] [<class>!is[blank]then<class>] +[join[ ]]
+<div class=<<_f.tipClass>>>
+	<%if [<title>!is[blank]] %><div>''<<title>>''</div><%endif%>
+	<div class="doc-block-icon"><$transclude $tiddler=<<icon>> size=<<iconSize>>/></div>
+	<<text>>
+</div>
+\end
+
+\procedure .note(_:"", title:"Note", icon:"$:/core/images/info-button", class:"doc-note", iconSize:"22pt")
+<$macrocall $name=".infoBox" text=<<_>> title=<<title>> icon=<<icon>> class=<<class>> iconSize=<<iconSize>>/>
+\end
+
+\procedure .tip(_:"", title:"Tip" , icon:"$:/core/images/tip", class:"doc-tip", iconSize:"22pt")
+<$macrocall $name=".infoBox" text=<<_>> title=<<title>> icon=<<icon>> class=<<class>> iconSize=<<iconSize>>/>
+\end
+
+\procedure .warning(_:"", title:"Warning", icon:"$:/core/images/warning", class:"doc-warning", iconSize:"22pt")
+<$macrocall $name=".infoBox" text=<<_>> title=<<title>> icon=<<icon>> class=<<class>> iconSize=<<iconSize>>/>
+\end
+
+\procedure .state-prefix() $:/state/editions/tw5.com/
+
+\procedure .lorem()
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 \end
 
-\define .toc-lorem()
+\procedure .toc-lorem()
 This is an example tiddler. See [[Table-of-Contents Macros (Examples)]].
 
 <<.lorem>>
 \end
 
-\define .example(n,eg,egvar:NO-SUCH-VAR)
+\procedure .example(n,eg,egvar)
+<$let eg={{{ [<egvar>!is[blank]getvariable[]] :else[<eg>] }}}>
 <div class="doc-example">
-<$reveal default="$egvar$" type="match" text="NO-SUCH-VAR">
-	<$macrocall $name="copy-to-clipboard-above-right" src="""$eg$"""/>
-	<$codeblock code="""$eg$"""/>
-</$reveal>
-<$reveal default="$egvar$" type="nomatch" text="NO-SUCH-VAR">
-	<!-- allow an example to contain """ -->
-	<$macrocall $name="copy-to-clipboard-above-right" src=<<$egvar$>>/>
-	<$codeblock code=<<$egvar$>>/>
-</$reveal>
-<$list filter="[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix[$n$]]" variable=".state">
-<$reveal state=<<.state>> type="nomatch" text="show">
-	<dl>
-	<dd><$button set=<<.state>> setTo="show">Try it</$button></dd>
-	</dl>
-</$reveal>
-<$reveal state=<<.state>> type="match" text="show">
-	<dl>
-	<dd><$button set=<<.state>> setTo="">Hide</$button></dd>
-	</dl>
-	<blockquote class="doc-example-result">
-	<$reveal default="$egvar$" type="match" text="NO-SUCH-VAR">
-		$eg$
-	</$reveal>
-	<$reveal default="$egvar$" type="nomatch" text="NO-SUCH-VAR">
-		<<$egvar$>>
-	</$reveal>
-	</blockquote>
-</$reveal>
-</$list>
+	<$macrocall $name="copy-to-clipboard-above-right" src=<<eg>>/>
+	<$codeblock code=<<eg>>/>
+	<$list filter=`[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix[$(n)$]]` variable=".state">
+		<$reveal state=<<.state>> type="nomatch" text="show">
+			<dl>
+				<dd><$button set=<<.state>> setTo="show">Try it</$button></dd>
+			</dl>
+		</$reveal>
+		<$reveal state=<<.state>> type="match" text="show">
+			<dl>
+				<dd><$button set=<<.state>> setTo="">Hide</$button></dd>
+			</dl>
+			<blockquote class="doc-example-result">
+				<$transclude $variable="eg" $mode="block"/>
+			</blockquote>
+		</$reveal>
+	</$list>
+</div>
+</$let>
 \end
 
-<pre><$view field="text"/></pre>
+\procedure .bad-example(eg)
+<table class="doc-bad-example">
+	<tbody>
+		<tr class="evenRow">
+			<td>
+				<span class="tc-small-gap-right" style="font-size:1.5em;">&#9888;</span>
+				Warning:<br> Don't do it this way!
+			</td>
+			<td>
+				<$transclude $variable="eg" $mode="block"/>
+			</td>
+		</tr>
+	</tbody>
+</table>
+\end
+
+\procedure .link-badge(text,link,colour)
+<a href=<<link>> class="doc-link-badge" style.background-color=<<colour>> target="_blank" rel="noopener noreferrer">
+	<$text text=<<text>>/>
+</a>
+\end
+
+<!-- TODO use $:/palette colour settings -->
+\procedure .link-badge-added(link,colour:#ffe246)    <$macrocall $name=".link-badge" text="added"    link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-addendum(link,colour:#fcc84a) <$macrocall $name=".link-badge" text="addendum" link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-extended(link,colour:#f9a344) <$macrocall $name=".link-badge" text="extended" link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-fixed(link,colour:#ffa86d)    <$macrocall $name=".link-badge" text="fixed"    link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-here(link,colour:#d88e63)     <$macrocall $name=".link-badge" text="here"     link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-hide(link,colour:#9d959f)     <$macrocall $name=".link-badge" text="hide"     link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-improved(link,colour:#7593c7) <$macrocall $name=".link-badge" text="improved" link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-modified(link,colour:#7f99c9) <$macrocall $name=".link-badge" text="modified" link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-removed(link,colour:#a9aabc)  <$macrocall $name=".link-badge" text="removed"  link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-renamed(link,colour:#b4b995)  <$macrocall $name=".link-badge" text="renamed"  link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-updated(link,colour:#91ba66)  <$macrocall $name=".link-badge" text="updated"  link=<<link>> colour=<<colour>>/>
+
+\procedure .banner-credits(credit,url)
+<img src=<<url>> width="140" style="float:left;margin-right:0.5em;"/>
+<<credit>>
+<div style="clear:both;"/>
+\end
+
+\procedure .contributors(usernames)
+<ol class="doc-github-contributors">
+	<$list filter="[enlist<usernames>sort[]]" variable="username">
+		<li>
+			<a href={{{ [[https://github.com/]addsuffix<username>] }}} class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer">
+				<img src={{{ [[https://github.com/]addsuffix<username>addsuffix[.png?size=64]] }}} width="64" height="64"/>
+				<span class="doc-github-contributor-username">
+					@<$text text=<<username>>/>
+				</span>
+			</a>
+		</li>
+	</$list>
+</ol>
+\end
+
+\procedure .copy-code-to-clipboard(text)
+<div>
+<$transclude $variable="copy-to-clipboard-above-right" src=<<text>>/>
+<$codeblock code=<<text>>/>
+</div>
+\end .copy-code-to-clipboard
+

--- a/editions/dev/tiddlers/system/doc-styles.tid
+++ b/editions/dev/tiddlers/system/doc-styles.tid
@@ -1,21 +1,222 @@
+code-body: yes
 created: 20150117152612000
-modified: 20230325101137075
+modified: 20240223123123497
 tags: $:/tags/Stylesheet
 title: $:/editions/tw5.com/doc-styles
 type: text/vnd.tiddlywiki
 
-a.doc-from-version.tc-tiddlylink {
-    display: inline-block;
-    border-radius: 1em;
-	background: <<colour muted-foreground>>;
-	color: <<colour background>>;
-	fill: <<colour background>>;
-    padding: 0 0.4em;
-    font-size: 0.7em;
-    text-transform: uppercase;
+.doc-def {
+	font-style: normal;
+	font-weight: bold;
+}
+
+.doc-em {
+	font-style: italic;
+	font-variant: small-caps;
+	text-decoration: none;
+}
+
+.doc-strong {
+	color: <<colour alert-highlight>>;
+	font-style: normal;
+	font-weight: bold;
+}
+
+.doc-foreign {
+	font-style: italic;
+}
+
+.doc-place {
+	background-color: <<color background>>;
+	border: none;
+	color: <<color very-muted-foreground>>;
+	font-style: normal;
+	font-weight: bold;
+	padding: 0;
+}
+
+.doc-button,
+.doc-tab,
+.doc-tag,
+.doc-tiddler,
+.doc-field,
+.doc-value,
+.doc-operator,
+.doc-var,
+.doc-widget,
+.doc-attr,
+.doc-param {
+	background-color: <<color background>>;
+	border: none;
+	color: <<color very-muted-foreground>>;
+	font-weight: bold;
+	padding: 0;
+}
+
+a .doc-place,
+a .doc-button,
+a .doc-tab,
+a .doc-tag,
+a .doc-tiddler,
+a .doc-field,
+a .doc-value,
+a .doc-operator,
+a .doc-var,
+a .doc-widget,
+a .doc-attr {
+	color: <<color tiddler-link-foreground>>;
+}
+
+.doc-button svg {
+	height: 1em;
+}
+
+td svg {
+	height: 1em;
+}
+
+.doc-key {
+	color: <<color very-muted-foreground>>;
+	font-weight: bold;
+}
+
+.doc-clink code {
+	color: <<colour tiddler-link-foreground>>;
+}
+
+.doc-preamble {
+	border: 2px solid <<colour code-border>>;
+	color: <<colour very-muted-foreground>>;
+	margin-left: 0;
+	padding: 0.5em 0.7em;
+}
+
+.doc-note dt {
+	color: <<colour very-muted-foreground>>;
+}
+.doc-note dd {
+	border-left: 2px solid <<colour code-border>>;
+	padding-left: 0.6em;
+}
+
+.doc-example {
+	margin: 1em 0;
+	padding: 0.8em 0;
+}
+.doc-example:hover {
+	background-color: <<colour code-background>>;
+}
+.doc-example ul {
+	margin-bottom: 0;
+	padding-bottom: 0;
+	margin-top: 0.2em;
+}
+
+.doc-example input[type=search] { 
+	width: 95%;
+}
+.doc-example pre:first-child {
+	margin-top: 0;
+}
+.doc-example-result {
+	border-left: 5px solid <<colour blockquote-bar>>;
+	border-right: 5px solid <<colour blockquote-bar>>;
+	margin-left: 0;
+	margin-right: 0;
+	padding: 0 10px;
+}
+.doc-example-result ul {
+	margin-left: 0;
+	padding-left: 10px;
+}
+.doc-example-result ol {
+	margin-left: 0;
+	padding-left: 20px;
+}
+
+.doc-examples-hard-breaks .doc-example-result li {
+    white-space: pre-wrap;
+}
+
+.doc-bad-example code, .doc-bad-example pre, table.doc-bad-example {
+	background-color:#ffff80;
+}
+
+.doc-table th, .doc-table tr {
+	vertical-align: top;
+}
+.doc-table th a {
+	font-weight: bold;
+}
+
+tr.doc-table-subheading {
+	height: 2em;
+	vertical-align: middle;
+}
+
+.doc-table.before-tiddler-body {
+	margin-top: 2em;
+}
+
+.doc-icon svg {
+	width: 1em;
+	height: 1em;
+    vertical-align: middle;
+}
+
+.doc-icon-block {
+	border-left: 4px solid <<colour blockquote-bar>>;
+	margin: 15px 0 15px 3em;
+	padding-left: 0.6em;
+	position: relative;
+}
+
+.doc-block-icon {
+	position: absolute;
+	left: -3em;
+	top: 0.2em;
+}
+
+.doc-icon-block.doc-note {
+	border-left: 4px solid <<colour blockquote-bar>>;
+	background: <<colour blockquote-bar>>11;
+}
+
+.doc-icon-block.doc-tip {
+	border-left: 4px solid <<colour primary>>;
+	background: <<colour primary>>11;
+}
+
+.doc-icon-block.doc-warning {
+	border-left: 4px solid <<colour alert-highlight>>;
+	background: <<colour alert-highlight>>11;
+}
+
+.doc-block-icon .tc-image-tip {
+	fill: <<colour primary>>;
+}
+
+.doc-block-icon .tc-image-warning {
+	fill: <<colour alert-highlight>>;
+}
+
+a.doc-from-version {
+    background-color: <<colour muted-foreground>>;
+    color: <$wikify name="background" text="<<colour muted-foreground>>" mode="inline"><$transclude $variable="contrastcolour" target=<<background>> colourA="#000000" colourB="#ffffff" /></$wikify>;
+    padding: 3px;
+    border-radius: 4px;
     font-weight: bold;
-    line-height: 1.5;
-    vertical-align: text-bottom;
+    font-size: 0.75em;
+}
+
+a.doc-from-version.doc-from-version-new {
+    background-color: <<colour highlight-background>>;
+    color: <<colour highlight-foreground>>;
+}
+
+a.doc-from-version svg {
+    fill: currentColor;
+    vertical-align: sub;
 }
 
 a.doc-deprecated-version.tc-tiddlylink {
@@ -37,4 +238,92 @@ a.doc-deprecated-version.tc-tiddlylink {
 	width: 1em;
 	height: 1em;
     vertical-align: text-bottom;
+}
+
+.doc-link-badge {
+    text-decoration: none;
+    background-color: #7eba4c;
+    color: <<colour foreground>>;
+    padding: 3px;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 0.75em;
+}
+
+.doc-link-badge:hover {
+    text-decoration: underline;
+}
+
+.doc-tiddler-fields {
+	background-color: <<colour code-background>>;
+	border: 1px solid <<colour tiddler-border>>;
+	border-radius: 4px;
+    padding: 0 0.5em;
+}
+
+.doc-tiddler-fields h2 svg {
+	height: 1em;
+}
+
+.doc-tiddler-fields table, 
+.doc-tiddler-fields h2 {
+	margin: 0.5em 0;
+}
+
+.doc-tiddler-fields table {
+	background-color: <<colour tiddler-background>>;
+}
+
+@media screen {
+	.doc-tiddler-fields {
+		<<box-shadow "1px 1px 6px rgba(0, 0, 0, 0.6)">>
+	}
+}
+.doc-github-contributors {
+	list-style: none;
+	display: flex;
+	flex-wrap: wrap;
+}
+ol.doc-github-contributors li {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-direction:column;
+	width:82px;
+	height:82px;
+	margin:3px 3px 10px 3px;
+	text-decoration:none;
+}
+.doc-github-contributors a img { 
+	border-radius: 50%; 
+	background:#eee;
+}
+.doc-github-contributor-username {
+	display:inline-block;
+	font-size:12px;
+	font-weight:500;
+	text-align:center;
+	width:75px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.doc-op-comparison {
+	table-layout: fixed;
+	width: 80%;
+}
+.doc-op-comparison th .doc-operator {
+	background-color: unset;
+	color: #666;
+}
+.doc-tabs.tc-tab-buttons button {
+	font-size: 1rem;
+	padding: 0.5em;
+}
+.doc-tabs button .doc-attr {
+	background-color: unset;
+	color: #666;
+}
+.doc-tab-link .doc-attr {
+	color: unset;
 }

--- a/editions/dev/tiddlers/system/version-macros.tid
+++ b/editions/dev/tiddlers/system/version-macros.tid
@@ -1,14 +1,40 @@
 code-body: yes
 created: 20161008085627406
-modified: 20221007122259593
+modified: 20240229155633000
 tags: $:/tags/Macro
 title: $:/editions/tw5.com/version-macros
 type: text/vnd.tiddlywiki
 
-\define .from-version(version)
-<$link to={{{ [<__version__>addprefix[Release ]] }}} class="doc-from-version">{{$:/core/images/warning}} New in: <$text text=<<__version__>>/></$link>
+\whitespace trim
+
+\function tf.from-version-reference() 5.3.0
+
+\procedure .from-version-template(class, text)
+<$link to={{{ [<version>addprefix[Release ]] }}} class=<<class>> >
+	<span class="tc-tiny-gap-right">
+		{{$:/core/images/info-button}}
+	</span>
+	<<text>><<version>>
+</$link>
 \end
 
-\define .deprecated-since(version, superseded:"")
-<$link to="Deprecated - What does it mean" class="doc-deprecated-version tc-btn-invisible">{{$:/core/images/warning}} Deprecated from v<$text text=<<__version__>>/></$link> <%if [<__superseded__>else[]!match[]] %>(see <$link to=<<__superseded__>>><$text text=<<__superseded__>>/></$link>)<%endif%>
+\procedure .from-version(version)
+<%if [<version>compare:version:gteq<tf.from-version-reference>] %>
+	<<.from-version-template "doc-from-version doc-from-version-new" "New in v">>
+<%else%>
+	<<.from-version-template "doc-from-version" "Introduced in v">>
+<%endif%>
+\end
+
+\procedure .deprecated-since(version, superseded:"")
+<$link to="Deprecated - What does it mean" class="doc-deprecated-version tc-btn-invisible">
+	{{$:/core/images/warning}}
+	<span class="tc-tiny-gap">Deprecated from </span>
+	v<$text text=<<version>>/>
+</$link>
+<%if [<superseded>else[]!match[]] %>
+	<span class="tc-tiny-gap-left">
+		(see <$link class="tc-tiny-gap-left" to=<<superseded>>><$text text=<<superseded>>/></$link>)
+	</span>
+<%endif%>
 \end

--- a/editions/dev/tiddlywiki.info
+++ b/editions/dev/tiddlywiki.info
@@ -18,29 +18,37 @@
 		"tiddlywiki/readonly"
 	],
 	"languages": [
+		"ar-PS",
 		"ca-ES",
 		"cs-CZ",
 		"da-DK",
 		"de-AT",
 		"de-DE",
 		"el-GR",
+		"en-PH",
 		"en-US",
 		"es-ES",
 		"fa-IR",
 		"fr-FR",
+		"he-IL",
 		"hi-IN",
 		"ia-IA",
 		"it-IT",
 		"ja-JP",
 		"ko-KR",
+		"mk-MK",
 		"nl-NL",
 		"pa-IN",
+		"pl-PL",
 		"pt-PT",
+		"pt-BR",
 		"ru-RU",
 		"sk-SK",
+		"sl-SI",
 		"sv-SE",
 		"zh-Hans",
-		"zh-Hant"
+		"zh-Hant",
+		"zh-HK"
 	],
 	"build": {
 		"index": [


### PR DESCRIPTION
This PR updates the DEV edition with latest tw5.com macros and styles. So it looks better again. 

Current DEV edition. https://tiddlywiki.com/dev/#Adding%20Babel%20Polyfill%20to%20TiddlyWiki

![image](https://github.com/user-attachments/assets/bb784db1-c071-4b56-87df-ef730d149eaf)

**With this PR**

![image](https://github.com/user-attachments/assets/4f9faa1e-6266-4634-a761-d9cb6d55ade0)

------

There are 4 commits to see the details.

I did open all 147 tiddlers side by side **tiddlywiki.com/dev** and **localhost:8080**

They seem to work in the same way. So no info missing or hidden.
