### PR TITLE
MWS: Require bags in recipe form

### DIFF
--- a/plugins/tiddlywiki/multiwikiserver/templates/get-index.tid
+++ b/plugins/tiddlywiki/multiwikiserver/templates/get-index.tid
@@ -114,7 +114,7 @@ title: $:/plugins/tiddlywiki/multiwikiserver/templates/get-index
 			<label class="mws-form-field-description">
 				Bags in recipe (space separated)
 			</label>
-			<input name="bag_names" type="text"/>
+			<input name="bag_names" type="text" required/>
 		</div>
 	</div>
 	<div class="mws-form-buttons">


### PR DESCRIPTION
Not having bags in a recipe currently creates a bad url, adding required to form prevents users from making a mistake when building a recipe.