### PR TITLE
WIP: Create a more-info footer with several tabs

### DIFF
--- a/editions/tw5.com/tiddlers/$__editions_tw5.com_more-info-tab-button-template.tid
+++ b/editions/tw5.com/tiddlers/$__editions_tw5.com_more-info-tab-button-template.tid
@@ -1,0 +1,7 @@
+created: 20250326003708725
+modified: 20250326004622985
+tags: 
+title: $:/editions/tw5.com/more-info-tab-button-template
+type: text/vnd.tiddlywiki
+
+<$transclude $tiddler={{{ [<currentTab>get[icon]] }}} size="64px"/> <$view tiddler=<<currentTab>> field="caption"><$view tiddler=<<currentTab>> field="title"/></$view>

--- a/editions/tw5.com/tiddlers/$__editions_tw5.com_more-info-tab-linked-here.tid
+++ b/editions/tw5.com/tiddlers/$__editions_tw5.com_more-info-tab-linked-here.tid
@@ -1,0 +1,11 @@
+caption: Linked here
+created: 20250326001003637
+icon: $:/core/images/link
+modified: 20250326013143551
+tags: $:/tags/MoreInfoFooter
+title: $:/editions/tw5.com/more-info-tab-linked-here
+type: text/vnd.tiddlywiki
+
+<div class="tc-more-info-footer-list"> 
+<$list filter="[contains:related<currentTiddler>] [<currentTiddler>backlinks[]] +[unique[]sortan[]]" emptyMessage="No tiddlers directly linking here." template="$:/core/ui/ListItemTemplate" />
+</div>

--- a/editions/tw5.com/tiddlers/$__editions_tw5.com_more-info-tab-related.tid
+++ b/editions/tw5.com/tiddlers/$__editions_tw5.com_more-info-tab-related.tid
@@ -1,0 +1,11 @@
+caption: Related
+created: 20250326000854162
+icon: $:/core/images/info-button
+modified: 20250326013228035
+tags: $:/tags/MoreInfoFooter
+title: $:/editions/tw5.com/more-info-tab-related
+type: text/vnd.tiddlywiki
+
+<div class="tc-more-info-footer-list"> 
+<$list filter="[enlist{!!related}]" emptyMessage="No titles explicitly listed as related to this." template="$:/core/ui/ListItemTemplate">
+</div>

--- a/editions/tw5.com/tiddlers/$__editions_tw5.com_more-info-tab-tagging.tid
+++ b/editions/tw5.com/tiddlers/$__editions_tw5.com_more-info-tab-tagging.tid
@@ -1,0 +1,11 @@
+caption: Tagging
+created: 20250326012220025
+icon: $:/core/images/tag-button
+modified: 20250326013116440
+tags: $:/tags/MoreInfoFooter
+title: $:/editions/tw5.com/more-info-tab-tagging
+type: text/vnd.tiddlywiki
+
+<div class="tc-more-info-footer-list">
+<$list filter="[all[current]tagging[]]" emptyMessage="No tiddlers tagged with this one." template="$:/core/ui/ListItemTemplate" />
+</div>

--- a/editions/tw5.com/tiddlers/$__editions_tw5.com_more-info-view-template.tid
+++ b/editions/tw5.com/tiddlers/$__editions_tw5.com_more-info-view-template.tid
@@ -1,0 +1,19 @@
+created: 20250326000304980
+list-after: $:/core/ui/ViewTemplate/body
+modified: 20250326012903180
+tags: $:/tags/ViewTemplate
+title: $:/editions/tw5.com/more-info-view-template
+type: text/vnd.tiddlywiki
+
+<% if [<currentTiddler>!is[system]] %>
+
+<div class="tc-more-info-footer">
+<<tabs 
+  "[tag[$:/tags/MoreInfoFooter]!has[draft.of]]"
+  $:/editions/tw5.com/more-info-tab-related
+  "$:/state/more-info-footer-tab"
+  buttonTemplate:"$:/editions/tw5.com/more-info-tab-button-template" 
+>>
+</div>
+
+<% endif %>

