### PR TITLE
Make draft title translatable

### DIFF
--- a/core/language/en-GB/DraftAuthor.tid
+++ b/core/language/en-GB/DraftAuthor.tid
@@ -1,0 +1,3 @@
+title: $:/language/DraftAuthor 
+
+ by $1$

--- a/core/language/en-GB/DraftNumber.tid
+++ b/core/language/en-GB/DraftNumber.tid
@@ -1,0 +1,3 @@
+title: $:/language/DraftNumber
+
+$1$ 

--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -15,6 +15,8 @@ ConfirmAction: Do you wish to proceed?
 Count: count
 DefaultNewTiddlerTitle: New Tiddler
 Diffs/CountMessage: <<diff-count>> differences
+
+DraftTitle: Draft $1$of '$2$'$3$
 DropMessage: Drop now (or use the 'Escape' key to cancel)
 Encryption/Cancel: Cancel
 Encryption/ConfirmClearPassword: Do you wish to clear the password? This will remove the encryption applied when saving this wiki

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1701,9 +1701,12 @@ exports.generateDraftTitle = function(title) {
 	var c = 0,
 		draftTitle,
 		username = this.getTiddlerText("$:/status/UserName"),
-		attribution = username ? " by " + username : "";
+		draftBaseTitle = $tw.language.getRawString("DraftTitle"),
+		draftAuthor = $tw.language.getRawString("DraftAuthor"),
+		draftNumber = $tw.language.getRawString("DraftNumber"),
+		attribution = username ? draftAuthor.replace("$1$",username) : "";
 	do {
-		draftTitle = "Draft " + (c ? (c + 1) + " " : "") + "of '" + title + "'" + attribution;
+		draftTitle = draftBaseTitle.replace("$1$", (c ? draftNumber.replace(draftNumber, "$1$") : "")).replace("$2$", title).replace("$3$",attribution);
 		c++;
 	} while(this.tiddlerExists(draftTitle));
 	return draftTitle;

--- a/languages/zh-Hans/Misc.multids
+++ b/languages/zh-Hans/Misc.multids
@@ -15,6 +15,9 @@ ConfirmAction: 是否要继续？
 Count: 计数
 DefaultNewTiddlerTitle: 新条目
 Diffs/CountMessage: <<diff-count>> 个差异
+DraftAuthor: $1$撰写的
+DraftNumber: $1$
+DraftTitle: $3$“$2$”的草稿$1$
 DropMessage: 现在放下（或按 ESC 键取消）
 Encryption/Cancel: 取消
 Encryption/ConfirmClearPassword: 您要清除密码吗？当保存此维基时，这将删除已套用的加密


### PR DESCRIPTION
Attempt to make the generated draft title localized. The `zh-Hans` translations are added as demo.

![图片](https://github.com/user-attachments/assets/7070c4d1-24f5-4c5c-a2f1-53d9ff4d391a)

Added three translatable strings:

* `DraftTitle`: Template for generating the draft title. `$1$` for the draft number, `$2$` for tiddler title, `$3$` for attribution.
* `DraftAuthor`: Template for generating the attribution.
* `DraftNumber`: Template for generating the draft number. Because of whitespace, this has to be customizable.