### PR TITLE
Add system-ui to default font family

### DIFF
--- a/themes/tiddlywiki/vanilla/settings.multids
+++ b/themes/tiddlywiki/vanilla/settings.multids
@@ -1,6 +1,6 @@
 title: $:/themes/tiddlywiki/vanilla/settings/
 
-fontfamily: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"
+fontfamily: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", system-ui, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"
 codefontfamily: ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace
 backgroundimageattachment: fixed
 backgroundimagesize: auto

--- a/themes/tiddlywiki/vanilla/settings.multids
+++ b/themes/tiddlywiki/vanilla/settings.multids
@@ -1,6 +1,6 @@
 title: $:/themes/tiddlywiki/vanilla/settings/
 
-fontfamily: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"
+fontfamily: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"
 codefontfamily: ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace
 backgroundimageattachment: fixed
 backgroundimagesize: auto


### PR DESCRIPTION
This PR makes sure arabic texts use sans-serif font and fixes the problem that some extended arabic characters is not displaying correctly on Firefox on Linux.

Before:

![图片](https://github.com/user-attachments/assets/5fedcf2f-f28c-4a67-9f1b-bb886c08b0fb)

After:

![图片](https://github.com/user-attachments/assets/d1e9dd93-c873-4f63-9af5-3eb39e6f2e5e)
