### PR TITLE
Filter inspection for debugging

### DIFF
--- a/core/language/en-GB/Search.multids
+++ b/core/language/en-GB/Search.multids
@@ -4,6 +4,8 @@ DefaultResults/Caption: List
 Filter/Caption: Filter
 Filter/Hint: Search via a [[filter expression|https://tiddlywiki.com/static/Filters.html]]
 Filter/Matches: //<small><<resultCount>> matches</small>//
+Filter/FilterResults/Results/Caption: Results
+Filter/FilterResults/Inspect/Caption: Inspect
 Matches: //<small><<resultCount>> matches</small>//
 Matches/All: All matches:
 Matches/NoMatch: //No match//

--- a/core/modules/filters/inspect.js
+++ b/core/modules/filters/inspect.js
@@ -1,0 +1,69 @@
+/*\
+title: $:/core/modules/filters/inspect.js
+type: application/javascript
+module-type: filteroperator
+
+Filter operator for inspecting the evaluation of a filter
+
+\*/
+
+"use strict";
+
+/*
+Export our filter function
+*/
+exports.inspect = function(source,operator,options) {
+	var self = this,
+		inputFilter = operator.operands[0] || "",
+		output = {input: [],runs: []},
+		currentRun;
+	// Save the input
+	source(function(tiddler,title) {
+		output.input.push(title);
+	});
+	// Compile the filter with wrapper functions to log the details
+	var compiledFilter = options.wiki.compileFilter(inputFilter,{
+			wrappers: {
+				prefix: function(filterRunPrefixFunction,operationFunction,innerOptions) {
+					return function(results,innerSource,innerWidget) {
+						var details ={
+								prefixName: innerOptions.prefixName,
+								operators: []
+							};
+						currentRun = details.operators;
+						var innerResults = filterRunPrefixFunction.call(this,operationFunction,innerOptions),
+							prefixOutput = new $tw.utils.LinkedList();
+						innerResults(prefixOutput,innerSource,innerWidget);
+						var prefixOutputArray = prefixOutput.toArray();
+						details.output = prefixOutputArray;
+						output.runs.push(details);
+						results.clear();
+						$tw.utils.each(prefixOutputArray,function(title) {
+							results.push(title);
+						});
+					};
+				},
+				operator: function(operatorFunction,innerSource,innerOperator,innerOptions) {
+					var details = {
+							operatorName: innerOperator.operatorName,
+							operands: innerOperator.operands,
+							prefix: innerOperator.prefix,
+							suffix: innerOperator.suffix,
+							suffixes: innerOperator.suffixes,
+							regexp: innerOperator.regexp,
+							input: []
+						},
+						innerResults = operatorFunction.apply(self,Array.prototype.slice.call(arguments,1));
+					innerSource(function(tiddler,title) {
+						details.input.push(title);
+					});
+					currentRun.push(details);
+					return innerResults;
+				}
+		}
+	});
+	output.output = compiledFilter.call(this,source,options.widget);
+	var results = [];
+	results.push(JSON.stringify(output,null,4));
+	return results;
+};

--- a/core/ui/AdvancedSearch/Filter.tid
+++ b/core/ui/AdvancedSearch/Filter.tid
@@ -34,39 +34,11 @@ caption: {{$:/language/Search/Filter/Caption}}
 </$list>
 \end
 
-\procedure input-accept-actions()
-\whitespace trim
-<$list filter="[{$:/config/Search/NavigateOnEnter/enable}match[yes]]">
-	<$list-empty>
-		<$list filter="[<tiddler>get[text]!is[missing]] :else[<tiddler>get[text]is[shadow]]">
-			<$action-navigate $to={{{ [<tiddler>get[text]] }}}/>
-		</$list>
-	<$/list-empty>
-	<$action-navigate $to={{{ [<tiddler>get[text]] }}}/>
-</$list>
-\end
-
-\procedure input-accept-variant-actions()
-\whitespace trim
-<$list filter="[{$:/config/Search/NavigateOnEnter/enable}match[yes]]">
-	<$list-empty>
-		<$list filter="[<tiddler>get[text]!is[missing]] :else[<tiddler>get[text]is[shadow]]">
-			<$list filter="[<__tiddler__>get[text]minlength[1]]">
-				<$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<tiddler>get[text]] }}}/>
-			</$list>
-		</$list>
-	</$list-empty>
-	<$list filter="[<tiddler>get[text]minlength[1]]">
-		<$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<tiddler>get[text]] }}}/>
-	</$list>
-</$list>
-\end
-
 \whitespace trim
 
 <<lingo Filter/Hint>>
 
-<div class="tc-search tc-advanced-search">
+<div class="tc-search tc-advanced-search tc-edit-max-width">
 	<$keyboard key="((input-tab-right))" actions=<<set-next-input-tab>> class="tc-small-gap-right">
 		<$keyboard key="((input-tab-left))" actions=<<set-previous-input-tab>>>
 			<$transclude $variable="keyboard-driven-input"
