### PR TITLE
Adds a PR bot to check the target branch

### DIFF
--- a/.github/workflows/pr-branch-validation.yml
+++ b/.github/workflows/pr-branch-validation.yml
@@ -1,0 +1,34 @@
+name: PR Branch-Path Validation
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]  # Trigger on PR opened, updated or reopened
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+          ref: 'master'
+          sparse-checkout: |
+            .github
+            bin/ci-pr-validation
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '22'
+
+    - name: Install dependencies
+      run: npm install @actions/core @actions/github
+
+    - name: Validate PR file paths and post comments
+      run: node bin/ci-pr-validation/validate-branch.js
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        BASE_REF: ${{ github.base_ref }}
+        REPO: ${{ github.repository }}

--- a/bin/ci-pr-validation/pr-comment-utils.js
+++ b/bin/ci-pr-validation/pr-comment-utils.js
@@ -1,0 +1,130 @@
+
+class PRCommentUtils {
+	/**
+	 * Creates an instance of PRCommentUtils.
+	 *
+	 * @param {Object} octokit - The Octokit instance to interact with GitHub API.
+	 */
+	constructor(octokit) {
+		this.octokit = octokit;
+	}
+  
+	/**
+	 * Retrieves the list of changed files in a pull request.
+	 *
+	 * @param {string} owner - The repository owner's username.
+	 * @param {string} repoName - The repository name.
+	 * @param {number} prNumber - The pull request number.
+	 * @returns {Promise<string[]>} A list of changed filenames.
+	 */
+	async getChangedFiles(owner, repoName, prNumber) {
+		const { data } = await this.octokit.rest.pulls.listFiles({
+			owner,
+			repo: repoName,
+			pull_number: prNumber,
+		});
+		
+		return data.map(file => file.filename);
+	}
+  
+	/**
+	 * Posts or updates a comment on the pull request based on a specific tag.
+	 *
+	 * @param {Object} params - The parameters for posting/updating the comment.
+	 * @param {number} params.prNumber - The pull request number.
+	 * @param {string} params.repo - The repository in the format "owner/repo".
+	 * @param {string} params.tag - The tag used to identify the comment.
+	 * @param {string} params.message - The comment body.
+	 * @returns {Promise<void>} A promise that resolves once the comment operation is complete.
+	 */
+	async postOrUpdateComment({ prNumber, repo, tag, message}) {
+		const [owner, repoName] = repo.split('/');
+
+		// Check if the comment with the specific tag already exists
+		const existingComment = await this.getExistingComment(owner, repoName, prNumber, tag);
+
+		if(existingComment) {
+			// If the comment exists, update it
+			const commentId = existingComment.id;
+			await this.updateComment(owner, repoName, prNumber, commentId, message);
+		} else {
+			// If the comment doesn't exist, post a new one
+			await this.postComment(owner, repoName, prNumber, message);
+		}
+	}
+  
+	/**
+	 * Retrieves an existing comment on a pull request based on a specific tag.
+	 *
+	 * @param {string} owner - The repository owner's username.
+	 * @param {string} repoName - The repository name.
+	 * @param {number} prNumber - The pull request number.
+	 * @param {string} tag - The tag used to identify the comment.
+	 * @returns {Promise<Object|null>} A comment object if found, or null.
+	 */
+	async getExistingComment(owner, repoName, prNumber, tag) {
+		const { data: comments } = await this.octokit.rest.issues.listComments({
+			owner,
+			repo: repoName,
+			issue_number: prNumber,
+		});
+	
+		return comments.find(comment => comment.body.startsWith(tag)) || null;
+	}
+  
+	/**
+	 * Posts a new comment on a pull request.
+	 *
+	 * @param {string} owner - The repository owner's username.
+	 * @param {string} repoName - The repository name.
+	 * @param {number} prNumber - The pull request number.
+	 * @param {string} message - The comment body.
+	 * @returns {Promise<void>} A promise that resolves once the comment is posted.
+	 */
+	async postComment(owner, repoName, prNumber, message) {
+		await this.octokit.rest.issues.createComment({
+			owner,
+			repo: repoName,
+			issue_number: prNumber,
+			body: message,
+		});
+	}
+  
+	/**
+	 * Updates an existing comment on a pull request.
+	 *
+	 * @param {string} owner - The repository owner's username.
+	 * @param {string} repoName - The repository name.
+	 * @param {number} prNumber - The pull request number.
+	 * @param {number} commentId - The comment ID to update.
+	 * @param {string} message - The updated comment body.
+	 * @returns {Promise<void>} A promise that resolves once the comment is updated.
+	 */
+	async updateComment(owner, repoName, prNumber, commentId, message) {
+		await this.octokit.rest.issues.updateComment({
+			owner,
+			repo: repoName,
+			comment_id: commentId,
+			body: message,
+		});
+	}
+  
+	/**
+	 * Deletes a comment from a pull request.
+	 *
+	 * @param {string} owner - The repository owner's username.
+	 * @param {string} repoName - The repository name.
+	 * @param {number} prNumber - The pull request number.
+	 * @param {number} commentId - The comment ID to delete.
+	 * @returns {Promise<void>} A promise that resolves once the comment is deleted.
+	 */
+	async deleteComment(owner, repoName, prNumber, commentId) {
+		await this.octokit.rest.issues.deleteComment({
+			owner,
+			repo: repoName,
+			comment_id: commentId,
+		});
+	}
+}
+
+module.exports = PRCommentUtils;