--- a/editions/tw5.com/tiddlers/$__tags_MoreInfoFooter.tid
+++ b/editions/tw5.com/tiddlers/$__tags_MoreInfoFooter.tid
@@ -1,0 +1,5 @@
+created: 20250326001133408
+list: $:/editions/tw5.com/more-info-tab-related $:/editions/tw5.com/more-info-tab-linked-here
+modified: 20250326003425918
+title: $:/tags/MoreInfoFooter
+type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/Core Messages.tid
+++ b/editions/tw5.com/tiddlers/Core Messages.tid
@@ -1,7 +1,9 @@
 created: 20240421144407522
-modified: 20240422091247905
+modified: 20250326000209111
+related: ActionSendMessageWidget
 tags: Reference
 title: Core Messages
+type: text/vnd.tiddlywiki
 
 {{||Messages}}
 

--- a/editions/tw5.com/tiddlers/concepts/Messages.tid
+++ b/editions/tw5.com/tiddlers/concepts/Messages.tid
@@ -1,5 +1,6 @@
 created: 20140226083311937
-modified: 20240422091319082
+modified: 20250326000224490
+related: ActionSendMessageWidget
 tags: Concepts [[Core Messages]]
 title: Messages
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-add-field.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-add-field.tid
@@ -1,9 +1,10 @@
+caption: tm-add-field
 created: 20140908185153663
-modified: 20140908185153663
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-add-field
 type: text/vnd.tiddlywiki
-caption: tm-add-field
 
 The `tm-add-field` message is handled by the FieldManglerWidget. It adds the specified field with a blank value if the field doesn't already exist.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-add-tag.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-add-tag.tid
@@ -1,9 +1,10 @@
+caption: tm-add-tag
 created: 20140908185153663
-modified: 20140908185153663
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-add-tag
 type: text/vnd.tiddlywiki
-caption: tm-add-tag
 
 The `tm-add-tag` message is handled by the FieldManglerWidget. It adds the specified tag.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-auto-save-wiki.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-auto-save-wiki.tid
@@ -1,9 +1,10 @@
+caption: tm-auto-save-wiki
 created: 20140830112325641
-modified: 20140830115149288
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-auto-save-wiki
 type: text/vnd.tiddlywiki
-caption: tm-auto-save-wiki
 
 The autosave wiki message causes the current saver module to perform a background save if it is required.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-browser-refresh.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-browser-refresh.tid
@@ -1,9 +1,10 @@
+caption: tm-browser-refresh
 created: 20140819110529062
-modified: 20140826110529062
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-browser-refresh
 type: text/vnd.tiddlywiki
-caption: tm-browser-refresh
 
 The `tm-browser-refresh` message refreshes the page, causing the re-initialisation of any plugin tiddlers. It does not require any properties on the `event` object.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-cancel-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-cancel-tiddler.tid
@@ -1,9 +1,10 @@
+caption: tm-cancel-tiddler
 created: 20140226193622350
-modified: 20140226193906089
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-cancel-tiddler
 type: text/vnd.tiddlywiki
-caption: tm-cancel-tiddler
 
 The `tm-cancel-tiddler` message abandons the changes in a draft tiddler. It requires the following properties on the `event` object:
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-clear-password.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-clear-password.tid
@@ -1,9 +1,10 @@
+caption: tm-clear-password
 created: 20140226084018038
-modified: 20140226084916556
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-clear-password
 type: text/vnd.tiddlywiki
-caption: tm-clear-password
 
 The `tm-clear-password` message clears the current password from the password vault, clearing the [[$:/isEncrypted]] tiddler. See EncryptionMechanism for details.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-all-tiddlers.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-all-tiddlers.tid
@@ -1,9 +1,10 @@
+caption: tm-close-all-tiddlers
 created: 20140226194242809
-modified: 20140226194341303
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-close-all-tiddlers
 type: text/vnd.tiddlywiki
-caption: tm-close-all-tiddlers
 
 The close all tiddlers message empties the story list.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-all-windows.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-all-windows.tid
@@ -1,9 +1,10 @@
+caption: tm-close-all-windows
 created: 20220301162305764
-modified: 20220301180818011
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-close-all-windows
 type: text/vnd.tiddlywiki
