### PR TITLE
Fixed RSoD error with moduleproperty filter operator

### DIFF
--- a/core/modules/filters/moduleproperty.js
+++ b/core/modules/filters/moduleproperty.js
@@ -18,9 +18,13 @@ Export our filter function
 exports.moduleproperty = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
-		var value = require(title)[operator.operand || ""];
-		if(value !== undefined) {
-			results.push(value);
+		try {
+			var value = require(title)[operator.operand || ""];
+			if(value !== undefined) {
+				results.push(value);
+			}
+		} catch(e) {
+			// Do nothing. It probably wasn't a module.
 		}
 	});
 	results.sort();

--- a/core/modules/filters/moduleproperty.js
+++ b/core/modules/filters/moduleproperty.js
@@ -21,6 +21,9 @@ exports.moduleproperty = function(source,operator,options) {
 		try {
 			var value = require(title)[operator.operand || ""];
 			if(value !== undefined) {
+				if(typeof value !== "string") {
+					value = JSON.stringify(value);
+				}
 				results.push(value);
 			}
 		} catch(e) {

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -1134,6 +1134,14 @@ Tests the filtering mechanism.
 			expect(wiki.filterTiddlers("[[<>:\"/\\|?*]encodeuricomponent[]]").join(",")).toBe("%3C%3E%3A%22%2F%5C%7C%3F%2A");
 		});
 	
+		it("should handle the moduleproperty operator", function() {
+			// We don't need to confirm them all, only it it finds at least one module name that we're sure is there.
+			expect(wiki.filterTiddlers("[[macro]modules[]moduleproperty[name]]")).toContain("qualify");
+			// No such property. Nothing to return.
+			expect(wiki.filterTiddlers("[[macro]modules[]moduleproperty[nonexistent]]").length).toBe(0);
+			// No such tiddlers. Nothing to return.
+			expect(wiki.filterTiddlers("[[nonexistent]moduleproperty[name]]").length).toBe(0);
+		});
 	}
 	
 	});

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -1141,6 +1141,8 @@ Tests the filtering mechanism.
 			expect(wiki.filterTiddlers("[[macro]modules[]moduleproperty[nonexistent]]").length).toBe(0);
 			// No such tiddlers. Nothing to return.
 			expect(wiki.filterTiddlers("[[nonexistent]moduleproperty[name]]").length).toBe(0);
+			// Non string properties should get toStringed.
+			expect(wiki.filterTiddlers("[[$:/core/modules/commands/init.js]moduleproperty[info]]").join(" ")).toBe('{"name":"init","synchronous":true}');
 		});
 	}
 	


### PR DESCRIPTION
Found this while working with this filter operator. If you try to pull properties from tiddlers that aren't actually modules, then you get a crash.

Hope this operator wasn't an afterthought. This seemed like a pretty obvious bug, and there weren't any tests for it at all.

Let me know if this isn't the preferred fix.