--- a/bin/ci-pr-validation/run-validate-branch.js
+++ b/bin/ci-pr-validation/run-validate-branch.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+/*
+ * For standalone use outside of Github Actions
+ *
+ * Usage:
+ * export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_yourTokenHere
+ * node run-validate-branch.js --pr 123 --repo yourname/yourrepo
+ *
+ * Requires: @octokit/rest
+ *   npm install @octokit/rest --save-dev
+*/
+
+const { execSync } = require('child_process');
+const path = require('path');
+const https = require('https');
+
+function parseArgs() {
+	const args = process.argv.slice(2);
+	const options = {};
+
+	for(let i = 0; i < args.length; i++) {
+		if(args[i].startsWith('--')) {
+			const key = args[i].slice(2);
+			const value = args[i+1];
+			options[key] = value;
+			i++;
+		}
+	}
+
+	return options;
+}
+
+function fetchPRBase(repo, prNumber, token) {
+	return new Promise((resolve, reject) => {
+		const [owner, repoName] = repo.split('/');
+		const options = {
+			hostname: 'api.github.com',
+			path: `/repos/${owner}/${repoName}/pulls/${prNumber}`,
+			method: 'GET',
+			headers: {
+				'User-Agent': 'validate-pr-cli',
+				'Authorization': `token ${token}`,
+				'Accept': 'application/vnd.github.v3+json'
+			}
+		};
+
+		const req = https.request(options, res => {
+			let data = '';
+			res.on('data', chunk => data += chunk);
+			res.on('end', () => {
+				if(res.statusCode >= 200 && res.statusCode < 300) {
+					const pr = JSON.parse(data);
+					resolve(pr.base.ref);
+				} else {
+					reject(new Error(`GitHub API responded with status ${res.statusCode}: ${data}`));
+				}
+			});
+		});
+
+		req.on('error', reject);
+		req.end();
+	});
+}
+
+(async () => {
+	const options = parseArgs();
+	const prNumber = options.pr;
+	const repo = options.repo;
+	const token = process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
+
+	if(!prNumber || !repo) {
+		console.error('❌ Usage: node run-validate-branch.js --pr <number> --repo <owner/repo>');
+		process.exit(1);
+	}
+
+	if(!token) {
+		console.error('❌ GITHUB_PERSONAL_ACCESS_TOKEN environment variable is not set.');
+		process.exit(1);
+	}
+
+	let baseRef;
+	try {
+		baseRef = await fetchPRBase(repo, prNumber, token);
+		console.log(`ℹ️  Using base branch: ${baseRef}`);
+	} catch(err) {
+		console.error('❌ Failed to fetch base branch:', err.message);
+		process.exit(1);
+	}
+
+	const scriptPath = 'validate-branch.js';
+
+	execSync(`node ${scriptPath}`, {
+		env: {
+			...process.env,
+			PR_NUMBER: prNumber,
+			REPO: repo,
+			BASE_REF: baseRef,
+			GITHUB_PERSONAL_ACCESS_TOKEN: token
+		},
+		stdio: 'inherit'
+	});
+})();

