### PR TITLE
Mark IE related things as deprecated

### DIFF
--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Internet Explorer.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Internet Explorer.tid
@@ -1,7 +1,7 @@
 caption: Internet Explorer
 created: 20140811172058274
 modified: 20211114031651879
-tags: GettingStarted
+tags: GettingStarted $:/deprecated
 title: GettingStarted - Internet Explorer
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/howtos/Windows HTA Hack.tid
+++ b/editions/tw5.com/tiddlers/howtos/Windows HTA Hack.tid
@@ -5,10 +5,11 @@ delivery: DIY
 description: Manual method to let Internet Explorer save changes directly
 method: save
 modified: 20200507110355115
-tags: Saving Windows
+tags: Saving Windows $:/deprecated
 title: Windows HTA Hack
 type: text/vnd.tiddlywiki
 
+<<.deprecated-since "5.3.6">>
 Under Windows it is possible to convert TiddlyWiki into a true local application by renaming the HTML file to have the extension `*.hta`. The ''fsosaver'' module can then use the ~ActiveX ~FileSystemObject to save changes.
 
 Note that one disadvantage of this approach is that the TiddlyWiki file is saved in UTF-16 format, making it up to twice as large as it would be with the usual UTF-8 encoding. However, opening and saving the file via another saving method will re-encode the file to UTF-8.

--- a/editions/tw5.com/tiddlers/saving/Saving with TiddlyIE.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving with TiddlyIE.tid
@@ -6,10 +6,11 @@ delivery: Browser Extension
 description: Browser extension for Internet Explorer
 method: save
 modified: 20200507201415232
-tags: [[Internet Explorer]] Saving
+tags: [[Internet Explorer]] Saving $:/deprecated
 title: Saving with TiddlyIE
 type: text/vnd.tiddlywiki
 
+<<.deprecated-since "5.3.6">>
 # Install the TiddlyIE add-on from:
 #* https://github.com/davidjade/TiddlyIE/releases
 # Restart Internet Explorer. IE will prompt you to enable the TiddlyIE add-on.

--- a/editions/tw5.com/tiddlers/saving/Saving.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving.tid
@@ -1,6 +1,6 @@
 created: 20140912140651119
 modified: 20220812144516626
-saving-browser: Firefox Chrome Edge [[Internet Explorer]] Safari Opera [[Standalone App]]
+saving-browser: Firefox Chrome Edge Safari Opera [[Standalone App]]
 saving-os: Windows Mac Linux Android iOS
 tags: [[Working with TiddlyWiki]]
 title: Saving
@@ -8,7 +8,7 @@ type: text/vnd.tiddlywiki
 
 
 \define alltagsfilter()  
-<$vars tag1="tag[" tag2="]" lb="[" rb="tag[Saving]sort[delivery]]">
+<$vars tag1="tag[" tag2="]" lb="[" rb="tag[Saving]sort[delivery]!tag[$:/deprecated]]">
 <$set filter="[list<stateTiddler>addprefix<tag1>addsuffix<tag2>]+[join[]addprefix<lb>addsuffix<rb>]" name="alltags" select=0>
 <$text text=<<alltags>>/>
 </$set>


### PR DESCRIPTION
See #5192.

Although Tiddlywiki hasn't dropped support for Internet Explorer at present, we had better mark IE as deprecated in the documention to discourage using Tiddlywiki with IE.