### PR TITLE
Fix: Don't set dirty flag when shadow tiddler changes

### DIFF
--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -46,8 +46,10 @@ function SaverHandler(options) {
 			// Filter the changes so that we only count changes to tiddlers that we care about
 			var filteredChanges = self.filterFn.call(self.wiki,function(iterator) {
 				$tw.utils.each(changes,function(change,title) {
-					var tiddler = self.wiki.getTiddler(title);
-					iterator(tiddler,title);
+					if(change.normal) {
+						var tiddler = self.wiki.getTiddler(title);
+						iterator(tiddler,title);
+					}
 				});
 			});
 			// Adjust the number of changes

--- a/core/modules/startup/plugins.js
+++ b/core/modules/startup/plugins.js
@@ -75,7 +75,7 @@ exports.startup = function() {
 				$tw.wiki.unpackPluginTiddlers();
 				// Queue change events for the changed shadow tiddlers
 				$tw.utils.each(Object.keys(changedShadowTiddlers),function(title) {
-					$tw.wiki.enqueueTiddlerEvent(title,changedShadowTiddlers[title]);
+					$tw.wiki.enqueueTiddlerEvent(title,changedShadowTiddlers[title], true);
 				});
 			}
 		}

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -141,12 +141,15 @@ This method should be called after the changes it describes have been made to th
 	title: Title of tiddler
 	isDeleted: defaults to false (meaning the tiddler has been created or modified),
 		true if the tiddler has been deleted
+	isShadow: defaults to false (meaning the change applies to the normal tiddler),
+		true if the tiddler being changed is a shadow tiddler
 */
-exports.enqueueTiddlerEvent = function(title,isDeleted) {
+exports.enqueueTiddlerEvent = function(title,isDeleted,isShadow) {
 	// Record the touch in the list of changed tiddlers
 	this.changedTiddlers = this.changedTiddlers || Object.create(null);
 	this.changedTiddlers[title] = this.changedTiddlers[title] || Object.create(null);
 	this.changedTiddlers[title][isDeleted ? "deleted" : "modified"] = true;
+	this.changedTiddlers[title][isShadow ? "shadow" : "normal"] = true;
 	// Increment the change count
 	this.changeCount = this.changeCount || Object.create(null);
 	if($tw.utils.hop(this.changeCount,title)) {


### PR DESCRIPTION
Adds `shadow` and `normal` flags to each entry in `changedTiddlers`, indicating whether the corresponding version of the tiddler has changed. Makes the saver handler ignore any changes that aren't flagged `normal`.

Fixes #8902.

---

I've tried this instead of changing `$:/config/SaverFilter` to exclude shadows, and it seems to be working properly for me. I haven't tested it extensively, however.