### PR TITLE
Set explicit state to a field to improve hackability

### DIFF
--- a/core/ui/AdvancedSearch.tid
+++ b/core/ui/AdvancedSearch.tid
@@ -1,8 +1,9 @@
 title: $:/AdvancedSearch
 icon: $:/core/images/advanced-search-button
 color: #bbb
+explicitState: $:/state/tab--1498284803
 
 \whitespace trim
 <div class="tc-advanced-search">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/AdvancedSearch]!has[draft.of]]" default="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<currentTab>>/>""" explicitState="$:/state/tab--1498284803"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/AdvancedSearch]!has[draft.of]]" default="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<currentTab>>/>""" explicitState={{!!explicitState}}/>
 </div>

--- a/core/ui/AdvancedSearch/Standard.tid
+++ b/core/ui/AdvancedSearch/Standard.tid
@@ -1,6 +1,7 @@
 title: $:/core/ui/AdvancedSearch/Standard
 tags: $:/tags/AdvancedSearch
 caption: {{$:/language/Search/Standard/Caption}}
+explicitState: $:/state/tab/search-results/advancedsearch
 
 \procedure lingo-base() $:/language/Search/
 \procedure set-next-input-tab() <$transclude $variable="change-input-tab" stateTitle="$:/state/tab--1498284803" tag="$:/tags/AdvancedSearch" beforeafter="after" defaultState="$:/core/ui/AdvancedSearch/System" actions="<$action-setfield $tiddler='$:/state/advancedsearch/currentTab' text=<<nextTab>>/>"/>
@@ -69,7 +70,7 @@ caption: {{$:/language/Search/Standard/Caption}}
 	tabsList="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]]"
 	default={{$:/config/SearchResults/Default}}
 	actions="<$action-setfield $tiddler='$:/state/advancedsearch/standard/currentTab' text=<<currentTab>>/>"
-	explicitState="$:/state/tab/search-results/advancedsearch" />
+	explicitState={{!!explicitState}} />
 </$list>
 </$vars>
 </$list>

--- a/core/ui/ControlPanel.tid
+++ b/core/ui/ControlPanel.tid
@@ -1,8 +1,9 @@
 title: $:/ControlPanel
 icon: $:/core/images/options-button
 color: #bbb
+explicitState: $:/state/tab-1749438307
 
 \whitespace trim
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel]!has[draft.of]]" default="$:/core/ui/ControlPanel/Info" explicitState="$:/state/tab-1749438307"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel]!has[draft.of]]" default="$:/core/ui/ControlPanel/Info" explicitState={{!!explicitState}}/>
 </div>

--- a/core/ui/ControlPanel/Advanced.tid
+++ b/core/ui/ControlPanel/Advanced.tid
@@ -1,10 +1,11 @@
 title: $:/core/ui/ControlPanel/Advanced
 tags: $:/tags/ControlPanel/Info
 caption: {{$:/language/ControlPanel/Advanced/Caption}}
+explicitState: $:/state/tab--959111941
 
 \whitespace trim
 {{$:/language/ControlPanel/Advanced/Hint}}
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Advanced]!has[draft.of]]" default="$:/core/ui/ControlPanel/TiddlerFields" explicitState="$:/state/tab--959111941"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Advanced]!has[draft.of]]" default="$:/core/ui/ControlPanel/TiddlerFields" explicitState={{!!explicitState}}/>
 </div>

--- a/core/ui/ControlPanel/Appearance.tid
+++ b/core/ui/ControlPanel/Appearance.tid
@@ -1,10 +1,11 @@
 title: $:/core/ui/ControlPanel/Appearance
 tags: $:/tags/ControlPanel
 caption: {{$:/language/ControlPanel/Appearance/Caption}}
+explicitState: $:/state/tab--1963855381
 
 \whitespace trim
 {{$:/language/ControlPanel/Appearance/Hint}}
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Appearance]!has[draft.of]]" default="$:/core/ui/ControlPanel/Theme" explicitState="$:/state/tab--1963855381"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Appearance]!has[draft.of]]" default="$:/core/ui/ControlPanel/Theme" explicitState={{!!explicitState}}/>
 </div>

