### PR TITLE
fix page toolbar more dropdown inconsistent whitespace

### DIFF
--- a/core/ui/PageControls/advanced-search.tid
+++ b/core/ui/PageControls/advanced-search.tid
@@ -5,6 +5,7 @@ description: {{$:/language/Buttons/AdvancedSearch/Hint}}
 
 \whitespace trim
 \procedure advanced-search-button(class)
+\whitespace trim
 <$button to="$:/AdvancedSearch" tooltip={{$:/language/Buttons/AdvancedSearch/Hint}} aria-label={{$:/language/Buttons/AdvancedSearch/Caption}} class=`$(tv-config-toolbar-class)$ $(class)$`>
 <%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/advanced-search-button}}

--- a/core/ui/PageControls/controlpanel.tid
+++ b/core/ui/PageControls/controlpanel.tid
@@ -5,6 +5,7 @@ description: {{$:/language/Buttons/ControlPanel/Hint}}
 
 \whitespace trim
 \procedure control-panel-button(class)
+\whitespace trim
 <$button to="$:/ControlPanel" tooltip={{$:/language/Buttons/ControlPanel/Hint}} aria-label={{$:/language/Buttons/ControlPanel/Caption}} class=`$(tv-config-toolbar-class)$ $(class)$`>
 <%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/options-button}}

--- a/core/ui/PageControls/manager.tid
+++ b/core/ui/PageControls/manager.tid
@@ -5,6 +5,7 @@ description: {{$:/language/Buttons/Manager/Hint}}
 
 \whitespace trim
 \procedure manager-button(class)
+\whitespace trim
 <$button to="$:/Manager" tooltip={{$:/language/Buttons/Manager/Hint}} aria-label={{$:/language/Buttons/Manager/Caption}} class=`$(tv-config-toolbar-class)$ $(class)$`>
 <%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/list}}

--- a/core/ui/PageControls/tag-button.tid
+++ b/core/ui/PageControls/tag-button.tid
@@ -5,6 +5,7 @@ description: {{$:/language/Buttons/TagManager/Hint}}
 
 \whitespace trim
 \procedure control-panel-button(class)
+\whitespace trim
 <$button to="$:/TagManager" tooltip={{$:/language/Buttons/TagManager/Hint}} aria-label={{$:/language/Buttons/TagManager/Caption}} class=`$(tv-config-toolbar-class)$ $(class)$`>
 <%if [<tv-config-toolbar-icons>match[yes]] %>
 {{$:/core/images/tag-button}}


### PR DESCRIPTION
This PR fixes #8921

- #8921

Add `\trim whitespace` inside procedures if used with list `$:/tags/PageControls`

![image](https://github.com/user-attachments/assets/62b77fca-88de-4ccc-9b41-1d6615d07379)
