### PR TITLE
rocker palette, make toolbar buttons visible, sidebar tabs adjusted

### DIFF
--- a/core/palettes/Rocker.tid
+++ b/core/palettes/Rocker.tid
@@ -11,7 +11,7 @@ alert-highlight: #881122
 alert-muted-foreground: #b99e2f
 background: #ffffff
 blockquote-bar: <<colour muted-foreground>>
-button-background:
+button-background: #adadad
 button-foreground:
 button-border:
 code-background: #f7f7f9
@@ -47,36 +47,41 @@ modal-footer-background: #f5f5f5
 modal-footer-border: #dddddd
 modal-header-border: #eeeeee
 muted-foreground: #999999
+network-activity-foreground: <<colour primary>>
 notification-background: #ffffdd
 notification-border: #999999
 page-background: #000
 pre-background: #f5f5f5
 pre-border: #cccccc
 primary: #cc0000
-select-tag-background:
-select-tag-foreground:
+select-tag-background: <<colour foreground>>
+select-tag-foreground: <<colour foreground>>
 sidebar-button-foreground: <<colour foreground>>
-sidebar-controls-foreground-hover: #000000
-sidebar-controls-foreground: #ffffff
+sidebar-controls-foreground-hover: #797979
+sidebar-controls-foreground: #cacaca
 sidebar-foreground-shadow: rgba(255,255,255, 0.0)
 sidebar-foreground: #acacac
 sidebar-muted-foreground-hover: #444444
 sidebar-muted-foreground: #c0c0c0
-sidebar-tab-background-selected: #000
+sidebar-tab-background-selected: #000000
 sidebar-tab-background: <<colour tab-background>>
-sidebar-tab-border-selected: <<colour tab-border-selected>>
+sidebar-tab-border-selected: #7c7c7c
 sidebar-tab-border: <<colour tab-border>>
 sidebar-tab-divider: <<colour tab-divider>>
-sidebar-tab-foreground-selected: 
+sidebar-tab-foreground-selected: #ff0909
 sidebar-tab-foreground: <<colour tab-foreground>>
 sidebar-tiddler-link-foreground-hover: #ffbb99
 sidebar-tiddler-link-foreground: #cc0000
 site-title-foreground: <<colour tiddler-title-foreground>>
+stability-deprecated: #ff0000
+stability-experimental: #c07c00
+stability-legacy: #0000ff
+stability-stable: #008000
 static-alert-foreground: #aaaaaa
 tab-background-selected: #ffffff
 tab-background: #d8d8d8
 tab-border-selected: #d8d8d8
-tab-border: #cccccc
+tab-border: #bbbbbb
 tab-divider: #d8d8d8
 tab-foreground-selected: <<colour tab-foreground>>
 tab-foreground: #666666


### PR DESCRIPTION
- make toolbar buttons visible, 
- sidebar tabs adjusted

make sidebar buttons visible

![image](https://github.com/user-attachments/assets/a52dcd78-1cd7-4a5d-b4c7-7d9c1a7b989c)

sidebar tabs selected -> button adjustments

![image](https://github.com/user-attachments/assets/6a80b532-f1f1-47e2-b192-a0e74f83b324)
