### PR TITLE
fix contains operator RSOD if created field is accessed

### DIFF
--- a/core/modules/tiddler.js
+++ b/core/modules/tiddler.js
@@ -40,10 +40,10 @@ exports.getFieldString = function(field,defaultValue) {
 };
 
 /*
-Get the value of a field as a list
+Get the value of a field as an array / list
 */
 exports.getFieldList = function(field) {
-	var value = this.fields[field];
+	var value = this.getFieldString(field,null);
 	// Check for a missing field
 	if(value === undefined || value === null) {
 		return [];


### PR DESCRIPTION
This PR fixes #8918

- #8918

@Jermolene -- This mechanism is slightly slower than the existing code, because it converts the array to a string and then back to an array. But it will also avoid future problems if we would ever change `$tw.Tiddler.fieldModules` again. 