--- a/core/ui/ControlPanel/Info.tid
+++ b/core/ui/ControlPanel/Info.tid
@@ -1,10 +1,11 @@
 title: $:/core/ui/ControlPanel/Info
 tags: $:/tags/ControlPanel
 caption: {{$:/language/ControlPanel/Info/Caption}}
+explicitState: $:/state/tab--2112689675
 
 \whitespace trim
 {{$:/language/ControlPanel/Info/Hint}}
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Info]!has[draft.of]]" default="$:/core/ui/ControlPanel/Basics" explicitState="$:/state/tab--2112689675"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Info]!has[draft.of]]" default="$:/core/ui/ControlPanel/Basics" explicitState={{!!explicitState}}/>
 </div>

--- a/core/ui/ControlPanel/Plugins.tid
+++ b/core/ui/ControlPanel/Plugins.tid
@@ -1,6 +1,7 @@
 title: $:/core/ui/ControlPanel/Plugins
 tags: $:/tags/ControlPanel
 caption: {{$:/language/ControlPanel/Plugins/Caption}}
+explicitState: $:/state/tab--86143343
 
 \define lingo-base() $:/language/ControlPanel/Plugins/
 
@@ -17,4 +18,4 @@ caption: {{$:/language/ControlPanel/Plugins/Caption}}
 
 <<lingo Installed/Hint>>
 
-<$macrocall $name="tabs" tabsList="[all[tiddlers+shadows]tag[$:/tags/ControlPanel/Plugins]!has[draft.of]]" default="$:/core/ui/ControlPanel/Plugins/Installed/Plugins" explicitState="$:/state/tab--86143343"/>
+<$macrocall $name="tabs" tabsList="[all[tiddlers+shadows]tag[$:/tags/ControlPanel/Plugins]!has[draft.of]]" default="$:/core/ui/ControlPanel/Plugins/Installed/Plugins" explicitState={{!!explicitState}}/>

--- a/core/ui/ControlPanel/Saving.tid
+++ b/core/ui/ControlPanel/Saving.tid
@@ -1,10 +1,11 @@
 title: $:/core/ui/ControlPanel/Saving
 tags: $:/tags/ControlPanel
 caption: {{$:/language/ControlPanel/Saving/Caption}}
+explicitState: $:/state/tab-2065006209
 
 \whitespace trim
 {{$:/language/ControlPanel/Saving/Hint}}
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Saving]!has[draft.of]]" default="$:/core/ui/ControlPanel/Saving/General" explicitState="$:/state/tab-2065006209"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Saving]!has[draft.of]]" default="$:/core/ui/ControlPanel/Saving/General" explicitState={{!!explicitState}}/>
 </div>

--- a/core/ui/ControlPanel/Settings.tid
+++ b/core/ui/ControlPanel/Settings.tid
@@ -1,7 +1,8 @@
 title: $:/core/ui/ControlPanel/Settings
 tags: $:/tags/ControlPanel
 caption: {{$:/language/ControlPanel/Settings/Caption}}
+explicitState: $:/state/tab--697582678
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/SettingsTab]!has[draft.of]]" default="$:/core/ui/ControlPanel/Settings/TiddlyWiki" explicitState="$:/state/tab--697582678"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/SettingsTab]!has[draft.of]]" default="$:/core/ui/ControlPanel/Settings/TiddlyWiki" explicitState={{!!explicitState}}/>
 </div>

--- a/core/ui/ControlPanel/Toolbars.tid
+++ b/core/ui/ControlPanel/Toolbars.tid
@@ -1,10 +1,11 @@
 title: $:/core/ui/ControlPanel/Toolbars
 tags: $:/tags/ControlPanel/Appearance
 caption: {{$:/language/ControlPanel/Toolbars/Caption}}
+explicitState: $:/state/tabs/controlpanel/toolbars-1345989671
 
 \whitespace trim
 {{$:/language/ControlPanel/Toolbars/Hint}}
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Toolbars]!has[draft.of]]" default="$:/core/ui/ControlPanel/Toolbars/ViewToolbar" class="tc-vertical" explicitState="$:/state/tabs/controlpanel/toolbars-1345989671"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Toolbars]!has[draft.of]]" default="$:/core/ui/ControlPanel/Toolbars/ViewToolbar" class="tc-vertical" explicitState={{!!explicitState}}/>
 </div>

