### PR TITLE
[DOCS] Crosslink, then / else Operators, :then / :else Fiter Run Prefixes

### DIFF
--- a/editions/tw5.com/tiddlers/filters/else Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/else Operator.tid
@@ -1,6 +1,6 @@
 caption: else
 created: 20190802113024942
-modified: 20250214134515047
+modified: 20190802113919945
 op-input: a [[selection of titles|Title Selection]]
 op-output: the original input titles unless empty, in which case return a list with the single entry  <<.place E>>
 op-parameter: a string

--- a/editions/tw5.com/tiddlers/filters/else Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/else Operator.tid
@@ -1,6 +1,6 @@
 caption: else
 created: 20190802113024942
-modified: 20190802113919945
+modified: 20250214134515047
 op-input: a [[selection of titles|Title Selection]]
 op-output: the original input titles unless empty, in which case return a list with the single entry  <<.place E>>
 op-parameter: a string
@@ -13,3 +13,7 @@ type: text/vnd.tiddlywiki
 <<.from-version "5.1.20">> See [[Conditional Operators]] for an overview.
 
 <<.operator-examples "else">>
+
+Also see: [[then Operator]] | [[Then Filter Run Prefix]] and [[Else Filter Run Prefix]]
+
+

--- a/editions/tw5.com/tiddlers/filters/syntax/Else Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Else Filter Run Prefix.tid
@@ -1,6 +1,6 @@
 created: 20230318142408662
 from-version: 5.1.23
-modified: 20230322140756821
+modified: 20250214134609217
 rp-input: all titles from previous filter runs
 rp-output: if the filter output so far is an empty list then the output titles of the run are [[dominantly appended|Dominant Append]] to the filter's output.<br>if the filter output so far is not an empty list then the run is ignored.
 rp-purpose: the filter run is only evaluated if the filter output of all previous runs so far is an empty list
@@ -16,3 +16,5 @@ type: text/vnd.tiddlywiki
 """/>
 
 This prefix has a [[Shortcut Filter Run Prefix]] symbol `~run`
+
+Also see: [[Then Filter Run Prefix]] | [[then Operator]] and [[else Operator]]

--- a/editions/tw5.com/tiddlers/filters/syntax/Else Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Else Filter Run Prefix.tid
@@ -1,6 +1,6 @@
 created: 20230318142408662
 from-version: 5.1.23
-modified: 20250214134609217
+modified: 20230322140756821
 rp-input: all titles from previous filter runs
 rp-output: if the filter output so far is an empty list then the output titles of the run are [[dominantly appended|Dominant Append]] to the filter's output.<br>if the filter output so far is not an empty list then the run is ignored.
 rp-purpose: the filter run is only evaluated if the filter output of all previous runs so far is an empty list

--- a/editions/tw5.com/tiddlers/filters/syntax/then Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/then Filter Run Prefix.tid
@@ -1,6 +1,6 @@
 created: 20210618133745003
 from-version: 5.3.0
-modified: 20230710074225410
+modified: 20250214134634286
 rp-input: <<.olink all>> tiddler titles
 rp-output: the output of this filter run replaces the output of previous runs unless it is an empty list (see below)
 rp-purpose: replace any input to this filter run with its output, only evaluating the run when there is any input
@@ -35,4 +35,6 @@ The major difference between the <<.op then>> operator and a <<.op :then>> prefi
 
 
 [[Then Filter Run Prefix (Examples)]]
+
+Also see: [[Else Filter Run Prefix]] | [[then Operator]] and [[else Operator]]
 

--- a/editions/tw5.com/tiddlers/filters/syntax/then Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/then Filter Run Prefix.tid
@@ -1,6 +1,6 @@
 created: 20210618133745003
 from-version: 5.3.0
-modified: 20250214134634286
+modified: 20230710074225410
 rp-input: <<.olink all>> tiddler titles
 rp-output: the output of this filter run replaces the output of previous runs unless it is an empty list (see below)
 rp-purpose: replace any input to this filter run with its output, only evaluating the run when there is any input

--- a/editions/tw5.com/tiddlers/filters/then Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/then Operator.tid
@@ -1,6 +1,6 @@
 caption: then
 created: 20190802112756430
-modified: 20250214134501357
+modified: 20230501174334627
 op-input: a [[selection of titles|Title Selection]]
 op-output: the input titles with each one replaced by the string <<.place T>>
 op-parameter: a string

--- a/editions/tw5.com/tiddlers/filters/then Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/then Operator.tid
@@ -1,6 +1,6 @@
 caption: then
 created: 20190802112756430
-modified: 20230501174334627
+modified: 20250214134501357
 op-input: a [[selection of titles|Title Selection]]
 op-output: the input titles with each one replaced by the string <<.place T>>
 op-parameter: a string
@@ -15,3 +15,5 @@ type: text/vnd.tiddlywiki
 <<.tip "The [[Then Filter Run Prefix]] has a similar purpose to the <<.op then>> operator. See its documentation for a comparison of usage.">>
 
 <<.operator-examples "then">>
+
+Also see: [[else Operator]] | [[Then Filter Run Prefix]] and [[Else Filter Run Prefix]]


### PR DESCRIPTION
This PR crosslinks - then / else Operators and :then / :else Fiter Run Prefixes

This PR only fixes the OP part of # 8933. @yaisong's input needs a second PR 