### PR TITLE
Indexes operator: Return original order

### DIFF
--- a/core/modules/filters/indexes.js
+++ b/core/modules/filters/indexes.js
@@ -23,7 +23,6 @@ exports.indexes = function(source,operator,options) {
 			$tw.utils.pushTop(results,Object.keys(data));
 		}
 	});
-	results.sort();
 	return results;
 };
 


### PR DESCRIPTION
Current behavior of indexes operator is that it returns a sorted list of indexes of data tiddler. There is no way to return the original order of indexes.

This modification returns the indexes in the original order defined in the data tiddler. Sorting can be achieved by sort operator downstream in the filter run.