### PR TITLE
Fix switching language should not make the lang attribute empty

### DIFF
--- a/core/modules/startup/startup.js
+++ b/core/modules/startup/startup.js
@@ -88,7 +88,7 @@ exports.startup = function() {
 			if($tw.browser) {
 				var pluginTiddler = $tw.wiki.getTiddler(plugins[0]);
 				if(pluginTiddler) {
-					document.documentElement.setAttribute("lang",pluginTiddler.getFieldString("title").replace("$:/languages/",""));
+					document.documentElement.setAttribute("lang",pluginTiddler.getFieldString("name"));
 					document.documentElement.setAttribute("dir",pluginTiddler.getFieldString("text-direction") || "auto");
 				} else {
 					document.documentElement.removeAttribute("dir");

--- a/core/modules/startup/startup.js
+++ b/core/modules/startup/startup.js
@@ -88,6 +88,7 @@ exports.startup = function() {
 			if($tw.browser) {
 				var pluginTiddler = $tw.wiki.getTiddler(plugins[0]);
 				if(pluginTiddler) {
+					document.documentElement.setAttribute("lang",pluginTiddler.getFieldString("title").replace("$:/languages/",""));
 					document.documentElement.setAttribute("dir",pluginTiddler.getFieldString("text-direction") || "auto");
 				} else {
 					document.documentElement.removeAttribute("dir");


### PR DESCRIPTION
Make the `lang` attribute of `html` element be set correctly when switching languages.