### PR TITLE
Provides access to event properties as JSON in relevant widgets

### DIFF
--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -311,48 +311,6 @@ exports.getLocationPath = function() {
 	return window.location.toString().split("#")[0];
 };
 
-exports.copyEventProperties = function(event) {
-	var seen = new Set();
-  
-	function isDOMElement(value) {
-	  return value instanceof Node || value instanceof Window;
-	}
-  
-	function safeCopy(obj) {
-		//skip ciruclar references
-		if(seen.has(obj)) {
-			return "[Circular reference]";
-		}
-		//skip functions
-		if(typeof obj !== "object" || obj === null) {
-			return obj;
-		}
-		//skip DOM elements
-		if(isDOMElement(obj)) {
-			return "[DOM Element]";
-		}
-		//copy each element of the array
-		if(Array.isArray(obj)) {
-			return obj.map(safeCopy);
-		}
-
-		seen.add(obj);
-		var copy = {}, key;
-		for(key in obj) {
-			try{
-				copy[key] = safeCopy(obj[key]);
-			} catch(e) {
-				copy[key] = "[Unserializable]";
-			}
-		}
-		return copy;
-	}
-
-	var result = safeCopy(event);
-	seen.clear();
-	return result;
-};
-
 /*
 Collect DOM variables
 */
@@ -395,7 +353,7 @@ exports.collectDOMVariables = function(selectedNode,domNode,event) {
 		variables["tv-widgetnode-height"] = domNode.offsetHeight.toString();
 	}
 	if(event) {
-		var eventProperties = $tw.utils.copyEventProperties(event);
+		var eventProperties = $tw.utils.copyObjectPropertiesSafe(event);
 		variables["event-properties"] = JSON.stringify(eventProperties,null,2);
 
 		if(("clientX" in event) && ("clientY" in event)) {

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -292,6 +292,48 @@ exports.extendDeepCopy = function(object,extendedProperties) {
 	return result;
 };
 
+exports.copyObjectPropertiesSafe = function(object) {
+	var seen = new Set();
+  
+	function isDOMElement(value) {
+	  return value instanceof Node || value instanceof Window;
+	}
+  
+	function safeCopy(obj) {
+		//skip ciruclar references
+		if(seen.has(obj)) {
+			return "[Circular reference]";
+		}
+		//skip functions
+		if(typeof obj !== "object" || obj === null) {
+			return obj;
+		}
+		//skip DOM elements
+		if(isDOMElement(obj)) {
+			return "[DOM Element]";
+		}
+		//copy each element of the array
+		if(Array.isArray(obj)) {
+			return obj.map(safeCopy);
+		}
+
+		seen.add(obj);
+		var copy = {}, key;
+		for(key in obj) {
+			try{
+				copy[key] = safeCopy(obj[key]);
+			} catch(e) {
+				copy[key] = "[Unserializable]";
+			}
+		}
+		return copy;
+	}
+
+	var result = safeCopy(object);
+	seen.clear();
+	return result;
+};
+
 exports.deepFreeze = function deepFreeze(object) {
 	var property, key;
 	if(object) {

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -23,49 +23,6 @@ Inherit from the base widget class
 */
 EventWidget.prototype = new Widget();
 
-
-function getEventPropertiesJSON(event) {
-	var seen = new Set();
-  
-	function isDOMElement(value) {
-	  return value instanceof Node || value instanceof Window;
-	}
-  
-	function safeCopy(obj) {
-		//skip ciruclar references
-		if(seen.has(obj)) {
-			return "[Circular reference]";
-		}
-		//skip functions
-		if(typeof obj !== "object" || obj === null) {
-			return obj;
-		}
-		//skip DOM elements
-		if(isDOMElement(obj)) {
-			return "[DOM Element]";
-		}
-		//copy each element of the array
-		if(Array.isArray(obj)) {
-			return obj.map(safeCopy);
-		}
-
-		seen.add(obj);
-		var copy = {}, key;
-		for(key in obj) {
-			try{
-				copy[key] = safeCopy(obj[key]);
-			} catch(e) {
-				copy[key] = "[Unserializable]";
-			}
-		}
-		return copy;
-	}
-
-	var result = safeCopy(event);
-	seen.clear();
-	return result;
-};
-
 /*
 Render this widget into the DOM
 */


### PR DESCRIPTION
This PR adds support to access enumerable event properties as JSON in actions invoked by `$eventcatcher` and `$draggable` widgets. This is helpful when access to an event property is needed in actions but not specifically made available as a variable.

* The new utility method `$tw.utils.copyEventProperties` returns a JSON object representing the event properties while avoiding circular references, functions and DOM elements.
*  `$tw.utils.collectDOMVariables` now calls `copyEventProperties`, this required nested if statements and the diff looks large but nothing else has changed.
* The changes to `$eventcatcher` are cursory and only change where in the flow we call `$tw.utils.collectDOMVariables`
* Profiling shows that copying the event properties takes between 0.001 and 0.1ms depending on the event tested

To Do:
- [x] **Test performance impact**
- [x] **Test the following events** in Firefox and Chrome, testing for any failures or errors in serializing the event object:
  - [x] click
  - [x] dblclick
  - [x] contextmenu
  - [x] pointerdown
  - [x] pointermove
  - [x] mousedown
  - [x] mouseup
  - [x] mouseout
  - [x] mouseover
  - [x] wheel
  - [x] keydown
  - [x] keyup
  - [x] focusin
  - [x] focusout
  - [x] drag
  - [x] dragstart
  - [x] dragend
  - [x] dragenter
  - [x] dragleave
  - [x] dragover
  - [x] custom events
- [ ] **Update documentation**