--- a/bin/ci-pr-validation/validate-branch.js
+++ b/bin/ci-pr-validation/validate-branch.js
@@ -1,0 +1,108 @@
+/**
+ * This script validates pull requests based on specific conditions:
+ * - If the PR targets the 'tiddlywiki-com' branch, it ensures all files are inside the '/editions' folder.
+ * - If the PR targets the 'master' branch, it checks if the PR only modifies documentation within the '/editions' folder.
+ * 
+ * Environment variables needed:
+ * - `GITHUB_TOKEN` (GitHub Actions only): GitHub token to authenticate with GitHub's REST API. Set as a secret in GitHub Actions.
+ * - `GITHUB_PERSONAL_ACCESS_TOKEN` (for local/standalone execution): Personal access token for GitHub API to authenticate requests.
+ * - `PR_NUMBER`: The pull request number to validate.
+ * - `REPO`: The repository in the format "owner/repo". This is used to determine which repo to validate.
+ * - `BASE_REF`: The base branch of the pull request. This can be used to check the target branch (e.g., `tiddlywiki-com` or `master`).
+ *
+ * **Usage in GitHub Actions**:
+ * - GitHub Actions automatically provides the `GITHUB_TOKEN` for authentication and passes the PR number, repository, and base ref through the workflow.
+ * 
+ * **Usage outside of GitHub Actions**:
+ * - You need to provide a GitHub Personal Access Token (`GITHUB_PERSONAL_ACCESS_TOKEN`) and set the necessary environment variables.
+ *
+ * @example
+ * // Running the script outside of GitHub Actions
+ * // 1. Create a .env file with the following content:
+ * //    GITHUB_PERSONAL_ACCESS_TOKEN=your_personal_access_token_here
+ * //    PR_NUMBER=42
+ * //    REPO=my-user/my-repo
+ * //    BASE_REF=tiddlywiki-com
+ * 
+ * // 2. Run the script in your terminal:
+ * node validate-pr.js
+ */
+
+const isGitHubActions = process.env.GITHUB_ACTIONS === 'true';
+const PRCommentUtils = require('./pr-comment-utils');
+
+const ERROR_TAG = "<!-- editions-folder-error -->";
+const WARNING_TAG = "<!-- editions-folder-warning -->";
+
+const ERROR_MESSAGE = `${ERROR_TAG}
+❌ **Error**: PRs targeting the \`tiddlywiki-com\` branch must not contain any files outside the \`/editions\` folder.`;
+
+const WARNING_MESSAGE = `${WARNING_TAG}
+⚠️ **Warning**: This PR only modifies documentation (within \`/editions\`). If the changes do not relate to the prerelease, please consider targeting the \`master\` branch instead.`;
+
+async function run() {
+	let octokit;
+	let core;
+
+	try {
+		if(isGitHubActions) {
+			core = require('@actions/core');
+			const github = require('@actions/github');
+			octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+		} else {
+			const { Octokit } = await import('@octokit/rest');
+			const token = process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
+			octokit = new Octokit({ auth: token });
+		}
+
+		const prNumber = parseInt(process.env.PR_NUMBER, 10);
+		const repo = process.env.REPO;
+		const baseRef = process.env.BASE_REF;
+		const [owner, repoName] = repo.split('/');
+
+		const utils = new PRCommentUtils(octokit);
+		const changedFiles = await utils.getChangedFiles(owner, repoName, prNumber);
+
+		let messageToPost = '';
+
+		// Skip PRs that only modify a license file
+		if(changedFiles.length === 1 && changedFiles[0].startsWith("licenses/")) {
+			return;
+		}
+
+		if(baseRef === 'tiddlywiki-com') {
+			const allInEditions = changedFiles.every(file => file.startsWith('editions/'));
+			if(!allInEditions) {
+				messageToPost = ERROR_MESSAGE;
+			}
+		} else if(baseRef === 'master') {
+			const allInEditions = changedFiles.every(file => file.startsWith('editions/'));
+			if(allInEditions) {
+				messageToPost = WARNING_MESSAGE;
+			}
+		}
+
+		const existingError = await utils.getExistingComment(owner, repoName, prNumber, ERROR_TAG);
+		if(existingError) {
+			await utils.deleteComment(owner, repoName, prNumber, existingError.id);
+		}
+
+		const existingWarning = await utils.getExistingComment(owner, repoName, prNumber, WARNING_TAG);
+		if(existingWarning) {
+			await utils.deleteComment(owner, repoName, prNumber, existingWarning.id);
+		}
+
+		if(messageToPost) {
+			await utils.postComment(owner, repoName, prNumber, messageToPost);
+		}
+	} catch (err) {
+		if (core) {
+			core.setFailed(`Action failed: ${err.message}`);
+		} else {
+			console.error(`Validation failed: ${err.message}`);
+			process.exit(1);
+		}
+	}
+}
+
+run();


### PR DESCRIPTION
This PR implements a workflow that checks the paths of files modified in a PR and where appropriate, comments on the PR to provide direction to contributors. 

By design, the bulk of the logic is an external JavaScript file which should help with maintenance and makes it easier to extend to cover other scenarios.

**Current logic:**
* If the target branch is `tiddlywiki-com`, verify that every file included in the PR is within the `/editions` folder. If there are any files outside this folder then add an error message to the PR "Error: PRs targeting the 'tiddlywiki-com' branch must not contain any files outside the `/editions` folder"
* If the target branch is `master`, check whether every file included in the PR is within the `/editions` folder. If all the files are within this folder then add a warning message "It looks like this PR comprises only documentation. If these changes do not specifically relate to the prerelease then this PR should target the 'master' branch"

Fixes #9041 

In the longer run to facilitate maintenance we should consider refactoring this into a GitHub action in a separate repo.

**⚠️❗After merging this PR, the `tiddlywiki-com` branch needs to be merged into `master` to ensure that the workflows and associated scripts are available in both branches.**