-caption: tm-close-all-windows
 
 <<.from-version 5.2.2>>
 The `tm-close-all-windows` [[message|Messages]] closes all additional //browser// window that were opened with [[tm-open-window|WidgetMessage: tm-open-window]]. 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-other-tiddlers.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-other-tiddlers.tid
@@ -1,9 +1,10 @@
+caption: tm-close-other-tiddlers
 created: 20140302183306544
-modified: 20140302183352966
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-close-other-tiddlers
 type: text/vnd.tiddlywiki
-caption: tm-close-other-tiddlers
 
 The `tm-close-other-tiddlers` message removes all but a specified tiddler from the story list. It requires the following properties on the `event` object:
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-tiddler.tid
@@ -1,9 +1,10 @@
+caption: tm-close-tiddler
 created: 20140226193940778
-modified: 20140226194227227
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-close-tiddler
 type: text/vnd.tiddlywiki
-caption: tm-close-tiddler
 
 The `tm-close-tiddler` message removes a specified tiddler from the story list. It requires the following properties on the `event` object:
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-window.tid
@@ -1,6 +1,7 @@
 caption: tm-open-window
 created: 20220228140417116
-modified: 20230723220539648
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-close-window
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-copy-to-clipboard.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-copy-to-clipboard.tid
@@ -1,6 +1,7 @@
 caption: tm-copy-to-clipboard
 created: 20171215150056004
-modified: 20250127134445040
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-copy-to-clipboard
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-delete-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-delete-tiddler.tid
@@ -1,9 +1,10 @@
+caption: tm-delete-tiddler
 created: 20140226090324129
-modified: 20140226090441236
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-delete-tiddler
 type: text/vnd.tiddlywiki
-caption: tm-delete-tiddler
 
 The `tm-delete-tiddler` message deletes the specified tiddler and removes it from the current story. If the tiddler is a draft then it also deletes the tiddler specified in the `draft.of` field. The delete tiddler message requires the following properties on the `event` object:
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-download-file.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-download-file.tid
@@ -1,6 +1,7 @@
 caption: tm-download-file
 created: 20140811112201235
-modified: 20230723214745520
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-download-file
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-edit-bitmap-operation.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-edit-bitmap-operation.tid
@@ -1,6 +1,7 @@
 caption: tm-edit-bitmap-operation
 created: 20160424204236050
-modified: 20230803045807664
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-edit-bitmap-operation
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-edit-text-operation.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-edit-text-operation.tid
@@ -1,6 +1,7 @@
 caption: tm-edit-text-operation
 created: 20160424211339792
-modified: 20240909083525060
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-edit-text-operation
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-edit-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-edit-tiddler.tid
@@ -1,9 +1,10 @@
+caption: tm-edit-tiddler
 created: 20140226085529797
-modified: 20140226090641987
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-edit-tiddler
 type: text/vnd.tiddlywiki
-caption: tm-edit-tiddler
 
 The `tm-edit-tiddler` message replaces the specified tiddler in the current story with a draft version of itself. It requires the following properties on the `event` object:
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-focus-selector.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-focus-selector.tid
@@ -1,6 +1,7 @@
 caption: tm-focus-selector
 created: 20190628162542132
-modified: 20230723215122038
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-focus-selector
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-fold-all-tiddlers.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-fold-all-tiddlers.tid
@@ -1,6 +1,7 @@
 caption: tm-fold-all-tiddlers
 created: 20160424230908388
-modified: 20191028113838596
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-fold-all-tiddlers
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-fold-other-tiddlers.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-fold-other-tiddlers.tid
@@ -1,6 +1,7 @@
 caption: tm-fold-other-tiddlers
 created: 20160424232355215
-modified: 20191028113932268
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-fold-other-tiddlers
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-fold-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-fold-tiddler.tid
@@ -1,6 +1,7 @@
 caption: tm-fold-tiddler
 created: 20160424232749223
-modified: 20191028113537119
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-fold-tiddler
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-full-screen.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-full-screen.tid
@@ -1,6 +1,7 @@
 caption: tm-full-screen
 created: 20140811112400855
-modified: 20180814215126941
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-full-screen
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-home.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-home.tid
@@ -1,9 +1,10 @@
+caption: tm-home
 created: 20140819110529062
