### PR TITLE
AI tools: add more servers

### DIFF
--- a/plugins/tiddlywiki/ai-tools/docs.tid
+++ b/plugins/tiddlywiki/ai-tools/docs.tid
@@ -14,16 +14,9 @@ See the ''settings'' tab for set up instructions.
 #* If using ~OpenAI it is possible to attach a single image to a prompt
 # Click "Send" and wait for the output of the LLM
 
-!! Import ~ChatGPT Conversation Archives
+!! Use utility
 
-# [[Follow the instructions|https://help.openai.com/en/articles/7260999-how-do-i-export-my-chatgpt-history-and-data]] to request an export of your ~ChatGPT data
-# You will receive a link to download your data as a ZIP file
-# Download and unzip the file
-# Locate the file `conversations.json` within the archive and import it into your TiddlyWiki
-# Visit the ''tools'' tab and locate your `conversations.json` tiddler
-# Click the associated ''import'' button
-# See the imported conversations listed in the ''tools'' tab
-# The imported tiddler `conversations.json` is no longer required and can be deleted
+For example, to import ~ChatGPT conversation archives, follow the instructions in the [[utilities tab|$:/plugins/tiddlywiki/ai-tools/utilities]].
 
 !! Conversation Format
 

--- a/plugins/tiddlywiki/ai-tools/globals.tid
+++ b/plugins/tiddlywiki/ai-tools/globals.tid
@@ -19,7 +19,7 @@ completionModel - Optional model to use
 	completionServer={{{ [<completionServer>!is[blank]else<ai-tools-default-llm-completion-server>] }}}
 	completionModel={{{ [<completionModel>!is[blank]else<ai-tools-default-llm-completion-model>] }}}
 >
-	<$importvariables filter="[<completionServer>]">
+	<$importvariables filter="[<completionServer>get[extends]] [<completionServer>]">
 		<$wikify name="json" text=<<json-prompt>>>
 			<$action-log message="ai-tools-get-llm-completion"/>
 			<$action-log/>

--- a/plugins/tiddlywiki/ai-tools/globals.tid
+++ b/plugins/tiddlywiki/ai-tools/globals.tid
@@ -2,7 +2,10 @@ title: $:/plugins/tiddlywiki/ai-tools/globals
 tags: $:/tags/Global
 
 \function ai-tools-default-llm-completion-server()
-[all[shadows+tiddlers]tag[$:/tags/AI/CompletionServer]sort[caption]first[]]
+[[$:/plugins/tiddlywiki/ai-tools/configs/default-server]get[completion-server]]
+\end
+\function ai-tools-default-llm-completion-model()
+[[$:/plugins/tiddlywiki/ai-tools/configs/default-server]get[completion-model]]
 \end
 
 <!--
@@ -119,21 +122,6 @@ Procedure to display a message from an AI conversation. Current tiddler is the c
 Action procedure to get the next response from the LLM on a chat tiddler.
 -->
 \procedure ai-tools-action-get-response()
-<!-- Assign a server and model on tiddler if user forget to pick one. -->
-<% if [<currentTiddler>!has[completion-server]] %>
-	<$action-setfield
-		$tiddler=<<currentTiddler>>
-		$field="completion-server"
-		$value={{{[all[shadows+tiddlers]tag[$:/tags/AI/CompletionServer]sort[caption]first[]]}}}
-	/>
-<% endif %>
-<% if [<currentTiddler>!has[completion-model]] %>
-	<$action-setfield
-		$tiddler=<<currentTiddler>>
-		$field="completion-model"
-		$value={{{[{!!completion-server}get[models]enlist-input[]first[]]}}}
-	/>
-<% endif %>
 <!-- Get the response -->
 <$let
 	resultTitlePrefix={{{ [<currentTiddler>addsuffix[ - Prompt]] }}}
@@ -173,10 +161,15 @@ Action procedure to get the next response from the LLM on a chat tiddler.
 	</$list>
 	</$select>
 	Model: <$select tiddler=<<currentTiddler>> field="completion-model" default=<<ai-tools-default-llm-completion-model>>>
-	<$list filter="[{!!completion-server}get[models]enlist-input[]]">
+	<$list filter="[<ai-tools-default-llm-completion-server>get[models]enlist-input[]]">
 	<option value=<<currentTiddler>>><<currentTiddler>></option>
 	</$list>
 	</$select>
