### PR TITLE
Minor improvement to filter code

### DIFF
--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -248,8 +248,7 @@ exports.compileFilter = function(filterString) {
 		// Create a function for the chain of operators in the operation
 		var operationSubFunction = function(source,widget) {
 			var accumulator = source,
-				results = [],
-				currTiddlerTitle = widget && widget.getVariable("currentTiddler");
+				results = [];
 			$tw.utils.each(operation.operators,function(operator) {
 				var operands = [],
 					operatorFunction;
@@ -265,6 +264,7 @@ exports.compileFilter = function(filterString) {
 				}
 				$tw.utils.each(operator.operands,function(operand) {
 					if(operand.indirect) {
+						var currTiddlerTitle = widget && widget.getVariable("currentTiddler");
 						operand.value = self.getTextReference(operand.text,"",currTiddlerTitle);
 					} else if(operand.variable) {
 						var varTree = $tw.utils.parseFilterVariable(operand.text);

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -1139,6 +1139,15 @@ Tests the filtering mechanism.
 			// Non string properties should get toStringed.
 			expect(wiki.filterTiddlers("[[$:/core/modules/commands/init.js]moduleproperty[info]]").join(" ")).toBe('{"name":"init","synchronous":true}');
 		});
+
+		it("should minimize unnecessary variable lookup", function() {
+			var widget = wiki.makeWidget();
+			var getVar = spyOn(widget, "getVariableInfo").and.callThrough();
+			expect(wiki.filterTiddlers("[all[]prefix[anything]]", widget).length).toBe(0);
+			// We didn't use any indirect operands or variables.
+			// No variable lookup should have occurred.
+			expect(getVar).not.toHaveBeenCalled();
+		});
 	}
 	
 	});


### PR DESCRIPTION
This is the improvement no one asked for but me.

This fixes how the filter run code fetches the `currentTiddler` variable, even if it doesn't need it. Why?

For my TW5-graph plugin, I'm making a filterrunprefix `:cache[]`, which can cache generating filter runs. It'll be pretty clutch for some larger graphs. But it needs to keep track of what variables its runs call, because obviously different combinations of variables can have different outputs.

But it can't work very well if ALL filter runs call `currentTiddler` just for funsies. the cache would have to assume every filter call in my large, tight loops might have different results even if currentTiddler isn't actually used.

This fix *might* make my cache possible, but even if I hit another wall, this improvement...

1. Makes the code slightly simpler to understand
2. Slightly more efficient. Turns out, preloading currentTiddler like that only improved performance if a filter run had multiple indirect references, which basically never happens in core. But what happens very often is that they have NO indirect references. For instance, here are call counts up the widget stack for exploring all of tw5.com's sidebar tabs:
   * Without this improvement: 37,244 calls
   * With this improvement: 26,294 calls 

Will this result in noticeable improvement to runtime? No, but it will make me happy. And I stand by it that this code is actually easier to read now.