-modified: 20140819110529062
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-home
 type: text/vnd.tiddlywiki
-caption: tm-home
 
 The `tm-home` message closes any open tiddlers and re-opens the default tiddlers set in [[$:/DefaultTiddlers]]. It also remove any [[permalink|PermaLinks]] from the browser address bar. It does not require any properties on the `event` object.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-cancel-all-requests.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-cancel-all-requests.tid
@@ -1,6 +1,7 @@
 caption: tm-http-cancel-all-requests
 created: 20230429161453032
-modified: 20230429161453032
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-http-cancel-all-requests
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
@@ -1,6 +1,7 @@
 caption: tm-http-request
 created: 20230429161453032
-modified: 20240614204704401
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-http-request
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-import-tiddlers.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-import-tiddlers.tid
@@ -1,9 +1,10 @@
+caption: tm-import-tiddlers
 created: 20140716084658099
-modified: 20150228143618000
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-import-tiddlers
 type: text/vnd.tiddlywiki
-caption: tm-import-tiddlers
 
 The `tm-import-tiddlers` message inserts a list of tiddlers into the pending import tiddler [[$:/Import]]. It also applies any active ''upgrader'' modules to each tiddler as it arrives (see the UpgradeMechanism for more details).
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-load-plugin-from-library.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-load-plugin-from-library.tid
@@ -1,6 +1,7 @@
 caption: tm-load-plugin-from-library
 created: 20160424233627001
-modified: 20160424235543975
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-load-plugin-from-library
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-load-plugin-library.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-load-plugin-library.tid
@@ -1,6 +1,7 @@
 caption: tm-load-plugin-library
 created: 20160424235548387
-modified: 20160425000427238
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-load-plugin-library
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-login.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-login.tid
@@ -1,9 +1,10 @@
+caption: tm-login
 created: 20140811112445887
-modified: 20201025163134940
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-login
 type: text/vnd.tiddlywiki
-caption: tm-login
 
 The login message prompts the user for a username and password and attempts to login to the current serverside host. The tiddler [[$:/status/IsLoggedIn]] reflects the current login status with the values "yes" or "no", and [[$:/status/UserName]] reflects the current username.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-logout.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-logout.tid
@@ -1,9 +1,10 @@
+caption: tm-logout
 created: 20140811112457311
-modified: 20140811113344084
+modified: 20250326000000406
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-logout
 type: text/vnd.tiddlywiki
-caption: tm-logout
 
 The logout message attempts to log the user out of the current serverside host. The tiddler [[$:/status/IsLoggedIn]] reflects the current login status with the values "yes" or "no", and [[$:/status/UserName]] reflects the current username.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-modal.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-modal.tid
@@ -1,6 +1,7 @@
 caption: tm-modal
 created: 20140811112133701
-modified: 20230723215434712
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-modal
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-navigate.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-navigate.tid
@@ -1,9 +1,10 @@
+caption: tm-navigate
 created: 20140226085215941
-modified: 20210705094948968
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-navigate
 type: text/vnd.tiddlywiki
-caption: tm-navigate
 
 The `tm-navigate` message inserts the specified tiddler into the story and puts it at the top of the history stack. If the tiddler is not already present in the story then it will be positioned immediately after the tiddler specified in `event.navigateFromTitle`.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-new-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-new-tiddler.tid
@@ -1,6 +1,7 @@
 caption: tm-new-tiddler
 created: 20140226194405353
-modified: 20230723215831560
+modified: 20250326000013556
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-new-tiddler
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-notify.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-notify.tid
@@ -1,6 +1,7 @@
 caption: tm-notify
 created: 20140811112304772
-modified: 20230723220728382
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-notify
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-external-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-external-window.tid
@@ -1,6 +1,7 @@
 caption: tm-open-external-window
 created: 20170121182300000
-modified: 20230723220850135
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-open-external-window
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-window.tid
@@ -1,6 +1,7 @@
 caption: tm-open-window
 created: 20160424181447704
-modified: 20230831201518773
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-open-window
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-perform-import.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-perform-import.tid
@@ -1,9 +1,10 @@
+caption: tm-perform-import
 created: 20140716084242809