+	<$list filter="[<ai-tools-default-llm-completion-server>get[settings]]">
+		<$button to=<<currentTiddler>> class="tc-btn-invisible">
+			{{$:/core/images/options-button}}
+		</$button>
+	</$list>
 
 	<div class="ai-conversation">
 		<$transclude

--- a/plugins/tiddlywiki/ai-tools/globals.tid
+++ b/plugins/tiddlywiki/ai-tools/globals.tid
@@ -12,10 +12,12 @@ resultTitlePrefix - Prefix of the tiddler to be used for saving the result. If t
 resultTags - Tags to be applied to the result tiddler
 ai-tools-status-title - Optional title of a tiddler to which the status of the request will be bound: "pending", "complete", "error"
 completionServer - Optional URL of server
+completionModel - Optional model to use
 -->
-\procedure ai-tools-get-llm-completion(conversationTitle,resultTitlePrefix,resultTags,ai-tools-status-title,completionServer)
+\procedure ai-tools-get-llm-completion(conversationTitle,resultTitlePrefix,resultTags,ai-tools-status-title,completionServer,completionModel,authTokenStoreKey)
 <$let
 	completionServer={{{ [<completionServer>!is[blank]else<ai-tools-default-llm-completion-server>] }}}
+	completionModel={{{ [<completionModel>!is[blank]else<ai-tools-default-llm-completion-model>] }}}
 >
 	<$importvariables filter="[<completionServer>]">
 		<$wikify name="json" text=<<json-prompt>>>
@@ -26,7 +28,7 @@ completionServer - Optional URL of server
 				url={{{ [<completionServer>get[url]] }}}
 				body=<<json>>
 				header-content-type="application/json"
-				bearer-auth-token-from-store="openai-secret-key"
+				bearer-auth-token-from-store=<<authTokenStoreKey>>
 				method="POST"
 				oncompletion=<<completion-callback>>
 				bind-status=<<ai-tools-status-title>>
@@ -136,6 +138,8 @@ Action procedure to get the next response from the LLM
 			$variable="ai-tools-get-llm-completion"
 			conversationTitle=<<currentTiddler>>
 			completionServer={{!!completion-server}}
+			completionModel={{!!completion-model}}
+			authTokenStoreKey={{{[{!!completion-server}get[auth-token-store-key]]}}}
 			resultTitlePrefix=<<resultTitlePrefix>>
 			resultTags=<<resultTags>>
 			ai-tools-status-title=<<ai-tools-status-title>>
@@ -150,6 +154,11 @@ Action procedure to get the next response from the LLM
 	Server: <$select tiddler=<<currentTiddler>> field="completion-server" default=<<ai-tools-default-llm-completion-server>>>
 	<$list filter="[all[shadows+tiddlers]tag[$:/tags/AI/CompletionServer]sort[caption]]">
 	<option value=<<currentTiddler>>><$view field='caption'/></option>
+	</$list>
+	</$select>
+	Model: <$select tiddler=<<currentTiddler>> field="completion-model" default=<<ai-tools-default-llm-completion-model>>>
+	<$list filter="[{!!completion-server}get[models]enlist-input[]]">
+	<option value=<<currentTiddler>>><<currentTiddler>></option>
 	</$list>
 	</$select>
 

--- a/plugins/tiddlywiki/ai-tools/globals.tid
+++ b/plugins/tiddlywiki/ai-tools/globals.tid
@@ -116,9 +116,25 @@ Procedure to display a message from an AI conversation. Current tiddler is the c
 \end
 
 <!--
-Action procedure to get the next response from the LLM
+Action procedure to get the next response from the LLM on a chat tiddler.
 -->
 \procedure ai-tools-action-get-response()
+<!-- Assign a server and model on tiddler if user forget to pick one. -->
+<% if [<currentTiddler>!has[completion-server]] %>
+	<$action-setfield
+		$tiddler=<<currentTiddler>>
+		$field="completion-server"
+		$value={{{[all[shadows+tiddlers]tag[$:/tags/AI/CompletionServer]sort[caption]first[]]}}}
+	/>
+<% endif %>
+<% if [<currentTiddler>!has[completion-model]] %>
+	<$action-setfield
+		$tiddler=<<currentTiddler>>
+		$field="completion-model"
+		$value={{{[{!!completion-server}get[models]enlist-input[]first[]]}}}
+	/>
+<% endif %>
+<!-- Get the response -->
 <$let
 	resultTitlePrefix={{{ [<currentTiddler>addsuffix[ - Prompt]] }}}
 	resultTags={{{ [<currentTiddler>format:titlelist[]] }}}

