### PR TITLE
Addresses #7836: Noisy $fill widgets

### DIFF
--- a/core/modules/widgets/fill.js
+++ b/core/modules/widgets/fill.js
@@ -24,6 +24,10 @@ Inherit from the base widget class
 */
 FillWidget.prototype = new Widget();
 
+FillWidget.prototype.execute = function() {
+	// Do nothing. Make no child widgets. $Fill widgets should be invisible when naturally encountered. Instead, their parseTreeNodes are made available to $slot widgets that want it.
+};
+
 exports.fill = FillWidget;
 
 })();

--- a/editions/test/tiddlers/tests/data/transclude/CustomWidget-RawAndSlotted.tid
+++ b/editions/test/tiddlers/tests/data/transclude/CustomWidget-RawAndSlotted.tid
@@ -1,0 +1,34 @@
+title: Transclude/CustomWidget/RawAndSlotted
+description: Custom widget can mix ts-raw and custom slots
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+\widget $my.widget()
+\whitespace trim
+<$slot $name="ts-header">
+	Default Header
+</$slot>
+-
+<$slot $name="ts-raw"/>
+\end
+<$my.widget>
+	First Body
+</$my.widget>
+
+
+<$my.widget>
+	<$fill $name="ts-header">
+		Custom Header
+	</$fill>
+	<$fill $name="ts-never">
+		<$log RawAndSlotted="Transclude/CustomWidget/RawAndSlotted is actually failing. $fill slots are executing silently when they weren't invoked." />
+	</$fill>
+	Second Body
+</$my.widget>
++
+title: ExpectedResult
+
+<p>Default Header-First Body</p><p>Custom Header-Second Body</p>


### PR DESCRIPTION
$fill widgets will get ignored when encountered by ts-raw slots

There. If anyone complains about the loss of the old behavior, I will eat my T-shirt and post it to YouTube.