### PR TITLE
Stringify derived fields for tiddlywiki.files

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2000,7 +2000,7 @@ $tw.loadTiddlersFromSpecification = function(filepath,excludeRegExp) {
 					var value = tiddler[name];
 					switch(fieldInfo.source) {
 						case "subdirectories":
-							value = path.relative(rootPath, filename).split(path.sep).slice(0, -1);
+							value = $tw.utils.stringifyList(path.relative(rootPath, filename).split(path.sep).slice(0, -1));
 							break;
 						case "filepath":
 							value = path.relative(rootPath, filename).split(path.sep).join('/');
@@ -2021,10 +2021,10 @@ $tw.loadTiddlersFromSpecification = function(filepath,excludeRegExp) {
 							value = path.extname(filename);
 							break;
 						case "created":
-							value = new Date(fs.statSync(pathname).birthtime);
+							value = $tw.utils.stringifyDate(new Date(fs.statSync(pathname).birthtime));
 							break;
 						case "modified":
-							value = new Date(fs.statSync(pathname).mtime);
+							value = $tw.utils.stringifyDate(new Date(fs.statSync(pathname).mtime));
 							break;
 					}
 					if(fieldInfo.prefix) {


### PR DESCRIPTION
Otherwise, when serializing the tiddlers as JSON when loading plugins, derived values may end up with the incorrect values.

Take the `modified` field for example - without stringification, it ends up as something like `new Date(2025, 3, 12, 6, 56, 23)`, which then gets serialized as `"2025-04-12T11:56:23.000Z"` (in my timezone), rather than `"20250412115623000"`.  The string `"2025-04-12T11:56:23.000Z"` trips up TiddlyWiki's date parser upon load, and it gets parsed as `20250101000000000` instead.

Fixes GH #9021