--- a/plugins/tiddlywiki/ai-tools/page-menu/import-chatgpt.tid
+++ b/plugins/tiddlywiki/ai-tools/page-menu/import-chatgpt.tid
@@ -1,6 +1,0 @@
-title: $:/plugins/tiddlywiki/ai-tools/page-menu/import-chatgpt
-tags: $:/tags/AI/PageMenu
-
-<$button actions=<<ai-tools-import-conversations>> class="tc-btn-invisible">
-{{$:/core/images/input-button}} Import Conversations from ~ChatGPT
-</$button>

--- a/plugins/tiddlywiki/ai-tools/plugin.info
+++ b/plugins/tiddlywiki/ai-tools/plugin.info
@@ -2,6 +2,6 @@
 	"title": "$:/plugins/tiddlywiki/ai-tools",
 	"name": "AI Tools",
 	"description": "AI Tools for TiddlyWiki",
-	"list": "readme docs utilities settings tree",
+	"list": "readme docs settings utilities tree",
 	"stability": "STABILITY_1_EXPERIMENTAL"
 }

--- a/plugins/tiddlywiki/ai-tools/plugin.info
+++ b/plugins/tiddlywiki/ai-tools/plugin.info
@@ -2,6 +2,6 @@
 	"title": "$:/plugins/tiddlywiki/ai-tools",
 	"name": "AI Tools",
 	"description": "AI Tools for TiddlyWiki",
-	"list": "readme docs tools settings",
+	"list": "readme docs tools settings tree",
 	"stability": "STABILITY_1_EXPERIMENTAL"
 }

--- a/plugins/tiddlywiki/ai-tools/plugin.info
+++ b/plugins/tiddlywiki/ai-tools/plugin.info
@@ -2,6 +2,6 @@
 	"title": "$:/plugins/tiddlywiki/ai-tools",
 	"name": "AI Tools",
 	"description": "AI Tools for TiddlyWiki",
-	"list": "readme docs tools settings tree",
+	"list": "readme docs utilities settings tree",
 	"stability": "STABILITY_1_EXPERIMENTAL"
 }

--- a/plugins/tiddlywiki/ai-tools/servers/deepseek.tid
+++ b/plugins/tiddlywiki/ai-tools/servers/deepseek.tid
@@ -5,3 +5,4 @@ caption: DeepSeek
 auth-token-store-key: deepseek-secret-key
 models: deepseek-chat deepseek-reasoner
 extends: $:/plugins/tiddlywiki/ai-tools/servers/openai
+settings: $:/plugins/tiddlywiki/ai-tools/settings/deepseek

--- a/plugins/tiddlywiki/ai-tools/servers/deepseek.tid
+++ b/plugins/tiddlywiki/ai-tools/servers/deepseek.tid
@@ -1,0 +1,7 @@
+title: $:/plugins/tiddlywiki/ai-tools/servers/deepseek
+tags: $:/tags/AI/CompletionServer
+url: https://api.deepseek.com/chat/completions
+caption: DeepSeek
+auth-token-store-key: deepseek-secret-key
+models: deepseek-chat deepseek-reasoner
+extends: $:/plugins/tiddlywiki/ai-tools/servers/openai

--- a/plugins/tiddlywiki/ai-tools/servers/llamafile-llava.tid
+++ b/plugins/tiddlywiki/ai-tools/servers/llamafile-llava.tid
@@ -2,6 +2,7 @@ title: $:/plugins/tiddlywiki/ai-tools/servers/llamafile-llava
 tags: $:/tags/AI/CompletionServer
 url: http://127.0.0.1:8080/completion
 caption: Local Llamafile server running LLaVA models
+settings: $:/plugins/tiddlywiki/ai-tools/settings/llamafile
 
 <!--
 Wikified JSON text to be sent to server

