### PR TITLE
update vanilla palette with resolvable values using current tooling

### DIFF
--- a/core/palettes/Vanilla.tid
+++ b/core/palettes/Vanilla.tid
@@ -69,7 +69,7 @@ select-tag-foreground:
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #000000
 sidebar-controls-foreground: #aaaaaa
-sidebar-foreground-shadow: rgba(255,255,255, 0.8)
+sidebar-foreground-shadow: #ffffff
 sidebar-foreground: #acacac
 sidebar-muted-foreground-hover: #444444
 sidebar-muted-foreground: #c0c0c0
@@ -83,7 +83,7 @@ sidebar-tab-foreground: <<colour tab-foreground>>
 sidebar-tiddler-link-foreground-hover: #444444
 sidebar-tiddler-link-foreground: #999999
 site-title-foreground: <<colour tiddler-title-foreground>>
-stability-stable: #008000
+stability-stable: #00b700
 stability-experimental: #c07c00
 stability-deprecated: #ff0000
 stability-legacy: #0000ff
@@ -138,13 +138,13 @@ wikilist-title: #666666
 wikilist-title-svg: <<colour wikilist-title>>
 wikilist-url: #aaaaaa
 wikilist-button-open: #4fb82b
-wikilist-button-open-hover: green
+wikilist-button-open-hover: #009300
 wikilist-button-reveal: #5778d8
-wikilist-button-reveal-hover: blue
+wikilist-button-reveal-hover: #0000ff
 wikilist-button-remove: #d85778
-wikilist-button-remove-hover: red
+wikilist-button-remove-hover: #ff0000
 wikilist-toolbar-background: #d3d3d3
 wikilist-toolbar-foreground: #888888
-wikilist-droplink-dragover: rgba(255,192,192,0.5)
+wikilist-droplink-dragover: #ffc0c0
 wikilist-button-background: #acacac
 wikilist-button-foreground: #000000


### PR DESCRIPTION
This is the **first** PR related to #9004

- #9004

1. It replaces values that are currently unresolvable by browser native colour pickers. Like "red"
2. `stability-stable` is made a bit lighter, so it will be visible if background is set to "primary colour"

**this PR**

![image](https://github.com/user-attachments/assets/314d31ff-4955-455c-8932-f3feae53d36e)

**v5.3.6**

![image](https://github.com/user-attachments/assets/126181c9-0c47-4a4c-8f6a-e1c06df548ae)

------

Also see my comment at: https://github.com/TiddlyWiki/TiddlyWiki5/issues/9004#issuecomment-2780722985

>I did check https://wikilabs.github.io/editions/palette-manager/ where the default landing page shows the testcase UI. 
>
>All the palettes with the suffix **WL** contain the palettes settings, that I personally use. For me **Spartan Night WL** works as expected. 
