### PR TITLE
Remove links in field descriptions

### DIFF
--- a/core/language/en-GB/Fields.multids
+++ b/core/language/en-GB/Fields.multids
@@ -4,12 +4,12 @@ _canonical_uri: The full URI of an external image tiddler
 author: Name of the author of a plugin
 bag: The name of the bag from which a tiddler came
 caption: The text to be displayed on a tab or button
-class: The CSS class applied to a tiddler when rendering it - see [[Custom styles by user-class]].  Also used for [[Modals]]
+class: The CSS class applied to a tiddler when rendering it.  Also used for Modals
 code-body: The view template will display the tiddler as code if set to ''yes''
 color: The CSS color value associated with a tiddler
-component: The name of the component responsible for an [[alert tiddler|AlertMechanism]]
+component: The name of the component responsible for an alert tiddler
 core-version: For a plugin, indicates what version of TiddlyWiki with which it is compatible
-current-tiddler: Used to cache the top tiddler in a [[history list|HistoryMechanism]]
+current-tiddler: Used to cache the top tiddler in a history list
 created: The date a tiddler was created
 creator: The name of the person who created a tiddler
 dependents: For a plugin, lists the dependent plugin titles


### PR DESCRIPTION
Since field descriptions aren't wikified in control panel, the links are useless here.