### PR TITLE
[DOCS] Add HTML Tag info to reveal-widget

### DIFF
--- a/editions/tw5.com/tiddlers/HTML Tags.tid
+++ b/editions/tw5.com/tiddlers/HTML Tags.tid
@@ -1,0 +1,11 @@
+created: 20250211092107689
+modified: 20250211092307574
+tags: Definitions
+title: HTML Tags
+type: text/vnd.tiddlywiki
+
+<<<
+In HTML, a tag is used for creating an element.
+
+The name of an HTML element is the name that appears at the beginning of the element's start tag and at the end of the element's end tag (if the element has an end tag). For example, the p in the `<p>` start tag and `</p>` end tag is the name of the HTML paragraph element. Note that an element name in an end tag is preceded by a slash character: `</p>`, and that for void elements, the end tag is neither required nor allowed.
+<<< https://developer.mozilla.org/en-US/docs/Glossary/Tag

--- a/editions/tw5.com/tiddlers/widgets/RevealWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RevealWidget.tid
@@ -1,7 +1,7 @@
 caption: reveal
 created: 20131024141900000
 jeremy: tiddlywiki
-modified: 20240721175716320
+modified: 20250211091937860
 tags: Widgets
 title: RevealWidget
 type: text/vnd.tiddlywiki
@@ -28,7 +28,7 @@ The content of the `<$reveal>` widget is displayed according to the rules given 
 |stateTitle |A title containing the state, ''without'' TextReference. Gets preferred over the <<.attr state>> attribute |
 |stateField |A ''field name'' which is used to look for the state, if the attribute <<.attr stateTitle>> is present |
 |stateIndex |An ''index'' which is used to look for the state, if the attribute <<.attr stateTitle>> is present |
-|tag |Overrides the default HTML element tag (`<div>` in block mode or `<span>` in inline mode) |
+|tag |Overrides the default [[HTML Tags]] (`<div>` in block mode or `<span>` in inline mode) |
 |type |The type of matching performed: ''match'', ''nomatch'', ''popup'', ''lt'', ''gt'', ''lteq'' or ''gteq'' |
 |text |The text to match when the type is ''match'', ''nomatch'', ''lt'', ''gt'', ''lteq'' or ''gteq'' |
 |class |An optional CSS class name to be assigned to the HTML element<br/>&raquo; Set to `tc-popup-keep` to make a popup "sticky", so it won't close when you click inside of it|


### PR DESCRIPTION
This PR adds HTML Tag info to reveal-widget and also creates a new "Definitions" tiddler

Triggered by a problem at Talk. See: https://talk.tiddlywiki.org/t/reveal-not-work-as-expected/11909/3 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small> 