### PR TITLE
Fix a config filter in $:/AdvancedSearch (Standard)

### DIFF
--- a/core/ui/AdvancedSearch/Standard.tid
+++ b/core/ui/AdvancedSearch/Standard.tid
@@ -37,7 +37,7 @@ caption: {{$:/language/Search/Standard/Caption}}
 	inputCancelActions=<<cancel-search-actions>>
 	inputAcceptActions=<<input-accept-actions>>
 	inputAcceptVariantActions=<<input-accept-variant-actions>>
-	configTiddlerFilter="[[$:/state/search/currentTab]!is[missing]get[text]] :else[{$:/config/SearchResults/Default}]"
+	configTiddlerFilter="[[$:/state/advancedsearch/standard/currentTab]!is[missing]get[text]] :else[{$:/config/SearchResults/Default}]"
 	filterMinLength={{$:/config/Search/MinLength}}/>
 </$keyboard>
 </$keyboard>


### PR DESCRIPTION
The keyboard-driven-input takes a parameter `configTiddlerFilter` that references `$:/state/search/currentTab` where I believe it should be `$:/state/advancedsearch/standard/currentTab`. Currently, this prevents new result tabs from working correctly, as the filters from the regular search are used.