@@ -75,13 +47,15 @@ caption: {{$:/language/Search/Filter/Caption}}
 				refreshTitle="$:/temp/advancedsearch/refresh"
 				selectionStateTitle="$:/temp/advancedsearch/selected-item"
 				type="search"
-				tag="input"
+				tag="textarea"
 				focus={{$:/config/Search/AutoFocus}}
 				configTiddlerFilter="[[$:/temp/advancedsearch]]"
 				firstSearchFilterField="text"
-				inputAcceptActions=<<input-accept-actions>>
-				inputAcceptVariantActions=<<input-accept-variant-actions>>
+				inputAcceptActions=""
+				inputAcceptVariantActions=""
 				inputCancelActions=<<cancel-search-actions>>
+				minHeight="2em"
+				autoHeight="yes"
 			/>
 		</$keyboard>
 	</$keyboard>
@@ -91,12 +65,10 @@ caption: {{$:/language/Search/Filter/Caption}}
 </div>
 
 <$reveal state="$:/temp/advancedsearch" type="nomatch" text="" tag="div" class="tc-search-results">
-	<$set name="resultCount" value="<$count filter={{$:/temp/advancedsearch}}/>">
-		<p><<lingo Filter/Matches>></p>
-		<$list filter={{$:/temp/advancedsearch}}>
-			<span class={{{[<currentTiddler>addsuffix[-primaryList]] -[[$:/temp/advancedsearch/selected-item]get[text]] :and[then[]else[tc-list-item-selected]] }}}>
-				<$transclude tiddler="$:/core/ui/ListItemTemplate"/>
-			</span>
-		</$list>
-	</$set>
+<$macrocall
+	$name="tabs"
+	tabsList="[all[shadows+tiddlers]tag[$:/tags/AdvancedSearch/FilterResults]!has[draft.of]]"
+	default="$:/core/ui/AdvancedSearch/Filter/FilterResults/Results"
+	explicitState="$:/state/tab-1749438307"
+/>
 </$reveal>

--- a/core/ui/AdvancedSearch/FilterResults/Inspect.tid
+++ b/core/ui/AdvancedSearch/FilterResults/Inspect.tid
@@ -1,0 +1,12 @@
+title: $:/core/ui/AdvancedSearch/Filter/FilterResults/Inspect
+tags: $:/tags/AdvancedSearch/FilterResults
+caption: {{$:/language/Search/Filter/FilterResults/Inspect/Caption}}
+
+\procedure lingo-base() $:/language/Search/
+
+
+<$let json={{{ [inspect{$:/temp/advancedsearch}] }}}>
+	<$transclude $variable="copy-to-clipboard-above-right" src=<<json>>/>
+	<$codeblock code=<<json>> language="application/json" }}}/>
+
+<$codeblock code=/>

--- a/core/ui/AdvancedSearch/FilterResults/Results.tid
+++ b/core/ui/AdvancedSearch/FilterResults/Results.tid
@@ -1,0 +1,13 @@
+title: $:/core/ui/AdvancedSearch/Filter/FilterResults/Results
+tags: $:/tags/AdvancedSearch/FilterResults
+caption: {{$:/language/Search/Filter/FilterResults/Results/Caption}}
+
+\procedure lingo-base() $:/language/Search/
+<$set name="resultCount" value="<$count filter={{$:/temp/advancedsearch}}/>">
+	<p><<lingo Filter/Matches>></p>
+	<$list filter={{$:/temp/advancedsearch}}>
+		<span class={{{[<currentTiddler>addsuffix[-primaryList]] -[[$:/temp/advancedsearch/selected-item]get[text]] :and[then[]else[tc-list-item-selected]] }}}>
+			<$transclude tiddler="$:/core/ui/ListItemTemplate"/>
+		</span>
+	</$list>
+</$set>

--- a/core/wiki/config/AdvancedSearchDefaultTab.tid
+++ b/core/wiki/config/AdvancedSearchDefaultTab.tid
@@ -1,0 +1,2 @@
+title: $:/state/tab--1498284803
+text: $:/core/ui/AdvancedSearch/Filter

--- a/core/wiki/config/AdvancedSearchFilterDefaultTab.tid
+++ b/core/wiki/config/AdvancedSearchFilterDefaultTab.tid
@@ -1,0 +1,2 @@
+title: $:/state/tab-1749438307
+text: $:/core/ui/AdvancedSearch/Filter/FilterResults/Results

--- a/core/wiki/tags/AdvancedSearchFilterResults.tid
+++ b/core/wiki/tags/AdvancedSearchFilterResults.tid
@@ -1,0 +1,2 @@
+title: $:/tags/AdvancedSearch/FilterResults
+list: $:/core/ui/AdvancedSearch/Filter/FilterResults/Results $:/core/ui/AdvancedSearch/Filter/FilterResults/Inspect

