### PR TITLE
Add another example to the wikify widget : use core svg to show an icon next to links

### DIFF
--- a/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
+++ b/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
@@ -1,0 +1,50 @@
+created: 20241206225533517
+description: Rendering parametrized svg for use in stylesheets
+modified: 20241206233219095
+tags: $:/tags/wiki-test-spec
+title: TestCases/WikifyWidget/RenderSVGURI
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+The core svg icons use a parameter widget, making their use in stylesheets impossible without wikify.
++
+title: Output
+
+https://tiddlywiki.com/
+
+<style>{{Stylesheet}}</style>
++
+title: Stylesheet
+
+\rules except dash
+\procedure mask(img)
+<$tiddler tiddler=<<img>> 
+><$wikify name="image" text={{!!text}} mode="inline" output="html"
+><$let
+        type={{!!type}}
+        uri={{!!_canonical_uri}}
+        external=`color:transparent;--mask:unset;--url:url($(uri)$)`
+        base64=`color:transparent;--mask:unset;--url:url(data:${[{!!type}]}$;base64,$(image)$)`
+        svg=`--mask:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg">${[<image>get[text]else<image>search-replace:g[#],[%23]search-replace:g[
+],[]]}$</svg>')`
+        ><$text text={{{ [<uri>!is[blank]then<external>]~[<type>!is[blank]!search[svg]then<base64>]~[<svg>] }}}
+/>;</$let></$wikify></$tiddler>
+\end
+
+<$text text=```
+.tc-tiddlylink-external{
+    &:after{
+        width:.7rem;
+        height:.7rem;
+        background:center/contain no-repeat var(--url);
+        background-color:currentColor;
+        display: inline-block;
+        -webkit-mask: center / contain no-repeat var(--mask);
+        mask: center / contain no-repeat var(--mask);
+        margin-inline:.5ch;
+        content:"";
+    }
+    ```/><<mask "$:/core/images/open-window">><$text text=```
+}
+```/>

--- a/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
+++ b/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
@@ -23,15 +23,11 @@ title: Stylesheet
 \procedure link-icon(protocol,img)
 <$tiddler tiddler=<<img>> >
   <$wikify name="image" text={{!!text}} mode="inline" output="html">
-    <$let
-      type={{!!type}}
-      uri={{!!_canonical_uri}}
-      external=`color:transparent;--mask:unset;--url:url($(uri)$)`
-      base64=`color:transparent;--mask:unset;--url:url(data:${[{!!type}]}$;base64,$(image)$)`
-      svg=`--mask:url('data:image/svg+xml;utf8,${[<image>get[text]]~[<image>search-replace:g[#],[%23]split[<svg]join[<svg xmlns="http://www.w3.org/2000/svg"]]}$')`
-    >
-      <$text text=`[href*="$(protocol)$"]{${ [<uri>!is[blank]then<external>]~[<type>!is[blank]!search[svg]then<base64>]~[<svg>] }$;}`/>
-    </$let>
+    <$text text=```
+      [href*="$(protocol)$"]{
+        --mask:url('data:image/svg+xml;utf8,${ [<image>get[text]]~[<image>search-replace:g[#],[%23]split[<svg]join[<svg xmlns="http://www.w3.org/2000/svg"]] }$');
+      }
+    ```/>
   </$wikify>
 </$tiddler>
 \end

--- a/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
+++ b/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
@@ -22,12 +22,12 @@ title: Stylesheet
 \rules except dash
 \procedure link-icon(protocol,img)
 <$tiddler tiddler=<<img>> >
-  <$wikify name="image" text={{!!text}} mode="inline" output="html">
-    <$text text=```
+  <$wikify name="svg" text={{!!text}} mode="inline" output="html">
+    <$text text=`
       [href*="$(protocol)$"]{
-        --mask:url('data:image/svg+xml;utf8,${ [<image>get[text]]~[<image>search-replace:g[#],[%23]split[<svg]join[<svg xmlns="http://www.w3.org/2000/svg"]] }$');
+        --mask:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg">$(svg)$</svg>');
       }
-    ```/>
+    `/>
   </$wikify>
 </$tiddler>
 \end

