### PR TITLE
Uses v3 of cerebrus that also posts a build size report to PRs

### DIFF
--- a/.github/workflows/pr-check-build-size.yml
+++ b/.github/workflows/pr-check-build-size.yml
@@ -1,18 +1,18 @@
-name: Validate PR Paths
-
+name: Calculate PR build size
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 
 jobs:
-  validate-pr:
+  calculate-build-size:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Validate PR
-      uses: TiddlyWiki/cerebrus@v3
+    - name: Build and check size
+      uses: saqimtiaz/cerebrus@v3
       with:
         pr_number: ${{ github.event.pull_request.number }}
         repo: ${{ github.repository }}
         base_ref: ${{ github.base_ref }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        mode: size:calc

--- a/.github/workflows/pr-comment-build-size.yml
+++ b/.github/workflows/pr-comment-build-size.yml
@@ -1,0 +1,23 @@
+name: Comment on PR build size (Trusted workflow)
+
+on:
+  repository_dispatch:
+    types: [pr_build_size_report]
+
+jobs:
+  comment-build-size-on-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+    - name: Build and check size
+      uses: TiddlyWiki/cerebrus@v3
+      with:
+        pr_number: ${{ github.event.client_payload.pr_number }}
+        repo: ${{ github.repository }}
+        base_ref: ${{ github.event.client_payload.base_branch }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        mode: size:comment
+        pr_size: ${{ github.event.client_payload.pr_size }}
+        base_size: ${{ github.event.client_payload.base_size }}


### PR DESCRIPTION
This PR updates the cerebrus action to v3 which now supports building empty.html from PRs and comparing the size to empty.html from the merge-base commit. 

To enable this, two more workflows are added:
1. a pull_request workflow with no write permission to trigger the building and size calculation,  dispatching a request to trigger the next workflow.
2. a respository_dispatch workflow receives and sanitizes the receieved input and then posts a PR build size report to the PR in question.

Note the improvements in cerebrus intentionally forego using a bash script in favour of javascript to facilitate better sanitation and validation of inputs.

Preview:
![image](https://github.com/user-attachments/assets/b9af2d62-8169-43a2-8c0f-4e556dbf154c)

**⚠️❗After merging this PR, the `tiddlywiki-com` branch needs to be merged into `master` to ensure that the workflows are available in both branches.**