### PR TITLE
fix problem toc-selective-expandable

### DIFF
--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -1,7 +1,6 @@
 title: $:/core/macros/toc
 tags: $:/tags/Macro
 
-
 \define toc-open-icon() $:/core/images/down-arrow
 \define toc-closed-icon() $:/core/images/right-arrow
 
@@ -121,7 +120,7 @@ tags: $:/tags/Macro
   <$set name="toc-item-class" filter=<<__itemClassFilter__>> emptyValue="toc-item-selected" value="toc-item" >
     <li class=<<toc-item-class>>>
       <$link to={{{ [<currentTiddler>get[target]else<currentTiddler>] }}}>
-          <$list filter="[all[current]tagging[]$sort$limit[1]]  -[subfilter<__exclude__>]" variable="ignore" emptyMessage="<$button class='tc-btn-invisible'>{{$:/core/images/blank}}</$button>">
+          <$list filter="[all[current]tagging[]$sort$]  -[subfilter<__exclude__>] +[limit[1]]" variable="ignore" emptyMessage="<$button class='tc-btn-invisible'>{{$:/core/images/blank}}</$button>">
           <$reveal type="nomatch" stateTitle=<<toc-state>> text="open">
             <$button setTitle=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
             <$transclude tiddler=<<toc-closed-icon>> />
@@ -148,7 +147,7 @@ tags: $:/tags/Macro
 <$qualify name="toc-state" title={{{ [[$:/state/toc]addsuffix<__path__>addsuffix[-]addsuffix<currentTiddler>] }}}>
   <$set name="toc-item-class" filter=<<__itemClassFilter__>> emptyValue="toc-item-selected" value="toc-item">
     <li class=<<toc-item-class>>>
-      <$list filter="[all[current]tagging[]$sort$limit[1]] -[subfilter<__exclude__>]" variable="ignore" emptyMessage="""<$button class="tc-btn-invisible">{{$:/core/images/blank}}</$button><span class="toc-item-muted"><<toc-caption>></span>""">
+      <$list filter="[all[current]tagging[]$sort$] -[subfilter<__exclude__>] +[limit[1]]" variable="ignore" emptyMessage="""<$button class="tc-btn-invisible">{{$:/core/images/blank}}</$button><span class="toc-item-muted"><<toc-caption>></span>""">
         <$reveal type="nomatch" stateTitle=<<toc-state>> text="open">
           <$button setTitle=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
             <$transclude tiddler=<<toc-closed-icon>> />


### PR DESCRIPTION
fix problem toc-selective-expandable

This PR fixes the problem described at Talk: https://talk.tiddlywiki.org/t/issue-using-toc-selective-expandable-with-exclude/11972

```
<div class="tc-table-of-contents">
<<toc-selective-expandable 'TableOfContents' exclude:'[tag[done]]'>>
</div>
```

- I then changed the Videos tiddler to have tag “done”. While this excluded the Videos tiddler under the Learning tiddler in the Contents tab, the “expandable arrow” disappears too, which seems like a bug?

![7e0b019eb551d19c817b009325039e6b08896a26](https://github.com/user-attachments/assets/7d2800de-1cfe-44a0-8c50-74c26bdce6a5)