--- a/core/ui/MoreSideBar/Plugins.tid
+++ b/core/ui/MoreSideBar/Plugins.tid
@@ -1,8 +1,8 @@
 title: $:/core/ui/MoreSideBar/Plugins
 tags: $:/tags/MoreSideBar
 caption: {{$:/language/ControlPanel/Plugins/Caption}}
-
+explicitState: $:/state/tab-1163638994
 
 {{$:/language/ControlPanel/Plugins/Installed/Hint}}
 
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/MoreSideBar/Plugins]!has[draft.of]]" default="$:/core/ui/MoreSideBar/Plugins/Plugins" explicitState="$:/state/tab-1163638994"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/MoreSideBar/Plugins]!has[draft.of]]" default="$:/core/ui/MoreSideBar/Plugins/Plugins" explicitState={{!!explicitState}}/>

--- a/core/ui/SearchResults.tid
+++ b/core/ui/SearchResults.tid
@@ -1,4 +1,5 @@
 title: $:/core/ui/SearchResults
+explicitState: $:/state/tab/search-results/sidebar
 
 <div class="tc-search-results">
 
@@ -10,7 +11,7 @@ title: $:/core/ui/SearchResults
 	tabsList="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]]"
 	default={{$:/config/SearchResults/Default}}
 	actions="<$action-setfield $tiddler='$:/state/search/currentTab' text=<<currentTab>>/>"
-	explicitState="$:/state/tab/search-results/sidebar"/>
+	explicitState={{!!explicitState}}/>
 
 </$list>
 

--- a/core/ui/SideBar/More.tid
+++ b/core/ui/SideBar/More.tid
@@ -1,8 +1,9 @@
 title: $:/core/ui/SideBar/More
 tags: $:/tags/SideBar
 caption: {{$:/language/SideBar/More/Caption}}
+explicitState: $:/state/tab/moresidebar-1850697562
 
 \whitespace trim
 <div class={{{ [{$:/config/ui/SideBar/More/horizontal}match[yes]then[tc-sidebar-tabs]else[tc-more-sidebar]] }}}>
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/MoreSideBar]!has[draft.of]]" default={{$:/config/DefaultMoreSidebarTab}} state="$:/state/tab/moresidebar" class={{{ [{$:/config/ui/SideBar/More/horizontal}match[yes]then[tc-sidebar-tabs-more]else[tc-vertical tc-sidebar-tabs-more]] }}} explicitState="$:/state/tab/moresidebar-1850697562"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/MoreSideBar]!has[draft.of]]" default={{$:/config/DefaultMoreSidebarTab}} state="$:/state/tab/moresidebar" class={{{ [{$:/config/ui/SideBar/More/horizontal}match[yes]then[tc-sidebar-tabs-more]else[tc-vertical tc-sidebar-tabs-more]] }}} explicitState={{!!explicitState}}/>
 </div>

--- a/core/ui/SideBarSegments/tabs.tid
+++ b/core/ui/SideBarSegments/tabs.tid
@@ -1,8 +1,9 @@
 title: $:/core/ui/SideBarSegments/tabs
 tags: $:/tags/SideBarSegment
+explicitState: $:/state/tab/sidebar--595412856
 
 <div class="tc-sidebar-lists tc-sidebar-tabs" role="region" aria-label={{$:/language/SideBar/Caption}}>
 
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" class="tc-sidebar-tabs-main" explicitState="$:/state/tab/sidebar--595412856"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" class="tc-sidebar-tabs-main" explicitState={{!!explicitState}}/>
 
 </div>


### PR DESCRIPTION
Tabs in the control panels use specific states. For instance, the control panel's state is "$:/state/tab-1749438307", and for Appearance, it's "$:/state/tab--1963855381". With this information, it's possible to create a button to open the control panel in a particular setup. 

Currently, these states are seemingly random, therefore it would be helpful to set these value to a field in order to be able to dynamically locate and manage the control panel states more effectively.