### PR TITLE
Fix for #5930: missing tiddlers with checkbox indexes

### DIFF
--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -157,7 +157,7 @@ CheckboxWidget.prototype.getValue = function() {
 		if(this.checkboxTag) {
 			return false;
 		}
-		if(this.checkboxField) {
+		if(this.checkboxField || this.checkboxIndex) {
 			if(this.checkboxDefault === this.checkboxChecked) {
 				return true;
 			}


### PR DESCRIPTION
Also, fixed how the checkboxWidget test suite was actually running the last test over and over again, instead of running all the tests. 