--- a/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
+++ b/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
@@ -1,6 +1,5 @@
 created: 20241206225533517
 description: Rendering parametrized svg for use in stylesheets
-modified: 20241206233219095
 tags: $:/tags/wiki-test-spec
 title: TestCases/WikifyWidget/RenderSVGURI
 type: text/vnd.tiddlywiki-multiple
@@ -11,28 +10,35 @@ The core svg icons use a parameter widget, making their use in stylesheets impos
 +
 title: Output
 
-https://tiddlywiki.com/
+* https://tiddlywiki.com/
+* [[TW5|http://tiddlywiki.com/]]
+* [[Mail me|mailto:me@where.net]]
+* [[Open file|file:///c:/users/me/index.html]]
 
 <style>{{Stylesheet}}</style>
 +
 title: Stylesheet
 
 \rules except dash
+\procedure link-icon(protocol,img)
 \procedure mask(img)
-<$tiddler tiddler=<<img>> 
-><$wikify name="image" text={{!!text}} mode="inline" output="html"
-><$let
-        type={{!!type}}
-        uri={{!!_canonical_uri}}
-        external=`color:transparent;--mask:unset;--url:url($(uri)$)`
-        base64=`color:transparent;--mask:unset;--url:url(data:${[{!!type}]}$;base64,$(image)$)`
-        svg=`--mask:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg">${[<image>get[text]else<image>search-replace:g[#],[%23]search-replace:g[
-],[]]}$</svg>')`
-        ><$text text={{{ [<uri>!is[blank]then<external>]~[<type>!is[blank]!search[svg]then<base64>]~[<svg>] }}}
-/>;</$let></$wikify></$tiddler>
-\end
+<$tiddler tiddler=<<img>> >
+  <$wikify name="image" text={{!!text}} mode="inline" output="html">
+    <$let
+      type={{!!type}}
+      uri={{!!_canonical_uri}}
+      external=`color:transparent;--mask:unset;--url:url($(uri)$)`
+      base64=`color:transparent;--mask:unset;--url:url(data:${[{!!type}]}$;base64,$(image)$)`
+      svg=`--mask:url('data:image/svg+xml;utf8,${[<image>get[text]]~[<image>search-replace:g[#],[%23]split[<svg]join[<svg xmlns="http://www.w3.org/2000/svg"]]}$')`
+    >
+      <$text text={{{ [<uri>!is[blank]then<external>]~[<type>!is[blank]!search[svg]then<base64>]~[<svg>] }}}/>;
+    </$let>
+  </$wikify>
+</$tiddler>
+\end mask
+:where([href*="<<protocol>>"]){<$transclude $variable="mask" img=<<img>> />}
+\end protocol-icon
 
-<$text text=```
 .tc-tiddlylink-external{
     &:after{
         width:.7rem;
@@ -45,6 +51,8 @@ title: Stylesheet
         margin-inline:.5ch;
         content:"";
     }
-    ```/><<mask "$:/core/images/open-window">><$text text=```
+    <<link-icon "http:" "$:/core/images/open-window">>
+    <<link-icon "https:" "$:/core/images/locked-padlock">>
+    <<link-icon "mailto:" "$:/core/images/mail">>
+    <<link-icon "file:" "$:/core/images/file">>
 }
-```/>

--- a/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
+++ b/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
@@ -21,7 +21,6 @@ title: Stylesheet
 
 \rules except dash
 \procedure link-icon(protocol,img)
-\procedure mask(img)
 <$tiddler tiddler=<<img>> >
   <$wikify name="image" text={{!!text}} mode="inline" output="html">
     <$let
@@ -31,28 +30,23 @@ title: Stylesheet
       base64=`color:transparent;--mask:unset;--url:url(data:${[{!!type}]}$;base64,$(image)$)`
       svg=`--mask:url('data:image/svg+xml;utf8,${[<image>get[text]]~[<image>search-replace:g[#],[%23]split[<svg]join[<svg xmlns="http://www.w3.org/2000/svg"]]}$')`
     >
-      <$text text={{{ [<uri>!is[blank]then<external>]~[<type>!is[blank]!search[svg]then<base64>]~[<svg>] }}}/>;
+      <$text text=`[href*="$(protocol)$"]{${ [<uri>!is[blank]then<external>]~[<type>!is[blank]!search[svg]then<base64>]~[<svg>] }$;}`/>
     </$let>
   </$wikify>
 </$tiddler>
-\end mask
-:where([href*="<<protocol>>"]){<$transclude $variable="mask" img=<<img>> />}
-\end protocol-icon
+\end
 
-.tc-tiddlylink-external{
-    &:after{
-        width:.7rem;
-        height:.7rem;
-        background:center/contain no-repeat var(--url);
-        background-color:currentColor;
-        display: inline-block;
-        -webkit-mask: center / contain no-repeat var(--mask);
-        mask: center / contain no-repeat var(--mask);
-        margin-inline:.5ch;
-        content:"";
-    }
-    <<link-icon "http:" "$:/core/images/open-window">>
-    <<link-icon "https:" "$:/core/images/locked-padlock">>
-    <<link-icon "mailto:" "$:/core/images/mail">>
-    <<link-icon "file:" "$:/core/images/file">>
+.tc-tiddlylink-external:after{
+  width:.7rem;
+  aspect-ratio:1;
+  background:currentColor;
+  display: inline-block;
+  mask: center / contain no-repeat var(--mask);
+  margin-inline:.5ch;
+  content:"";
 }
+
+<<link-icon "http:" "$:/core/images/open-window">>
+<<link-icon "https:" "$:/core/images/locked-padlock">>
+<<link-icon "mailto:" "$:/core/images/mail">>
+<<link-icon "file:" "$:/core/images/file">>

--- a/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
+++ b/editions/tw5.com/tiddlers/TestCases_WikifyWidget_RenderSVGURI.tid
@@ -1,5 +1,5 @@
 created: 20241206225533517
-description: Rendering parametrized svg for use in stylesheets
+description: Rendering parameterised SVG for use in stylesheets
 tags: $:/tags/wiki-test-spec
 title: TestCases/WikifyWidget/RenderSVGURI
 type: text/vnd.tiddlywiki-multiple

--- a/editions/tw5.com/tiddlers/widgets/WikifyWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/WikifyWidget.tid
@@ -1,6 +1,6 @@
 caption: wikify
 created: 20160321144949700
-modified: 20241202014354100
+modified: 20241206233352509
 tags: Widgets
 title: WikifyWidget
 type: text/vnd.tiddlywiki
@@ -44,3 +44,7 @@ The available output types are:
 !! Exporting rendered html
 
 <<testcase "TestCases/WikifyWidget/RenderHTML">>
+
+!! Rendering parametrized svg for use in stylesheets
+
+<<testcase "TestCases/WikifyWidget/RenderSVGURI">>

--- a/editions/tw5.com/tiddlers/widgets/WikifyWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/WikifyWidget.tid
@@ -7,11 +7,11 @@ type: text/vnd.tiddlywiki
 
 ! Introduction
 
-The <<.wid wikify>> widget parses and renders a string of text and assigns the result to a specified [[variable|Variables]]. The new value of the variable is available to the content within the wikify widget.
+The <<.wid wikify>> widget parses and renders a string of text and assigns the result to a specified [[variable|Variables]]. The new value of the variable is available to the content within the <<.wid wikify>> widget.
 
 ! Content and Attributes
 
-The content of the `<$wikify>` widget is the scope for the value assigned to the variable.
+The content of the <<.wid wikify>> widget is the scope for the value assigned to the variable.
 
 |!Attribute |!Description |
 |name |The name of the variable to assign |
@@ -45,6 +45,6 @@ The available output types are:
 
 <<testcase "TestCases/WikifyWidget/RenderHTML">>
 
-!! Rendering parametrized svg for use in stylesheets
+!! Rendering parameterised SVG for use in stylesheets
 
 <<testcase "TestCases/WikifyWidget/RenderSVGURI">>


### PR DESCRIPTION
Adding icons to links is something rather popular among users, so showing a way to do it without the need for any plugin seems fitting as an example for the doc.  

![Screenshot_20241207-030217~2.png](https://github.com/user-attachments/assets/eec9b4b1-8c4c-4a0d-9fed-387eb00abbd3)



Aside: I tried to apply the stylesheet by using $:/tags/Stylesheet but it didn't work. Is this intentional ?

<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>