### PR TITLE
Introduce let filter run prefix for assigning a filter run result to a variable

### DIFF
--- a/core/modules/filterrunprefixes/let.js
+++ b/core/modules/filterrunprefixes/let.js
@@ -1,0 +1,37 @@
+/*\
+title: $:/core/modules/filterrunprefixes/let.js
+type: application/javascript
+module-type: filterrunprefix
+
+Assign a value to a variable
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter prefix function
+*/
+exports.let = function(operationSubFunction,options) {
+	// Save the variable name
+	var name = options.suffixes[0][0];
+	// Return the filter run prefix function
+	return function(results,source,widget) {
+		// Set the input source to the incoming results
+		var inputSource = widget.wiki.makeTiddlerIterator(results.toArray());
+		// Assign the result of the subfunction to the variable
+		var variables = {};
+		variables[name] = operationSubFunction(inputSource,widget)[0] || "";
+		// Clear the results
+		results.clear();
+		// Return the variables
+		return {
+			variables: variables
+		};
+	};
+};
+
+})();

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -348,7 +348,13 @@ exports.compileFilter = function(filterString) {
 		self.filterRecursionCount = (self.filterRecursionCount || 0) + 1;
 		if(self.filterRecursionCount < MAX_FILTER_DEPTH) {
 			$tw.utils.each(operationFunctions,function(operationFunction) {
-				operationFunction(results,source,widget);
+				var operationResult = operationFunction(results,source,widget);
+				if(operationResult) {
+					if(operationResult.variables) {
+						// If the filter run prefix has returned variables, create a new fake widget with those variables
+						widget = widget.makeFakeWidgetWithVariables(operationResult.variables);
+					}
+				}
 			});
 		} else {
 			results.push("/**-- Excessive filter recursion --**/");

--- a/editions/test/tiddlers/tests/data/let-filter-prefix/All.tid
+++ b/editions/test/tiddlers/tests/data/let-filter-prefix/All.tid
@@ -1,0 +1,12 @@
+title: LetFilterRunPrefix/All
+description: Usage of "all[]" operator within "let" filter run prefix
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+<$text text={{{ [[colossus]] :let:another[all[]] [<another>] +[join[-]] }}}/>
++
+title: ExpectedResult
+
+<p>colossus</p>

--- a/editions/test/tiddlers/tests/data/let-filter-prefix/Simple.tid
+++ b/editions/test/tiddlers/tests/data/let-filter-prefix/Simple.tid
@@ -1,0 +1,12 @@
+title: LetFilterRunPrefix/Simple
+description: Simple usage of "let" filter run prefix
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+<$text text={{{ :let:varname[[magpie]] [<varname>] +[join[-]] }}}/>
++
+title: ExpectedResult
+
+<p>magpie</p>

--- a/editions/tw5.com/tiddlers/filters/syntax/Let Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Let Filter Run Prefix.tid
@@ -1,0 +1,23 @@
+created: 20250307212252946
+from-version: 5.3.7
+modified: 20250307212252946
+rp-input: all titles from previous filter runs
+rp-output: an empty title list is always returned from the "let" filter run prefix
+rp-purpose: assign the result of a filter run to a variable
+tags: [[Named Filter Run Prefix]]
+title: Let Filter Run Prefix
+type: text/vnd.tiddlywiki
+
+<$railroad text="""
+\start none
+\end none
+( ":let" ) 
+( ":" ) 
+( : "variable" )
+( ":" )
+[[run|"Filter Run"]]
+"""/>
+
+The `:let` filter run prefix assigns the first result of a filter run to a variable that is made available to the remaining [[filter runs|Filter Run]] in the [[filter expression|Filter Expression]]. If the filter run does not return any results then the variable is set to an empty string.
+
+Within the filter run the [[all Operator]] with an empty parameter retrieves all the titles from the previous filter runs, instead of the usual behaviour of retieving all the titles that were passed to the filter expression.

--- a/editions/tw5.com/tiddlers/filters/syntax/Named Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Named Filter Run Prefix.tid
@@ -23,6 +23,7 @@ A named filter run prefix can precede any [[run|Filter Run]] of a [[filter expre
 [[<":or"> |"Or Filter Run Prefix"]] |
 [[<":reduce"> |"Reduce Filter Run Prefix"]] |
 [[<":sort">  /"v5.2.0"/ |"Sort Filter Run Prefix"]] |
+[[<":let">  /"v5.3.7"/ |"Let Filter Run Prefix"]] |
 [[<":then">  /"v5.3.0"/ |"Then Filter Run Prefix"]]) [[run|"Filter Run"]]
 """/>
 


### PR DESCRIPTION
This PR introduces a new filter run prefix `:let` that assigns the result of the filter run to a variable that is made available for the remaining filter runs of the filter expression.

It solves the problem that otherwise it is impossible to compute values for filter operator parameters; parameters can only be a literal string, text reference or variable reference. The `:let` filter run prefix provides a solution:

```
:let:index[my.custom.function<param>,[2]] [<data>jsonget[top],<index>]
```

Note that within the filter run the `all[]` operator (with a blank parameter) will return all the input titles received by the `:let` filter run prefix, not the input titles received by the overall filter expression. This permits the results of other filter run prefixes to be assigned to a variable. For following example first sorts all the input tiddlers by length, and then uses the length of the shortest title as the second index of a JSON lookup:

```
[all[tiddlers]] :sort:number[get[text]length[]] :let:index[all[]] [<data>jsonget[top],<index>]
```

Note that this PR is intended to be a more generic replacement for the experiment `:apply` filter operator that is currently part of #8702 - see [the code](https://github.com/TiddlyWiki/TiddlyWiki5/pull/8702/files#diff-eec0da253e0b4c90bea5fdca097ce0f36967a5e4a345ee1c09edb7133dd8c7c7) and [the docs](https://github.com/TiddlyWiki/TiddlyWiki5/pull/8702/files#diff-d22aedea2c52b2b14a8422b78777473d25a71da68582aedc617f0d54f30294e8)