### PR TITLE
Markdown plugin remove function wrapper

### DIFF
--- a/plugins/tiddlywiki/markdown/editor-operations/make-markdown-link.js
+++ b/plugins/tiddlywiki/markdown/editor-operations/make-markdown-link.js
@@ -6,7 +6,6 @@ module-type: texteditoroperation
 Text editor operation to make a markdown link
 
 \*/
-(function(){
 
 /*jslint node: true, browser: true */
 /*global $tw: false */
@@ -39,5 +38,3 @@ exports["make-markdown-link"] = function(event,operation) {
 	operation.newSelStart = operation.selStart + operation.replacement.length;
 	operation.newSelEnd = operation.newSelStart;
 };
-
-})();

--- a/plugins/tiddlywiki/markdown/markdown-it-katex.js
+++ b/plugins/tiddlywiki/markdown/markdown-it-katex.js
@@ -5,7 +5,6 @@ module-type: library
 
 Based on markdown-it-katex v2.0.0 by @waylonflinn https://github.com/waylonflinn/markdown-it-katex | MIT License
 \*/
-(function(){
 /* Process inline math */
 /*
 Like markdown-it-simplemath, this is a stripped down, simplified version of:
@@ -167,4 +166,3 @@ module.exports = function math_plugin(md, options) {
     md.inline.ruler.after('escape', 'math_inline', math_inline);
     md.inline.ruler.after('escape', 'math_inline_block', math_inline_block);
 };
-})();

--- a/plugins/tiddlywiki/markdown/markdown-it-tiddlywiki.js
+++ b/plugins/tiddlywiki/markdown/markdown-it-tiddlywiki.js
@@ -6,7 +6,6 @@ module-type: library
 Wraps up the markdown-it parser for use as a Parser in TiddlyWiki
 
 \*/
-(function(){
 
 /*jslint node: true, browser: true */
 /*global $tw: false */
@@ -535,5 +534,3 @@ module.exports = function tiddlyWikiPlugin(markdown,options) {
 	md.core.ruler.disable('text_join');
 	md.core.ruler.push('wikify',wikify);
 };
-
-})();

--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -6,7 +6,6 @@ module-type: parser
 Wraps up the markdown-it parser for use as a Parser in TiddlyWiki
 
 \*/
-(function(){
 
 /*jslint node: true, browser: true */
 /*global $tw: false */
@@ -261,4 +260,3 @@ function MarkdownParser(type,text,options) {
 
 exports["text/markdown"] = MarkdownParser;
 exports["text/x-markdown"] = MarkdownParser;
-})();


### PR DESCRIPTION
Removes function wrapper in markdown plugin.

Related to #7596 .