### PR TITLE
Fix incorrect downloaded file extension

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -232,10 +232,10 @@ $tw.utils.error = function(err) {
 				var link = dm("a"),
 					text = JSON.stringify(tiddlers);
 				if(Blob !== undefined) {
-					var blob = new Blob([text], {type: "text/html"});
+					var blob = new Blob([text], {type: "application/json"});
 					link.setAttribute("href", URL.createObjectURL(blob));
 				} else {
-					link.setAttribute("href","data:text/html," + encodeURIComponent(text));
+					link.setAttribute("href","data:application/json," + encodeURIComponent(text));
 				}
 				link.setAttribute("download","emergency-tiddlers-" + (new Date()) + ".json");
 				document.body.appendChild(link);

--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -185,7 +185,7 @@ SaverHandler.prototype.saveWiki = function(options) {
 	// Call the highest priority saver that supports this method
 	for(var t=this.savers.length-1; t>=0; t--) {
 		var saver = this.savers[t];
-		if(saver.info.capabilities.indexOf(method) !== -1 && saver.save(text,method,callback,{variables: {filename: variables.filename}})) {
+		if(saver.info.capabilities.indexOf(method) !== -1 && saver.save(text,method,callback,{variables: {filename: variables.filename, type: variables.type}})) {
 			this.logger.log("Saving wiki with method",method,"through saver",saver.info.name);
 			return true;
 		}

--- a/core/modules/savers/download.js
+++ b/core/modules/savers/download.js
@@ -22,6 +22,7 @@ DownloadSaver.prototype.save = function(text,method,callback,options) {
 	options = options || {};
 	// Get the current filename
 	var filename = options.variables.filename;
+	var type = options.variables.type;
 	if(!filename) {
 		var p = document.location.pathname.lastIndexOf("/");
 		if(p !== -1) {
@@ -32,13 +33,16 @@ DownloadSaver.prototype.save = function(text,method,callback,options) {
 	if(!filename) {
 		filename = "tiddlywiki.html";
 	}
+	if(!type) {
+		type = "text/html";
+	}
 	// Set up the link
 	var link = document.createElement("a");
 	if(Blob !== undefined) {
-		var blob = new Blob([text], {type: "text/html"});
+		var blob = new Blob([text], {type: type});
 		link.setAttribute("href", URL.createObjectURL(blob));
 	} else {
-		link.setAttribute("href","data:text/html," + encodeURIComponent(text));
+		link.setAttribute("href","data:" + type + "," + encodeURIComponent(text));
 	}
 	link.setAttribute("download",filename);
 	document.body.appendChild(link);

--- a/core/templates/exporters/CsvFile.tid
+++ b/core/templates/exporters/CsvFile.tid
@@ -2,5 +2,6 @@ title: $:/core/templates/exporters/CsvFile
 tags: $:/tags/Exporter
 description: {{$:/language/Exporters/CsvFile}}
 extension: .csv
+file-type: text/csv
 
 <$macrocall $name="csvtiddlers" filter=<<exportFilter>> format="quoted-comma-sep" $output="text/raw"/>

--- a/core/templates/exporters/JsonFile.tid
+++ b/core/templates/exporters/JsonFile.tid
@@ -2,5 +2,6 @@ title: $:/core/templates/exporters/JsonFile
 tags: $:/tags/Exporter
 description: {{$:/language/Exporters/JsonFile}}
 extension: .json
+file-type: application/json
 
 <$macrocall $name="jsontiddlers" filter=<<exportFilter>> $output="text/raw"/>

--- a/core/templates/exporters/TidFile.tid
+++ b/core/templates/exporters/TidFile.tid
@@ -2,6 +2,7 @@ title: $:/core/templates/exporters/TidFile
 tags: $:/tags/Exporter
 description: {{$:/language/Exporters/TidFile}}
 extension: .tid
+file-type: text/vnd.tiddlywiki
 condition: [<count>compare:lte[1]]
 
 \define renderContent()

--- a/core/wiki/macros/export.tid
+++ b/core/wiki/macros/export.tid
@@ -39,6 +39,7 @@ tags: $:/tags/Macro
 							$param=<<currentTiddler>>
 							exportFilter=<<exportFilter>>
 							filename={{{ [<baseFilename>addsuffix{!!extension}] }}}
+							type={{!!file-type}}
 						/>
 						<$action-deletetiddler $tiddler=<<qualify "$:/state/popup/export">>/>
 						<$transclude field="description"/>

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-download-file.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-download-file.tid
@@ -15,6 +15,7 @@ The following variable names have special behaviour:
 
 |!Name |!Description |
 |filename |Filename for the downloaded file (note that this is a hint to the browser, and the actual filename used may be different) |
+|type |<<.from-version "5.3.7">> Content type for the downloaded file |
 
 The download file message is usually generated with the ButtonWidget.
 


### PR DESCRIPTION
This should fix #8881 , also fixes the wrong content type of the "download tiddlers as json" button in the RSOE screen.