### PR TITLE
Muted palette, minor adjustments

### DIFF
--- a/core/palettes/BrightMute.tid
+++ b/core/palettes/BrightMute.tid
@@ -18,7 +18,7 @@ code-background: #f7f7f9
 code-border: #e1e1e8
 code-foreground: #dd1144
 dirty-indicator: #ff0000
-download-background: #34c734
+download-background: #444fd0
 download-foreground: <<colour background>>
 dragger-background: <<colour foreground>>
 dragger-foreground: <<colour background>>
@@ -47,6 +47,7 @@ modal-footer-background: #f5f5f5
 modal-footer-border: #dddddd
 modal-header-border: #eeeeee
 muted-foreground: #bbb
+network-activity-foreground: <<colour primary>>
 notification-background: #ffffdd
 notification-border: #999999
 page-background: #6f6f70
@@ -56,22 +57,26 @@ primary: #29a6ee
 select-tag-background:
 select-tag-foreground:
 sidebar-button-foreground: <<colour foreground>>
-sidebar-controls-foreground-hover: #000000
+sidebar-controls-foreground-hover: #222222
 sidebar-controls-foreground: #c2c1c2
-sidebar-foreground-shadow: rgba(255,255,255,0)
+sidebar-foreground-shadow: transparent
 sidebar-foreground: #d3d2d4
-sidebar-muted-foreground-hover: #444444
+sidebar-muted-foreground-hover: #333333
 sidebar-muted-foreground: #c0c0c0
 sidebar-tab-background-selected: #6f6f70
 sidebar-tab-background: #666667
 sidebar-tab-border-selected: #999
 sidebar-tab-border: #515151
 sidebar-tab-divider: #999
-sidebar-tab-foreground-selected: 
-sidebar-tab-foreground: #999
+sidebar-tab-foreground-selected: #bfbfbf
+sidebar-tab-foreground: #b0b0b0
 sidebar-tiddler-link-foreground-hover: #444444
 sidebar-tiddler-link-foreground: #d1d0d2
 site-title-foreground: <<colour tiddler-title-foreground>>
+stability-deprecated: #bf616a
+stability-experimental: #d08770
+stability-legacy: #88c0d0
+stability-stable: #a3be8c
 static-alert-foreground: #aaaaaa
 tab-background-selected: #ffffff
 tab-background: #d8d8d8


### PR DESCRIPTION
- minor adjustments

In this PR

Change the download button colour from greenish to blue, to make the "hover state" text in the plugin-button visible.

![image](https://github.com/user-attachments/assets/17a3b133-d247-4433-b9ef-69339cbee03a)

>**v5.3.6** the green text is not readable
>
>![image](https://github.com/user-attachments/assets/50105805-8c6c-47a4-a3ca-210e4fc7f443)

sidebar-controls-foreground-hover -> make it "dark gray" instead of black.

![image](https://github.com/user-attachments/assets/0229433b-5c5c-4c67-bebc-e7152bc21b69)

sidebar-muted-hover -> gray instead of black

![image](https://github.com/user-attachments/assets/296c8b13-c531-4a2d-8376-75555e1ed1ce)

sidebar tabs -> should look better now

![image](https://github.com/user-attachments/assets/37365043-d5b5-4427-968b-8bbcfb4c5e0f)

