### PR TITLE
Execute collectDOMVariables() in $eventcatcher even without selection

### DIFF
--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -67,13 +67,11 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 				if(selectedNode === domNode) {
 					return false;
 				}
-				// Only set up variables if we have actions to invoke
-				if(actions) {
-					variables = $tw.utils.collectDOMVariables(selectedNode,self.domNode,event);
-				}
 			}
 			// Execute our actions with the variables
 			if(actions) {
+				// Set up DOM variables
+				variables = $tw.utils.collectDOMVariables(selectedNode,self.domNode,event);
 				// Add a variable for the modifier key
 				variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
 				// Add a variable for the mouse button


### PR DESCRIPTION
Normally, collectDOMVariables() is only called when a selector was defined as a widget attribute. However, $eventcatcher can be called without the `selector` attribute, as the JS event listener is attached to the $eventcatcher DOM node and will trigger events on this DOM node. In this case the DOM variables are not collected so that a e.g. popup cannot be triggered, since it requires these variables (other actions should work).

Why is this relevant? Because e.g. `mouseenter` and `mouseleave` don't bubble and so cannot be caught by $eventcatcher as `selector` is only matched against the children of the $eventcatcher. However, it is possible to catch these events directly on the $eventcatcher by simply not setting `selector`. Combined with a popup, this will enable tooltips on hover made with the $eventcatcher and a popup $reveal.

I will edit the doc tiddler if there is agreement to merge this.