### PR TITLE
syntax examples for using addprefix operator

### DIFF
--- a/editions/tw5.com/tiddlers/filters/addprefix.tid
+++ b/editions/tw5.com/tiddlers/filters/addprefix.tid
@@ -1,13 +1,13 @@
+caption: addprefix
 created: 20140410103123179
-modified: 20150203181822000
+modified: 20250323034328900
+op-input: a [[selection of titles|Title Selection]]
+op-output: the input, but with <<.place S>> added to the start of each title
+op-parameter: a string of characters
+op-parameter-name: S
+op-purpose: extend each input title with a prefix
 tags: [[Filter Operators]] [[String Operators]]
 title: addprefix Operator
 type: text/vnd.tiddlywiki
-caption: addprefix
-op-purpose: extend each input title with a prefix
-op-input: a [[selection of titles|Title Selection]]
-op-parameter: a string of characters
-op-parameter-name: S
-op-output: the input, but with <<.place S>> added to the start of each title
 
 <<.operator-examples "addprefix">>

--- a/editions/tw5.com/tiddlers/filters/examples/addprefix.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/addprefix.tid
@@ -1,7 +1,17 @@
 created: 20150118132851000
-modified: 20150118183116000
+modified: 20250323034523441
 tags: [[addprefix Operator]] [[Operator Examples]]
 title: addprefix Operator (Examples)
 type: text/vnd.tiddlywiki
 
 <<.operator-example 1 "Cat Garden [[Favourite Armchair]] +[addprefix[My ]]">>
+
+```
+The syntax for using the addprefix operator is as follows:
+ 
+     square brackets surround literal text value (e.g., addprefix[sometext] as shown in the example above)
+        
+     curly braces surround tiddler field references (e.g., addprefix{SomeTiddler!!somefield})
+       
+     angle brackets surround variable references (e.g., addprefix<somevariablename>)
+```


### PR DESCRIPTION
this amendment is based on a TW-TALK discussion  'Using Tiddler Field Values', a contribution by @ericshulman.
It makes it clear how to code for use of text literals, tiddler fields and variables when using this operator. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>