### PR TITLE
Resolves permissions issues in workflow to check PR build size

### DIFF
--- a/.github/workflows/pr-check-build-size.yml
+++ b/.github/workflows/pr-check-build-size.yml
@@ -1,18 +1,18 @@
-name: Validate PR Paths
-
+name: Calculate PR build size
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 
 jobs:
-  validate-pr:
+  calculate-build-size:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Validate PR
-      uses: TiddlyWiki/cerebrus@v3
+    - name: Build and check size
+      uses: saqimtiaz/cerebrus@v3
       with:
         pr_number: ${{ github.event.pull_request.number }}
         repo: ${{ github.repository }}
         base_ref: ${{ github.base_ref }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        mode: size:calc

--- a/.github/workflows/pr-check-build-size.yml
+++ b/.github/workflows/pr-check-build-size.yml
@@ -1,18 +1,50 @@
 name: Calculate PR build size
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 jobs:
   calculate-build-size:
     runs-on: ubuntu-latest
-
+    permissions:
+      pull-requests: read
+      contents: read
+    outputs:
+      pr_size: ${{ steps.get_sizes.outputs.pr_size }}
+      base_size: ${{ steps.get_sizes.outputs.base_size }}
     steps:
-    - name: Build and check size
-      uses: saqimtiaz/cerebrus@v3
+    - name: build-size-check
+      id: get_sizes
+      uses: TiddlyWiki/cerebrus@v4
       with:
         pr_number: ${{ github.event.pull_request.number }}
         repo: ${{ github.repository }}
         base_ref: ${{ github.base_ref }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
         mode: size:calc
+
+  dispatch-followup:
+    needs: calculate-build-size
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write  # Required to dispatch another workflow
+      pull-requests: write
+      contents: read
+    steps:
+    - name: Trigger follow-up workflow
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          await github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'pr-comment-build-size.yml',
+            ref: 'master',
+            inputs: {
+              pr_number: '${{ github.event.pull_request.number }}',
+              base_ref: '${{ github.event.pull_request.base.ref }}',
+              pr_size: '${{ needs.calculate-build-size.outputs.pr_size }}',
+              base_size: '${{ needs.calculate-build-size.outputs.base_size }}'
+            }
+          });

--- a/.github/workflows/pr-comment-build-size.yml
+++ b/.github/workflows/pr-comment-build-size.yml
@@ -1,0 +1,23 @@
+name: Comment on PR build size (Trusted workflow)
+
+on:
+  repository_dispatch:
+    types: [pr_build_size_report]
+
+jobs:
+  comment-build-size-on-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+    - name: Build and check size
+      uses: TiddlyWiki/cerebrus@v3
+      with:
+        pr_number: ${{ github.event.client_payload.pr_number }}
+        repo: ${{ github.repository }}
+        base_ref: ${{ github.event.client_payload.base_branch }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        mode: size:comment
+        pr_size: ${{ github.event.client_payload.pr_size }}
+        base_size: ${{ github.event.client_payload.base_size }}

--- a/.github/workflows/pr-comment-build-size.yml
+++ b/.github/workflows/pr-comment-build-size.yml
@@ -1,23 +1,36 @@
 name: Comment on PR build size (Trusted workflow)
 
 on:
-  repository_dispatch:
-    types: [pr_build_size_report]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        required: true
+        type: string
+      base_ref:
+        required: true
+        type: string
+      pr_size:
+        required: true
+        type: string
+      base_size:
+        required: true
+        type: string
 
 jobs:
-  comment-build-size-on-pr:
+  comment-on-pr:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: read
 
     steps:
     - name: Build and check size
-      uses: TiddlyWiki/cerebrus@v3
+      uses: TiddlyWiki/cerebrus@v4
       with:
-        pr_number: ${{ github.event.client_payload.pr_number }}
+        pr_number: ${{ inputs.pr_number }}
         repo: ${{ github.repository }}
-        base_ref: ${{ github.event.client_payload.base_branch }}
+        base_ref: ${{ inputs.base_ref }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
         mode: size:comment
-        pr_size: ${{ github.event.client_payload.pr_size }}
-        base_size: ${{ github.event.client_payload.base_size }}
+        pr_size: ${{ inputs.pr_size }}
+        base_size: ${{ inputs.base_size }}

--- a/.github/workflows/pr-path-validation.yml
+++ b/.github/workflows/pr-path-validation.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Validate PR
-      uses: TiddlyWiki/cerebrus@v3
+      uses: TiddlyWiki/cerebrus@v4
       with:
         pr_number: ${{ github.event.pull_request.number }}
         repo: ${{ github.repository }}


### PR DESCRIPTION
This PR resolves permissions issues when the workflow for checking the build size of a PR is triggered from a fork, while following best practices in terms of security.

**⚠️❗After merging this PR, the `tiddlywiki-com` branch needs to be merged into `master` to ensure that the workflows are available in both branches.**