### PR TITLE
Cleans up cruft from edit widget

### DIFF
--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -56,7 +56,7 @@ EditWidget.prototype.execute = function() {
 EditWidget.prototype.getEditorType = function() {
 	// Get the content type of the thing we're editing
 	var type;
-	if(editField === "text") {
+	if(this.editField === "text") {
 		var tiddler = this.wiki.getTiddler(this.editTitle);
 		if(tiddler) {
 			type = tiddler.fields.type;

--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -43,15 +43,6 @@ EditWidget.prototype.execute = function() {
 	// Get our parameters
 	this.editTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
 	this.editField = this.getAttribute("field","text");
-	this.editIndex = this.getAttribute("index");
-	this.editClass = this.getAttribute("class");
-	this.editPlaceholder = this.getAttribute("placeholder");
-	this.editTabIndex = this.getAttribute("tabindex");
-	this.editFocus = this.getAttribute("focus","");
-	this.editCancelPopups = this.getAttribute("cancelPopups","");
-	this.editInputActions = this.getAttribute("inputActions");
-	this.editRefreshTitle = this.getAttribute("refreshTitle");
-	this.editAutoComplete = this.getAttribute("autocomplete");
 	// Choose the appropriate edit widget
 	this.editorType = this.getEditorType();
 	// Make the child widgets
@@ -65,7 +56,7 @@ EditWidget.prototype.execute = function() {
 EditWidget.prototype.getEditorType = function() {
 	// Get the content type of the thing we're editing
 	var type;
-	if(this.editField === "text") {
+	if(this.getAttribute("field","text") === "text") {
 		var tiddler = this.wiki.getTiddler(this.editTitle);
 		if(tiddler) {
 			type = tiddler.fields.type;
@@ -89,8 +80,8 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 EditWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	// Refresh if an attribute has changed, or the type associated with the target tiddler has changed
-	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.tabindex || changedAttributes.cancelPopups || changedAttributes.inputActions || changedAttributes.refreshTitle || changedAttributes.autocomplete || (this.getEditorType() !== this.editorType)) {
+	// Refresh if the editor type has changed
+	if(changedAttributes.tiddler || changedAttributes.field || (this.getEditorType() !== this.editorType)) {
 		this.refreshSelf();
 		return true;
 	} else {

--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -56,7 +56,7 @@ EditWidget.prototype.execute = function() {
 EditWidget.prototype.getEditorType = function() {
 	// Get the content type of the thing we're editing
 	var type;
-	if(this.getAttribute("field","text") === "text") {
+	if(editField === "text") {
 		var tiddler = this.wiki.getTiddler(this.editTitle);
 		if(tiddler) {
 			type = tiddler.fields.type;


### PR DESCRIPTION
In #4740 we refactored the $edit widget to pass along the parseTreeNode attributes to the child widget that it creates. However, a lot of unneeded code to do with reading attributes and refresh was left behind.

The only refresh handling the $edit widget needs is to detect when the editor type has changed. All other refresh handling is the responsiblity of the child widget.