### PR TITLE
Adds a custom action to check the target branch

### DIFF
--- a/.github/workflows/pr-path-validation.yml
+++ b/.github/workflows/pr-path-validation.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Validate PR
-      uses: TiddlyWiki/cerebrus@v1
+      uses: TiddlyWiki/cerebrus@v2
       with:
         pr_number: ${{ github.event.pull_request.number }}
         repo: ${{ github.repository }}

--- a/.github/workflows/pr-path-validation.yml
+++ b/.github/workflows/pr-path-validation.yml
@@ -1,0 +1,18 @@
+name: Validate PR Paths
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Validate PR
+      uses: saqimtiaz/cerebrus@v1
+      with:
+        pr_number: ${{ github.event.pull_request.number }}
+        repo: ${{ github.repository }}
+        base_ref: ${{ github.base_ref }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-path-validation.yml
+++ b/.github/workflows/pr-path-validation.yml
@@ -1,7 +1,7 @@
 name: Validate PR Paths
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 jobs:

--- a/.github/workflows/pr-path-validation.yml
+++ b/.github/workflows/pr-path-validation.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Validate PR
-      uses: saqimtiaz/cerebrus@v1
+      uses: TiddlyWiki/cerebrus@v1
       with:
         pr_number: ${{ github.event.pull_request.number }}
         repo: ${{ github.repository }}


### PR DESCRIPTION
This is an alternative to #9044. The benefit of this approach is that the actual code lives in https://github.com/saqimtiaz/cerebrus as a custom action, and we use a **pinned version** of that action in a workflow in this repo. We can also move that repository to the TiddlyWiki organization if so desirable.

 This separate repo makes it easier to further develop and bugfix the code by allowing us to install the same action on a fork of the TiddlyWiki5 repository for testing, and updating the pinned version here when a new stable version is available.

**Current logic:**
* If the target branch is `tiddlywiki-com`, verify that every file included in the PR is within the `/editions` folder. If there are any files outside this folder then add an error message to the PR "Error: PRs targeting the 'tiddlywiki-com' branch must not contain any files outside the `/editions` folder"
* If the target branch is `master`, check whether every file included in the PR is within the `/editions` folder. If all the files are within this folder then add a warning message "It looks like this PR comprises only documentation. If these changes do not specifically relate to the prerelease then this PR should target the 'master' branch"

Fixes #9041 

**⚠️❗After merging this PR, the `tiddlywiki-com` branch needs to be merged into `master` to ensure that the workflows are available in both branches.**