### PR TITLE
Fix: Ensure now macro format is always a string to prevent Uncaught Type Error

### DIFF
--- a/core/modules/macros/now.js
+++ b/core/modules/macros/now.js
@@ -26,7 +26,7 @@ exports.params = [
 Run the macro
 */
 exports.run = function(format) {
-	return $tw.utils.formatDateString(new Date(),format || "0hh:0mm, DDth MMM YYYY");
+	return String($tw.utils.formatDateString(new Date(),format || "0hh:0mm, DDth MMM YYYY"));
 };
 
 })();

--- a/core/modules/macros/now.js
+++ b/core/modules/macros/now.js
@@ -26,7 +26,10 @@ exports.params = [
 Run the macro
 */
 exports.run = function(format) {
-	return String($tw.utils.formatDateString(new Date(),format || "0hh:0mm, DDth MMM YYYY"));
+    let formatString = format || "0hh:0mm, DDth MMM YYYY";
+    formatString = String(formatString);
+
+    return $tw.utils.formatDateString(new Date(), formatString);
 };
 
 })();


### PR DESCRIPTION
Fix https://github.com/TiddlyWiki/TiddlyWiki5/issues/8946