### PR TITLE
Add missing <<tag>> macro parameter in the ViewTemplate for system tags

### DIFF
--- a/editions/tw5.com/tiddlers/system/systemtag-template.tid
+++ b/editions/tw5.com/tiddlers/system/systemtag-template.tid
@@ -4,7 +4,7 @@ modified: 20240710163659672
 tags: $:/tags/ViewTemplate
 title: $:/editions/tw5.com/systemtag-template
 
-<$list filter='[all[current]prefix[SystemTag: ]]'>
+<%if [all[current]prefix[SystemTag: ]] %>
 <$let thisTag={{{ [all[current]removeprefix[SystemTag: ]] }}} >
 
 <$list filter='[all[tiddlers+shadows]tag<thisTag>limit[1]]' emptyMessage='(No tiddlers are currently tagged with <<tag $(thisTag)$ >>)'>
@@ -24,4 +24,4 @@ The following tiddlers are tagged with <<tag $(thisTag)$ >>
 </div>
 </$list>
 </$let>
-</$list>
+<%endif%>

--- a/editions/tw5.com/tiddlers/system/systemtag-template.tid
+++ b/editions/tw5.com/tiddlers/system/systemtag-template.tid
@@ -7,7 +7,7 @@ title: $:/editions/tw5.com/systemtag-template
 <$list filter='[all[current]prefix[SystemTag: ]]'>
 <$let thisTag={{{ [all[current]removeprefix[SystemTag: ]] }}} >
 
-<$list filter='[all[tiddlers+shadows]tag<thisTag>limit[1]]' emptyMessage='(No tiddlers are currently tagged with <<tag>> )'>
+<$list filter='[all[tiddlers+shadows]tag<thisTag>limit[1]]' emptyMessage='(No tiddlers are currently tagged with <<tag $(thisTag)$ >>)'>
 
 The following tiddlers are tagged with <<tag $(thisTag)$ >>
 


### PR DESCRIPTION
The `<<tag>>` macro was used without parameter in the _emptyMessage_ of the main `$list` widget, thus producing the same result as `<<tag $(currentTiddler)$>>`.

Seized the opportunity to upgrade the `$list`-based conditional construct to an `%if` shortcut syntax.