-modified: 20140716084341303
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-perform-import
 type: text/vnd.tiddlywiki
-caption: tm-perform-import
 
 The perform import message copies tiddlers from a specified plugin into the main store. See the UpgradeMechanism for an overview of how it is used by the core.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-permalink.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-permalink.tid
@@ -1,9 +1,10 @@
+caption: tm-permalink
 created: 20140723103751357
-modified: 20240523174013095
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-permalink
 type: text/vnd.tiddlywiki
-caption: tm-permalink
 
 The `tm-permalink` message changes the browser address bar to form a [[permalink|PermaLinks]] to a specified tiddler, defaulting to the current tiddler. The resulting link will be copied to the clipboard.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-permaview.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-permaview.tid
@@ -1,9 +1,10 @@
+caption: tm-permaview
 created: 20140723103751357
-modified: 20240523174013095
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-permaview
 type: text/vnd.tiddlywiki
-caption: tm-permaview
 
 The `tm-permaview` message changes the browser address bar to form a [[permaview|PermaLinks]] that specifies all the open tiddlers in the main story river, and the tiddler to be navigated, defaulting to the current tiddler.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-print.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-print.tid
@@ -1,9 +1,10 @@
+caption: tm-print
 created: 20161008085627406
-modified: 20161008085627406
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-print
 type: text/vnd.tiddlywiki
-caption: tm-print
 
 <<.from-version "5.1.14">> The `tm-print` message causes the browser to display the print dialog for the current page. It does not require any properties on the `event` object.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-relink-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-relink-tiddler.tid
@@ -1,6 +1,7 @@
 caption: tm-relink-tiddler
 created: 20220219093748993
-modified: 20220219093748993
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-relink-tiddler
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-remove-field.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-remove-field.tid
@@ -1,9 +1,10 @@
+caption: tm-remove-field
 created: 20140908185153663
-modified: 20140908185153663
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-remove-field
 type: text/vnd.tiddlywiki
-caption: tm-remove-field
 
 The `tm-remove-field` message is handled by the FieldManglerWidget. It removes the specified field.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-remove-tag.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-remove-tag.tid
@@ -1,9 +1,10 @@
+caption: tm-remove-tag
 created: 20140908185153663
-modified: 20140908185153663
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-remove-tag
 type: text/vnd.tiddlywiki
-caption: tm-remove-tag
 
 The `tm-remove-tag` message is handled by the FieldManglerWidget. It removes the specified tag.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-rename-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-rename-tiddler.tid
@@ -1,6 +1,7 @@
 caption: tm-rename-tiddler
 created: 20190909133618113
-modified: 20220219093748993
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-rename-tiddler
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-save-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-save-tiddler.tid
@@ -1,9 +1,10 @@
+caption: tm-save-tiddler
 created: 20140226090544323
-modified: 20140226090729828
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages navigator-message
 title: WidgetMessage: tm-save-tiddler
 type: text/vnd.tiddlywiki
-caption: tm-save-tiddler
 
 The `tm-save-tiddler` message is applied to draft tiddlers. It saves the draft over the tiddler identified in the `draft.of` field and then deletes the draft. The save tiddler message requires the following properties on the `event` object:
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-save-wiki.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-save-wiki.tid
@@ -1,6 +1,7 @@
 caption: tm-save-wiki
 created: 20140811112325641
-modified: 20230723220944427
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-save-wiki
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-scroll.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-scroll.tid
@@ -1,6 +1,7 @@
 caption: tm-scroll
 created: 20160425000906330
-modified: 20201014152456174
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-scroll
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-server-refresh.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-server-refresh.tid
@@ -1,9 +1,10 @@
+caption: tm-server-refresh
 created: 20140811112435281
-modified: 20140811113453568
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-server-refresh
 type: text/vnd.tiddlywiki
-caption: tm-server-refresh
 
 The server refresh message attempts to synchronise the latest changes to the current serverside host.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-set-password.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-set-password.tid
@@ -1,9 +1,10 @@
+caption: tm-set-password
 created: 20140226084623977
-modified: 20140226085200323
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-set-password
 type: text/vnd.tiddlywiki