--- a/plugins/tiddlywiki/ai-tools/servers/openai.tid
+++ b/plugins/tiddlywiki/ai-tools/servers/openai.tid
@@ -11,14 +11,17 @@ Wikified JSON text to be sent to server
 \procedure json-prompt()
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline html conditional commentblock commentinline
 {
-	"model": <<completionModel>>,
+	"model": "<<completionModel>>",
 	"messages": [
 		{
 			"role": "system",
 			"content": "<$text text={{{ [<conversationTitle>get[system-prompt]jsonstringify[]] }}}/>"
 		}
-		<!-- Loop through the tiddlers tagged with this one to pick up all the messages in the conversation -->
-		<$list filter="[all[shadows+tiddlers]tag<conversationTitle>!is[draft]sort[created]]">
+		<!--
+		Loop through the tiddlers tagged with this one to pick up all the messages in the conversation.
+		Exclude 'error' to limit role in 'system', 'user', 'assistant', 'tool'.
+		-->
+		<$list filter="[all[shadows+tiddlers]tag<conversationTitle>!is[draft]!role[error]sort[created]]">
 			,
 			{
 				<!-- We use JSON stringify to escape the characters that can't be used directly in JSON -->

--- a/plugins/tiddlywiki/ai-tools/servers/openai.tid
+++ b/plugins/tiddlywiki/ai-tools/servers/openai.tid
@@ -4,6 +4,7 @@ url: https://api.openai.com/v1/chat/completions
 auth-token-store-key: openai-secret-key
 caption: OpenAI Service
 models: gpt-4o gpt-4.5-preview gpt-4o-mini o1 o1-mini o3-mini
+settings: $:/plugins/tiddlywiki/ai-tools/settings/openai
 
 <!--
 Wikified JSON text to be sent to server

--- a/plugins/tiddlywiki/ai-tools/servers/openai.tid
+++ b/plugins/tiddlywiki/ai-tools/servers/openai.tid
@@ -1,7 +1,9 @@
 title: $:/plugins/tiddlywiki/ai-tools/servers/openai
 tags: $:/tags/AI/CompletionServer
 url: https://api.openai.com/v1/chat/completions
+auth-token-store-key: openai-secret-key
 caption: OpenAI Service
+models: gpt-4o gpt-4.5-preview gpt-4o-mini o1 o1-mini o3-mini
 
 <!--
 Wikified JSON text to be sent to server
@@ -9,7 +11,7 @@ Wikified JSON text to be sent to server
 \procedure json-prompt()
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline html conditional commentblock commentinline
 {
-	"model": "gpt-4o",
+	"model": <<completionModel>>,
 	"messages": [
 		{
 			"role": "system",

--- a/plugins/tiddlywiki/ai-tools/servers/siliconflow.tid
+++ b/plugins/tiddlywiki/ai-tools/servers/siliconflow.tid
@@ -1,0 +1,8 @@
+title: $:/plugins/tiddlywiki/ai-tools/servers/siliconflow
+tags: $:/tags/AI/CompletionServer
+url: https://api.siliconflow.cn/v1/chat/completions
+caption: SiliconFlow
+auth-token-store-key: siliconflow-secret-key
+models: deepseek-ai/DeepSeek-V3 deepseek-ai/DeepSeek-R1
+
+\import $:/plugins/tiddlywiki/ai-tools/servers/openai

--- a/plugins/tiddlywiki/ai-tools/servers/siliconflow.tid
+++ b/plugins/tiddlywiki/ai-tools/servers/siliconflow.tid
@@ -4,5 +4,4 @@ url: https://api.siliconflow.cn/v1/chat/completions
 caption: SiliconFlow
 auth-token-store-key: siliconflow-secret-key
 models: deepseek-ai/DeepSeek-V3 deepseek-ai/DeepSeek-R1
-
-\import $:/plugins/tiddlywiki/ai-tools/servers/openai
+extends: $:/plugins/tiddlywiki/ai-tools/servers/openai

--- a/plugins/tiddlywiki/ai-tools/servers/siliconflow.tid
+++ b/plugins/tiddlywiki/ai-tools/servers/siliconflow.tid
@@ -5,3 +5,4 @@ caption: SiliconFlow
 auth-token-store-key: siliconflow-secret-key
 models: deepseek-ai/DeepSeek-V3 deepseek-ai/DeepSeek-R1
 extends: $:/plugins/tiddlywiki/ai-tools/servers/openai
+settings: $:/plugins/tiddlywiki/ai-tools/settings/siliconflow

--- a/plugins/tiddlywiki/ai-tools/settings/deepseek.tid
+++ b/plugins/tiddlywiki/ai-tools/settings/deepseek.tid
@@ -1,0 +1,12 @@
+title: $:/plugins/tiddlywiki/ai-tools/settings/deepseek
+tags: $:/tags/AI/ServerSetting
+caption: DeepSeek
+
+!! ~DeepSeek API key
+
+# Register for an account at https://deepseek.com/
+# Complete the KYC and charge your account with a minimum of ￥1 on https://platform.deepseek.com/top_up
+# Visit https://platform.deepseek.com/api_keys to create a new secret API key
+# Copy and paste the value into the box below
+
+~DeepSeek Secret API Key: <$password name={{$:/plugins/tiddlywiki/ai-tools/servers/deepseek!!auth-token-store-key}}/>

--- a/plugins/tiddlywiki/ai-tools/settings/llamafile.tid
+++ b/plugins/tiddlywiki/ai-tools/settings/llamafile.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/tiddlywiki/ai-tools/settings/llamafile
-tags: $:/tags/AI/Setting
+tags: $:/tags/AI/ServerSetting
 caption: Llamafile
+models:
 
 !! Llamafile Setup
 

--- a/plugins/tiddlywiki/ai-tools/settings/llamafile.tid
+++ b/plugins/tiddlywiki/ai-tools/settings/llamafile.tid
@@ -1,0 +1,11 @@
+title: $:/plugins/tiddlywiki/ai-tools/settings/llamafile
+tags: $:/tags/AI/Setting
+caption: Llamafile
+
+!! Llamafile Setup
+
+[[Llamafile|https://github.com/Mozilla-Ocho/llamafile]] lets you download and run LLMs as a single file. See the [[announcement blog post|https://hacks.mozilla.org/2023/11/introducing-llamafile/]] for background.
+
+# Download and run Llamafile as [[described in the QuickStart guide|https://github.com/Mozilla-Ocho/llamafile?tab=readme-ov-file#quickstart]]
+# Visit http://127.0.0.1:8080 in a browser and verify that you can see the Llamafile interface. You can also try it out here
+# Return to AI Tools and start a conversation, specifying Llamafile as the server

--- a/plugins/tiddlywiki/ai-tools/settings/openai.tid
+++ b/plugins/tiddlywiki/ai-tools/settings/openai.tid
@@ -1,5 +1,5 @@
 title: $:/plugins/tiddlywiki/ai-tools/settings/openai
-tags: $:/tags/AI/Setting
+tags: $:/tags/AI/ServerSetting
 caption: OpenAI
 
 !! ~OpenAI API key
@@ -12,4 +12,4 @@ This plugin runs entirely in the browser, with no backend server component. A co
 # Visit https://platform.openai.com/api-keys to create a new secret API key
 # Copy and paste the value into the box below
 
-~OpenAI Secret API Key: <$password name="openai-secret-key"/>
+~OpenAI Secret API Key: <$password name={{$:/plugins/tiddlywiki/ai-tools/servers/openai!!auth-token-store-key}}/>

--- a/plugins/tiddlywiki/ai-tools/settings/openai.tid
+++ b/plugins/tiddlywiki/ai-tools/settings/openai.tid
@@ -1,6 +1,6 @@
-title: $:/plugins/tiddlywiki/ai-tools/settings
-
-! AI Tools Settings
+title: $:/plugins/tiddlywiki/ai-tools/settings/openai
+tags: $:/tags/AI/Setting
+caption: OpenAI
 
 !! ~OpenAI API key
 
@@ -13,11 +13,3 @@ This plugin runs entirely in the browser, with no backend server component. A co
 # Copy and paste the value into the box below
 
 ~OpenAI Secret API Key: <$password name="openai-secret-key"/>
-
-!! Llamafile Setup
-
-[[Llamafile|https://github.com/Mozilla-Ocho/llamafile]] lets you download and run LLMs as a single file. See the [[announcment blog post|https://hacks.mozilla.org/2023/11/introducing-llamafile/]] for background.
-
-# Download and run Llamafile as [[described in the QuickStart guide|https://github.com/Mozilla-Ocho/llamafile?tab=readme-ov-file#quickstart]]
-# Visit http://127.0.0.1:8080 in a browser and verify that you can see the Llamafile interface. You can also try it out here
-# Return to AI Tools and start a conversation, specifying Llamafile as the server

--- a/plugins/tiddlywiki/ai-tools/settings/settings.tid
+++ b/plugins/tiddlywiki/ai-tools/settings/settings.tid
@@ -1,5 +1,8 @@
 title: $:/plugins/tiddlywiki/ai-tools/settings
-
+tags: $:/tags/ControlPanel/SettingsTab
+caption: AI Tools
 These settings let you customise the behaviour of the "AI Tools" plugin.
 
-<<tabs "[all[shadows]tag[$:/tags/AI/Setting]]">>
+!! Completion Servers
+
+<<tabs "[all[shadows]tag[$:/tags/AI/ServerSetting]]">>

--- a/plugins/tiddlywiki/ai-tools/settings/settings.tid
+++ b/plugins/tiddlywiki/ai-tools/settings/settings.tid
@@ -5,4 +5,4 @@ These settings let you customise the behaviour of the "AI Tools" plugin.
 
 !! Completion Servers
 
-<<tabs "[all[shadows]tag[$:/tags/AI/ServerSetting]]">>
+<<tabs "[all[shadows+tiddlers]tag[$:/tags/AI/ServerSetting]]">>

--- a/plugins/tiddlywiki/ai-tools/settings/settings.tid
+++ b/plugins/tiddlywiki/ai-tools/settings/settings.tid
@@ -5,4 +5,19 @@ These settings let you customise the behaviour of the "AI Tools" plugin.
 
 !! Completion Servers
 
-<<tabs "[all[shadows+tiddlers]tag[$:/tags/AI/ServerSetting]]">>
+Default Server: <$select tiddler="$:/plugins/tiddlywiki/ai-tools/configs/default-server" field="completion-server">
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/AI/CompletionServer]sort[caption]]">
+<option value=<<currentTiddler>>><$view field='caption'/></option>
+</$list>
+</$select>
+Default Model: <$select tiddler="$:/plugins/tiddlywiki/ai-tools/configs/default-server" field="completion-model">
+<$list filter="[{$:/plugins/tiddlywiki/ai-tools/configs/default-server!!completion-server}get[models]enlist-input[]]">
+<option value=<<currentTiddler>>><<currentTiddler>></option>
+</$list>
+</$select>
+
+<$transclude
+  $variable="tabs"
+  tabsList="[all[shadows+tiddlers]tag[$:/tags/AI/ServerSetting]]"
+  default={{{[{$:/plugins/tiddlywiki/ai-tools/configs/default-server!!completion-server}get[settings]]}}}
+/>

--- a/plugins/tiddlywiki/ai-tools/settings/settings.tid
+++ b/plugins/tiddlywiki/ai-tools/settings/settings.tid
@@ -1,0 +1,5 @@
+title: $:/plugins/tiddlywiki/ai-tools/settings
+
+These settings let you customise the behaviour of the "AI Tools" plugin.
+
+<<tabs "[all[shadows]tag[$:/tags/AI/Setting]]">>

--- a/plugins/tiddlywiki/ai-tools/settings/siliconflow.tid
+++ b/plugins/tiddlywiki/ai-tools/settings/siliconflow.tid
@@ -1,0 +1,12 @@
+title: $:/plugins/tiddlywiki/ai-tools/settings/siliconflow
+tags: $:/tags/AI/ServerSetting
+caption: SiliconFlow
+
+!! ~SiliconFlow API key
+
+# Register for an account at https://siliconflow.com/ or https://siliconflow.cn/
+#* Newly registered accounts can claim a small amount of credit, no payment info is required
+# Visit https://cloud.siliconflow.com/account/ak or https://cloud.siliconflow.cn/account/ak to create a new secret API key
+# Copy and paste the value into the box below
+
+~SiliconFlow Secret API Key: <$password name={{$:/plugins/tiddlywiki/ai-tools/servers/siliconflow!!auth-token-store-key}}/>

--- a/plugins/tiddlywiki/ai-tools/styles.tid
+++ b/plugins/tiddlywiki/ai-tools/styles.tid
@@ -22,7 +22,7 @@ tags: [[$:/tags/Stylesheet]]
 
 .ai-conversation .ai-tools-message .ai-tools-message-toolbar {
 	background: <<colour sidebar-foreground-shadow>>;
-	color: white;
+	color: <<colour foreground>>;
 	padding: 0.25em 1em 0.25em 1em;
 	border-top-left-radius: 1em;
 	border-top-right-radius: 1em;
@@ -36,7 +36,7 @@ tags: [[$:/tags/Stylesheet]]
 
 .ai-conversation .ai-tools-message .ai-tools-message-toolbar .ai-tools-message-toolbar-button {
 	background: <<colour sidebar-foreground-shadow>>;
-	color: #333333;
+	color: <<colour foreground>>;
 	cursor: pointer;
 	display: inline-block;
 	outline: 0;
@@ -65,8 +65,8 @@ tags: [[$:/tags/Stylesheet]]
 
 .ai-conversation .ai-tools-message.ai-tools-message-role-system {
 	width: 60%;
-	background: #4c4c80;
-	color: white;
+	background: <<colour footnote-target-background>>;
+	color: <<colour foreground>>;
 }
 
 .ai-conversation .ai-tools-message.ai-tools-message-role-user {
@@ -76,11 +76,11 @@ tags: [[$:/tags/Stylesheet]]
 }
 
 .ai-conversation .ai-tools-message.ai-tools-message-role-assistant {
-	background: #dfd;
+	background: <<colour tiddler-editor-background>>;
 }
 
 .ai-conversation .ai-tools-message.ai-tools-message-role-error {
-	background: #fdd;
+	background: <<colour notification-background>>;
 }
 
 .ai-conversation .ai-user-prompt {

--- a/plugins/tiddlywiki/ai-tools/styles.tid
+++ b/plugins/tiddlywiki/ai-tools/styles.tid
@@ -4,24 +4,24 @@ tags: [[$:/tags/Stylesheet]]
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline
 
 .ai-conversation {
-	background: #f0eeff;
+	background: <<colour background>>;
 	border-radius: 2em;
 	padding: 1em 1em;
 	display: flex;
 	flex-direction: column;
 	gap: 1em;
-	box-shadow: 2px 2px 5px rgba(0,0,0,0.2);
+	box-shadow: 2px 2px 5px <<colour muted-foreground>>;
 }
 
 .ai-conversation .ai-tools-message {
-	box-shadow: 2px 2px 5px rgba(0,0,0,0.2);
+	box-shadow: 2px 2px 5px <<colour muted-foreground>>;
 	border-radius: 1em;
 	display: flex;
 	flex-direction: column;
 }
 
 .ai-conversation .ai-tools-message .ai-tools-message-toolbar {
-	background: rgba(1,1,1,0.35);
+	background: <<colour sidebar-foreground-shadow>>;
 	color: white;
 	padding: 0.25em 1em 0.25em 1em;
 	border-top-left-radius: 1em;
@@ -35,7 +35,7 @@ tags: [[$:/tags/Stylesheet]]
 }
 
 .ai-conversation .ai-tools-message .ai-tools-message-toolbar .ai-tools-message-toolbar-button {
-	background: rgba(255,255,255,0.35);
+	background: <<colour sidebar-foreground-shadow>>;
 	color: #333333;
 	cursor: pointer;
 	display: inline-block;
@@ -54,8 +54,8 @@ tags: [[$:/tags/Stylesheet]]
 }
 
 .ai-conversation .ai-tools-message .ai-tools-message-toolbar .ai-tools-message-toolbar-button:hover {
-	color: #ffffff;
-	background: rgba(255,255,255,0.55);
+	color: <<colour foreground>>;
+	background: <<colour sidebar-foreground-shadow>>;
 
 }
 
@@ -72,7 +72,7 @@ tags: [[$:/tags/Stylesheet]]
 .ai-conversation .ai-tools-message.ai-tools-message-role-user {
 	width: 60%;
 	margin-left: auto;
-	background: #ffcde0;
+	background: <<colour code-background>>;
 }
 
 .ai-conversation .ai-tools-message.ai-tools-message-role-assistant {
@@ -85,7 +85,7 @@ tags: [[$:/tags/Stylesheet]]
 
 .ai-conversation .ai-user-prompt {
 	padding: 1em;
-	background: #ffcde0;
+	background: <<colour code-background>>;
 	border-radius: 1em;
 	box-shadow: inset 3px 4px 2px rgba(0, 0, 0, 0.1);
 }
@@ -101,8 +101,8 @@ tags: [[$:/tags/Stylesheet]]
 }
 
 .ai-conversation .ai-user-prompt-text textarea {
-	color: #000;
-	background: #fff;
+	color: <<colour foreground>>;
+	background: <<colour background>>;
 }
 
 .ai-conversation .ai-user-prompt button.ai-user-prompt-send {
@@ -110,7 +110,7 @@ tags: [[$:/tags/Stylesheet]]
 	background-image: linear-gradient(-180deg, #e0c3ce, #963057);
 	border-radius: 1em;
 	box-shadow: rgba(0, 0, 0, 0.1) 0 2px 4px;
-	color: #FFFFFF;
+	color: <<colour foreground>>;
 	cursor: pointer;
 	display: inline-block;
 	outline: 0;
@@ -143,8 +143,8 @@ tags: [[$:/tags/Stylesheet]]
 }
 
 .ai-conversation .ai-user-prompt .ai-user-prompt-image button {
-	color: #000;
-	fill: #000;
+	color: <<colour foreground>>;
+	fill: <<colour foreground>>;
 }
 
 .ai-conversation .ai-user-prompt-type {

--- a/plugins/tiddlywiki/ai-tools/tree.tid
+++ b/plugins/tiddlywiki/ai-tools/tree.tid
@@ -1,0 +1,3 @@
+title: $:/plugins/tiddlywiki/ai-tools/tree
+
+<<tree prefix:"$:/plugins/tiddlywiki/ai-tools/">>

--- a/plugins/tiddlywiki/ai-tools/utilities/openai.tid
+++ b/plugins/tiddlywiki/ai-tools/utilities/openai.tid
@@ -1,12 +1,21 @@
-title: $:/plugins/tiddlywiki/ai-tools/tools
-
-! Import ~ChatGPT Export Archive
+title: $$:/plugins/tiddlywiki/ai-tools/utilities/openai
+tags: $:/tags/AI/Utility
+caption: Import ChatGPT Export Archive
 
 These instructions allow you to import the conversations from a ~ChatGPT export archive.
 
+# [[Follow the instructions|https://help.openai.com/en/articles/7260999-how-do-i-export-my-chatgpt-history-and-data]] to request an export of your ~ChatGPT data
+# You will receive a link to download your data as a ZIP file
+# Download and unzip the file
+# Locate the file `conversations.json` within the archive and import it into your TiddlyWiki
+# Visit the ''tools'' tab and locate your `conversations.json` tiddler
+# Click the associated ''import'' button
+# See the imported conversations listed in the ''tools'' tab
+# The imported tiddler `conversations.json` is no longer required and can be deleted
+
 !! 1- Request your archive
 
-Visit the ~ChatGPT site to request your achive. You will be sent an email with a link to a ZIP file. Download the file and locate the file `conversations.json` within it.
+Visit the ~ChatGPT site to request your archive. You will be sent an email with a link to a ZIP file. Download the file and locate the file `conversations.json` within it.
 
 !! 2 - Import `conversations.json` as a tiddler
 

--- a/plugins/tiddlywiki/ai-tools/utilities/utilities.tid
+++ b/plugins/tiddlywiki/ai-tools/utilities/utilities.tid
@@ -1,3 +1,3 @@
 title: $:/plugins/tiddlywiki/ai-tools/utilities
 
-<<tabs "[all[shadows]tag[$:/tags/AI/Utility]]">>
+<<tabs "[all[shadows+tiddlers]tag[$:/tags/AI/Utility]]">>

--- a/plugins/tiddlywiki/ai-tools/utilities/utilities.tid
+++ b/plugins/tiddlywiki/ai-tools/utilities/utilities.tid
@@ -1,0 +1,3 @@
+title: $:/plugins/tiddlywiki/ai-tools/utilities
+
+<<tabs "[all[shadows]tag[$:/tags/AI/Utility]]">>


### PR DESCRIPTION
Allow adding more server via community plugins.

![屏幕截图 2025-03-01 013433](https://github.com/user-attachments/assets/e92eb5ed-4fe9-4655-b7d5-751e0bde36cf)

- allow choose model based on `models` field of server tiddler
- use authTokenStoreKey for different server, based on `auth-token-store-key` field on server tiddler
- fix: shining color on dark mode, it's 1 a.m. so I use nord palette
- Add a SiliconFlow server example which extends openai server tiddler, but has different models
- rename `tools` tiddler to `utilities`, because "role: "tool" in ai prompt json means providing tool calling information, so it is a keyworld should be reserverd, we can add tools config later