### PR TITLE
Make search outline backward compatible

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -76,14 +76,20 @@ input[type="search"] {
 }
 
 button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible {
-	outline: 2px solid <<colour primary>>;
-	outline-offset: -2px;
+	/* TODO: Use border at present for backward compatibility */
+	/* outline: 2px solid <<colour primary>>;
+	outline-offset: -2px; */
+	outline: none;
+	border: 2px solid <<colour primary>>;
 	border-radius: 0.25em;
 }
 
 button:-moz-focusring, input:-moz-focusring, textarea:-moz-focusring, select:-moz-focusring {
-	outline: 2px solid <<colour primary>>;
-	outline-offset: -2px;
+	/* TODO: Use border at present for backward compatibility */
+	/* outline: 2px solid <<colour primary>>;
+	outline-offset: -2px; */
+	outline: none;
+	border: 2px solid <<colour primary>>;
 	border-radius: 0.25em;
 }
 


### PR DESCRIPTION
It turned out that the implementation in #8552 does not display correctly in some older browsers (like Safari on iOS 15). This PR uses `border` instead to make `border-radius` supported. 

On chrome 90, Before:

![图片](https://github.com/user-attachments/assets/5639e571-8908-41c5-a59c-d7bd9ac8a4f5)

After:

![图片](https://github.com/user-attachments/assets/5a0313f3-e4da-4413-a6e9-ca1375277f47)

Closes #7142.