--- a/editions/test/tiddlers/tests/data/filter-wrappers/Simple.tid
+++ b/editions/test/tiddlers/tests/data/filter-wrappers/Simple.tid
@@ -1,0 +1,92 @@
+title: FiltersWrappers/Simple
+description: Test filter inspection
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+
+\procedure test-filter()
+1 2 3
+\end
+
+\function test-filter-wrapper()
+[inspect<test-filter>]
+\end
+
+<$text text=<<test-filter>>/>
+-
+<$text text=<<test-filter-wrapper>>/>
++
+title: ExpectedResult
+
+<p>1 2 3-{
+    "input": [
+        "$:/core",
+        "ExpectedResult",
+        "Output"
+    ],
+    "runs": [
+        {
+            "prefixName": "or",
+            "operators": [
+                {
+                    "operatorName": "title",
+                    "operands": [
+                        "1"
+                    ],
+                    "input": [
+                        "$:/core",
+                        "ExpectedResult",
+                        "Output"
+                    ]
+                }
+            ],
+            "output": [
+                "1"
+            ]
+        },
+        {
+            "prefixName": "or",
+            "operators": [
+                {
+                    "operatorName": "title",
+                    "operands": [
+                        "2"
+                    ],
+                    "input": [
+                        "$:/core",
+                        "ExpectedResult",
+                        "Output"
+                    ]
+                }
+            ],
+            "output": [
+                "2"
+            ]
+        },
+        {
+            "prefixName": "or",
+            "operators": [
+                {
+                    "operatorName": "title",
+                    "operands": [
+                        "3"
+                    ],
+                    "input": [
+                        "$:/core",
+                        "ExpectedResult",
+                        "Output"
+                    ]
+                }
+            ],
+            "output": [
+                "3"
+            ]
+        }
+    ],
+    "output": [
+        "3"
+    ]
+}</p>

--- a/editions/tw5.com/tiddlers/filters/inspect Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/inspect Operator.tid
@@ -1,0 +1,26 @@
+caption: inspect
+created: 20250401094200994
+modified: 20250401094200994
+op-input: a [[selection of titles|Title Selection]]
+op-output: a JSON object containing the input, output and intermediate results of evaluating the specified filter
+op-parameter: the filter to be inspected
+op-parameter-name: F
+op-purpose: inspect the evaluation of a filter to aid debugging
+tags: [[Filter Operators]]
+title: inspect Operator
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.3.7">> The <<.op inspect>> operator evaluates a filter with the specified input titles and returns a JSON object containing the input, output and intermediate results of evaluating the specified filter.
+
+The JSON object contains the following properties:
+
+* `input`: the input titles passed to the filter
+* `output`: the output titles resulting from evaluating the filter
+* `runs`: an array of objects, each of which represents a single run of the filter. Each object contains the following properties:
+** `prefixName`: the name of the prefix operator that was used in this run
+** `operators`: an array of objects, each of which represents a single operator that was used in this run. Each object contains the following properties:
+*** `operatorName`: the name of the operator
+*** `operands`: an array of string operands passed to the operator
+*** `input`: the input titles passed to the operator
+** `output`: the output titles resulting from evaluating this run
+


### PR DESCRIPTION
This PR is an unfinished proof of concept for a new tool to aid with debugging complex filters.

It is based on a new operator `[inspect<filter>]` that evaluates a filter and returns a block of JSON that contains the overall input and output of the filter along with data about all the intermediate steps, including the intermediate result list. Also included is a first pass at integrating this new operator with the "Advanced Search" -> "Filter" tab.

# Changes to Advanced Search

* The Advanced Search "Filter" tab is now the default
* The text box is now an auto-expanding `<textarea>` to make it easier to work with complex filters
* The "Filter" tab now includes two separate tabs:
  * "Results" contains the familiar list of results
  * "Inspect" presents a schematic view of the filter evaluation process, showing the results at each stage of the evaluation

For the moment, the "Inspect" tab just shows the raw JSON. The JSON is typically so large and unwieldy that it is easier to analyse it by using the "copy" button to copy the JSON to a programmers editor that provides a UI for exploring JSON.

Ultimately, the plan would be to display it schematically, more along the lines of the railroad plugin (albeit probably vertical rather than horizontal). In practice, this view would have to provide an interactive way to truncate long lists.

# JSON Format

The JSON object returned by the `inspect` operator contains the following properties:

* `input`: the input titles passed to the filter
* `output`: the output titles resulting from evaluating the filter
* `runs`: an array of objects, each of which represents a single run of the filter. Each object contains the following properties:
  * `prefixName`: the name of the prefix operator that was used in this run
  * `operators`: an array of objects, each of which represents a single operator that was used in this run. Each object contains the following properties:
    * `operatorName`: the name of the operator
    * `operands`: an array of string operands passed to the operator
    * `input`: the input titles passed to the operator
  * `output`: the output titles resulting from evaluating this run

# Progress

- [ ] Fill in some information missing from the JSON (eg suffixes for filter runs)
- [ ] Schematic visualisation of JSON output
- [ ] New select box for selecting the input titles, defaulting to `all[tiddlers]`
- [ ] Proper toolbar without buttons appearing and disappearing