-caption: tm-set-password
 
 The `tm-set-password` message prompts the user for a new password and stores it in the password vault, replacing any existing password. It also sets the [[$:/isEncrypted]] tiddler. See EncryptionMechanism for details.
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-unfold-all-tiddlers.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-unfold-all-tiddlers.tid
@@ -1,6 +1,7 @@
 caption: tm-unfold-all-tiddlers
 created: 20160424233133261
-modified: 20191028113810219
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-unfold-all-tiddlers
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-unload-plugin-library.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-unload-plugin-library.tid
@@ -1,6 +1,7 @@
 caption: tm-unload-plugin-library
 created: 20191004112527669
-modified: 20191004113621714
+modified: 20250326000000407
+related: ActionSendMessageWidget
 tags: Messages
 title: WidgetMessage: tm-unload-plugin-library
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/system/Sources.tid
+++ b/editions/tw5.com/tiddlers/system/Sources.tid
@@ -1,9 +1,11 @@
 caption: Sources
 code-body: yes
 created: 20240313090915565
-modified: 20240313115026563
-tags: $:/tags/TiddlerInfo
+icon: $:/core/images/transcludify
+modified: 20250326004800717
+tags: $:/tags/TiddlerInfo $:/tags/MoreInfoFooter
 title: $:/editions/tw5.com/TiddlerInfo/Sources
+type: text/vnd.tiddlywiki
 
 \function static-link-base() [[https://tiddlywiki.com/static/$(title)$.html]substitute[]]
 

--- a/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
+++ b/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
@@ -1,5 +1,5 @@
 created: 20200507002727378
-modified: 20220719132112414
+modified: 20250326015821311
 tags: $:/tags/Stylesheet
 title: $:/_tw5.com-styles
 type: text/vnd.tiddlywiki
@@ -164,3 +164,13 @@ type: text/vnd.tiddlywiki
 	background: #ffd;
 	background: linear-gradient(#ffd, #ffd) padding-box, repeating-linear-gradient(-45deg, red 0, red 25%, transparent 0, transparent 50%) 0 / .6em .6em;
 }
+
+.tc-more-info-footer {
+	border-top: 1px solid <<colour tab-divider>>;
+	background-color: <<colour message-background>>;
+	padding: 0 1em .5em;
+}
+.tc-more-info-footer-list {
+	column-width: 20em;
+}
+


### PR DESCRIPTION
This is a follow-up to #8992.  Please review the discussion there first.

This still has the original logic from that PR of a `related` field containing a manually-curated list of tiddlers.  It now formats the result as part of a new tabbed footer, which also includes three other tabs.  These tabs include: a list of items linking to the current tiddler (with a text link or their own `related` field, a list of items tagged with the current tiddler, and the `Info > Sources` tab.

The other tabs are based on pre-existing structures, but the Related tab will only grow useful as we manually add links to related tiddlers.

### Comments ###

  * Reusing the Sources tab seems to make a great deal of sense.  But it makes me wonder what other ones we might want to repurpose.  (I didn't do this with `Tagging` because the existing tiddler uses `<<lingo>>` and I didn't want to go there.
  * The look and feel of the footer probably needs work.  I wanted a border or color difference to set it apart from the surroundings.  But nothing I've found looks *quite* right.  I would definitely consider trying to make this fill up the bottom of the tiddler with no white space to its left, right, or bottom.  But I haven't tried that yet.
  * The icon for the `Sources` tab is not a great fit, but it was the best I could come up with from the existing icons.  Suggestions quite welcome!

It's bedtime, and I didn't finish my list of comments.  I'll try to add to it when my brain isn't trying to dream as I type!

But in the meanwhile, I would appreciate any feedback.

![image](https://github.com/user-attachments/assets/d31a2081-b671-4175-8787-19b17f829975)

![image](https://github.com/user-attachments/assets/7be1cd7f-8476-4b22-b55d-1106d3925015)

![image](https://github.com/user-attachments/assets/1a3327d8-d54b-45f4-8a4a-c1e8b0e12477)

![image](https://github.com/user-attachments/assets/c2d92855-eb4e-45ef-8d27-dbb442559c48)



Closes #8992
