### PR TITLE
Dynamic parameters for macro/procedure/function calls

### DIFF
--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -214,7 +214,7 @@ exports.parseMacroInvocationAsTransclusion = function(source,pos) {
 			orderedAttributes: []
 		};
 	// Define our regexps
-	var reVarName = /([a-zA-Z0-9\-\$\._<]+)/g;
+	var reVarName = /([^\s>"'=:]+)/g;
 	// Skip whitespace
 	pos = $tw.utils.skipWhiteSpace(source,pos);
 	// Look for a double opening angle bracket
@@ -260,6 +260,7 @@ exports.parseMacroParametersAsAttributes = function(node,source,pos) {
 	while(attribute) {
 		if(!attribute.name) {
 			attribute.name = (position++) + "";
+			attribute.isPositional = true;
 		}
 		node.orderedAttributes.push(attribute);
 		node.attributes[attribute.name] = attribute;
@@ -485,7 +486,7 @@ exports.parseAttribute = function(source,pos) {
 						node.value = unquotedValue.match[1];
 					} else {
 						// Look for a macro invocation value
-						var macroInvocation = $tw.utils.parseMacroInvocation(source,pos);
+						var macroInvocation = $tw.utils.parseMacroInvocationAsTransclusion(source,pos);
 						if(macroInvocation) {
 							pos = macroInvocation.end;
 							node.type = "macro";

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -374,7 +374,21 @@ Widget.prototype.computeAttribute = function(attribute) {
 	} else if(attribute.type === "indirect") {
 		value = this.wiki.getTextReference(attribute.textReference,"",this.getVariable("currentTiddler")) || "";
 	} else if(attribute.type === "macro") {
-		var variableInfo = this.getVariableInfo(attribute.value.name,{params: attribute.value.params});
+		// Get the macro name
+		var macroName = attribute.value.attributes["$variable"].value;
+		// Collect macro parameters
+		var params = [];
+		$tw.utils.each(attribute.value.orderedAttributes,function(attr) {
+			var param = {
+				value: self.computeAttribute(attr)
+			};
+			if(attr.name && !attr.isPositional) {
+				param.name = attr.name;
+			}
+			params.push(param);
+		});
+		// Invoke the macro
+		var variableInfo = this.getVariableInfo(macroName,{params: params});
 		value = variableInfo.text;
 	} else if(attribute.type === "substituted") {
 		value = this.wiki.getSubstitutedText(attribute.rawValue,this) || "";

--- a/editions/prerelease/tiddlers/system/DefaultTiddlers.tid
+++ b/editions/prerelease/tiddlers/system/DefaultTiddlers.tid
@@ -2,11 +2,4 @@ created: 20131127215321439
 modified: 20140912135951542
 title: $:/DefaultTiddlers
 
-[[TiddlyWiki Pre-release]]
-HelloThere
-[[Quick Start]]
-[[Find Out More]]
-[[TiddlyWiki on the Web]]
-[[Testimonials and Reviews]]
-GettingStarted
-Community
+[[Improvements to Macro Calls in v5.4.0]]

--- a/editions/test/tiddlers/tests/data/macros/dynamic-macros/Attribute.tid
+++ b/editions/test/tiddlers/tests/data/macros/dynamic-macros/Attribute.tid
@@ -1,0 +1,34 @@
+title: Macros/Dynamic/Attribute
+description: Attribute macrocall with dynamic paramters
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define mamacromamacro(param:"red")
+It is $param$
+\end
+
+<$text text=<<mamacromamacro>>/>
+-
+<$text text=<<mamacromamacro param:{{{ [[a]addprefix[b]] }}}>>/>
+-
+<$text text=<<mamacromamacro param={{{ [[b]addprefix[a]] }}}>>/>
+-
+<$text text=<<mamacromamacro {{{ [[b]addprefix[a]] }}}>>/>
+-
+<$text text=<<mamacromamacro param>>/>
+
++
+title: ExpectedResult
+
+<p>It is red
+-
+It is ba
+-
+It is ab
+-
+It is ab
+-
+It is param
+</p>

--- a/editions/test/tiddlers/tests/data/macros/dynamic-macros/Standalone.tid
+++ b/editions/test/tiddlers/tests/data/macros/dynamic-macros/Standalone.tid
@@ -1,0 +1,26 @@
+title: Macros/Dynamic/Standalone
+description: Standalone macrocall with dynamic paramters
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+
+\define mamacro(one:"red",two:"green")
+It is $one$ and $two$ or <<__one__>> and <<__two__>>.
+\end
+
+<<mamacro>>
+
+<<mamacro one:{{{ [[a]addprefix[b]] }}}>>
+
+<<mamacro one={{{ [[b]addprefix[a]] }}}>>
+
+<<mamacro {{{ [[b]addprefix[a]] }}}>>
+
+<<mamacro one>>
++
+title: ExpectedResult
+
+<p>It is red and green or red and green.</p><p>It is ba and green or ba and green.</p><p>It is ab and green or ab and green.</p><p>It is ab and green or ab and green.</p><p>It is one and green or one and green.</p>

--- a/editions/test/tiddlers/tests/test-html-parser.js
+++ b/editions/test/tiddlers/tests/test-html-parser.js
@@ -204,11 +204,283 @@ describe("HTML tag new parser tests", function() {
 		expect(parser.parseTag("< $mytag attrib1='something' attrib2=else thing>",0)).toEqual(
 			null
 		);
-		expect(parser.parseTag("<$mytag attrib3=<<myMacro one:two three:'four and five'>>>",0)).toEqual(
-			{ type : 'mytag', start : 0, attributes : { attrib3 : { type : 'macro', start : 7, name : 'attrib3', value : { type : 'macrocall', start : 16, params : [ { type : 'macro-parameter', start : 25, value : 'two', name : 'one', end : 33 }, { type : 'macro-parameter', start : 33, value : 'four and five', name : 'three', end : 55 } ], name : 'myMacro', end : 57 }, end : 57 } }, orderedAttributes: [ { type : 'macro', start : 7, name : 'attrib3', value : { type : 'macrocall', start : 16, params : [ { type : 'macro-parameter', start : 25, value : 'two', name : 'one', end : 33 }, { type : 'macro-parameter', start : 33, value : 'four and five', name : 'three', end : 55 } ], name : 'myMacro', end : 57 }, end : 57 } ], tag : '$mytag', end : 58 }
+		expect(parser.parseTag("<$mytag attrib3=<<myMacro one:two three:'four and five'>>>", 0)).toEqual(
+			{
+				"type": "mytag",
+				"start": 0,
+				"attributes": {
+					"attrib3": {
+						"start": 7,
+						"name": "attrib3",
+						"type": "macro",
+						"value": {
+							"type": "transclude",
+							"start": 16,
+							"attributes": {
+								"$variable": {
+									"name": "$variable",
+									"type": "string",
+									"value": "myMacro"
+								},
+								"one": {
+									"start": 25,
+									"name": "one",
+									"type": "string",
+									"value": "two",
+									"end": 33
+								},
+								"three": {
+									"start": 33,
+									"name": "three",
+									"type": "string",
+									"value": "four and five",
+									"end": 55
+								}
+							},
+							"orderedAttributes": [
+								{
+									"name": "$variable",
+									"type": "string",
+									"value": "myMacro"
+								},
+								{
+									"start": 25,
+									"name": "one",
+									"type": "string",
+									"value": "two",
+									"end": 33
+								},
+								{
+									"start": 33,
+									"name": "three",
+									"type": "string",
+									"value": "four and five",
+									"end": 55
+								}
+							],
+							"end": 57
+						},
+						"end": 57
+					}
+				},
+				"orderedAttributes": [
+					{
+						"start": 7,
+						"name": "attrib3",
+						"type": "macro",
+						"value": {
+							"type": "transclude",
+							"start": 16,
+							"attributes": {
+								"$variable": {
+									"name": "$variable",
+									"type": "string",
+									"value": "myMacro"
+								},
+								"one": {
+									"start": 25,
+									"name": "one",
+									"type": "string",
+									"value": "two",
+									"end": 33
+								},
+								"three": {
+									"start": 33,
+									"name": "three",
+									"type": "string",
+									"value": "four and five",
+									"end": 55
+								}
+							},
+							"orderedAttributes": [
+								{
+									"name": "$variable",
+									"type": "string",
+									"value": "myMacro"
+								},
+								{
+									"start": 25,
+									"name": "one",
+									"type": "string",
+									"value": "two",
+									"end": 33
+								},
+								{
+									"start": 33,
+									"name": "three",
+									"type": "string",
+									"value": "four and five",
+									"end": 55
+								}
+							],
+							"end": 57
+						},
+						"end": 57
+					}
+				],
+				"tag": "$mytag",
+				"end": 58
+			}
 		);
 		expect(parser.parseTag("<$mytag attrib1='something' attrib2=else thing attrib3=<<myMacro one:two three:'four and five'>>>",0)).toEqual(
-			{ type : 'mytag', start : 0, attributes : { attrib1 : { type : 'string', start : 7, name : 'attrib1', value : 'something', end : 27 }, attrib2 : { type : 'string', start : 27, name : 'attrib2', value : 'else', end : 40 }, thing : { type : 'string', start : 40, name : 'thing', value : 'true', end : 47 }, attrib3 : { type : 'macro', start : 47, name : 'attrib3', value : { type : 'macrocall', start : 55, params : [ { type : 'macro-parameter', start : 64, value : 'two', name : 'one', end : 72 }, { type : 'macro-parameter', start : 72, value : 'four and five', name : 'three', end : 94 } ], name : 'myMacro', end : 96 }, end : 96 } }, orderedAttributes: [ { type : 'string', start : 7, name : 'attrib1', value : 'something', end : 27 }, { type : 'string', start : 27, name : 'attrib2', value : 'else', end : 40 }, { type : 'string', start : 40, name : 'thing', value : 'true', end : 47 }, { type : 'macro', start : 47, name : 'attrib3', value : { type : 'macrocall', start : 55, params : [ { type : 'macro-parameter', start : 64, value : 'two', name : 'one', end : 72 }, { type : 'macro-parameter', start : 72, value : 'four and five', name : 'three', end : 94 } ], name : 'myMacro', end : 96 }, end : 96 } ], tag : '$mytag', end : 97 }
+			{
+				"type": "mytag",
+				"start": 0,
+				"attributes": {
+					"attrib1": {
+						"start": 7,
+						"name": "attrib1",
+						"type": "string",
+						"value": "something",
+						"end": 27
+					},
+					"attrib2": {
+						"start": 27,
+						"name": "attrib2",
+						"type": "string",
+						"value": "else",
+						"end": 40
+					},
+					"thing": {
+						"start": 40,
+						"name": "thing",
+						"type": "string",
+						"value": "true",
+						"end": 47
+					},
+					"attrib3": {
+						"start": 47,
+						"name": "attrib3",
+						"type": "macro",
+						"value": {
+							"type": "transclude",
+							"start": 55,
+							"attributes": {
+								"$variable": {
+									"name": "$variable",
+									"type": "string",
+									"value": "myMacro"
+								},
+								"one": {
+									"start": 64,
+									"name": "one",
+									"type": "string",
+									"value": "two",
+									"end": 72
+								},
+								"three": {
+									"start": 72,
+									"name": "three",
+									"type": "string",
+									"value": "four and five",
+									"end": 94
+								}
+							},
+							"orderedAttributes": [
+								{
+									"name": "$variable",
+									"type": "string",
+									"value": "myMacro"
+								},
+								{
+									"start": 64,
+									"name": "one",
+									"type": "string",
+									"value": "two",
+									"end": 72
+								},
+								{
+									"start": 72,
+									"name": "three",
+									"type": "string",
+									"value": "four and five",
+									"end": 94
+								}
+							],
+							"end": 96
+						},
+						"end": 96
+					}
+				},
+				"orderedAttributes": [
+					{
+						"start": 7,
+						"name": "attrib1",
+						"type": "string",
+						"value": "something",
+						"end": 27
+					},
+					{
+						"start": 27,
+						"name": "attrib2",
+						"type": "string",
+						"value": "else",
+						"end": 40
+					},
+					{
+						"start": 40,
+						"name": "thing",
+						"type": "string",
+						"value": "true",
+						"end": 47
+					},
+					{
+						"start": 47,
+						"name": "attrib3",
+						"type": "macro",
+						"value": {
+							"type": "transclude",
+							"start": 55,
+							"attributes": {
+								"$variable": {
+									"name": "$variable",
+									"type": "string",
+									"value": "myMacro"
+								},
+								"one": {
+									"start": 64,
+									"name": "one",
+									"type": "string",
+									"value": "two",
+									"end": 72
+								},
+								"three": {
+									"start": 72,
+									"name": "three",
+									"type": "string",
+									"value": "four and five",
+									"end": 94
+								}
+							},
+							"orderedAttributes": [
+								{
+									"name": "$variable",
+									"type": "string",
+									"value": "myMacro"
+								},
+								{
+									"start": 64,
+									"name": "one",
+									"type": "string",
+									"value": "two",
+									"end": 72
+								},
+								{
+									"start": 72,
+									"name": "three",
+									"type": "string",
+									"value": "four and five",
+									"end": 94
+								}
+							],
+							"end": 96
+						},
+						"end": 96
+					}
+				],
+				"tag": "$mytag",
+				"end": 97
+			}
 		);
 	});
 

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -281,23 +281,23 @@ describe("WikiText parser tests", function() {
 	it("should parse tricky macrocall parameters", function() {
 		expect(parse("<<john pa>am>>")).toEqual(
 
-			[{"type":"transclude","start":0,"end":14,"attributes":{"0":{"name":"0","type":"string","value":"pa>am","start":6,"end":12},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"pa>am","start":6,"end":12}],"isBlock":true,"rule":"macrocallblock"}]
+			[{"type":"transclude","start":0,"end":14,"attributes":{"0":{"name":"0","type":"string","value":"pa>am","start":6,"end":12,"isPositional":true},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"pa>am","start":6,"end":12,"isPositional":true}],"isBlock":true,"rule":"macrocallblock"}]
 
 		);
 		expect(parse("<<john param> >>")).toEqual(
 
-			[{"type":"transclude","start":0,"end":16,"attributes":{"0":{"name":"0","type":"string","value":"param>","start":6,"end":13},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"param>","start":6,"end":13}],"isBlock":true,"rule":"macrocallblock"}]
+			[{"type":"transclude","start":0,"end":16,"attributes":{"0":{"name":"0","type":"string","value":"param>","start":6,"end":13,"isPositional":true},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"param>","start":6,"end":13,"isPositional":true}],"isBlock":true,"rule":"macrocallblock"}]
 
 		);
 		expect(parse("<<john param>>>")).toEqual(
 
-			[{"type":"element","tag":"p","children":[{"type":"transclude","start":0,"end":14,"rule":"macrocallinline","attributes":{"0":{"name":"0","type":"string","value":"param","start":6,"end":12},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"param","start":6,"end":12}]},{"type":"text","text":">","start":14,"end":15}],"start":0,"end":15}]
+			[{"type":"element","tag":"p","children":[{"type":"transclude","start":0,"end":14,"rule":"macrocallinline","attributes":{"0":{"name":"0","type":"string","value":"param","start":6,"end":12,"isPositional":true},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"param","start":6,"end":12,"isPositional":true}]},{"type":"text","text":">","start":14,"end":15}],"start":0,"end":15}]
 
 		);
 		// equals signs should be allowed
 		expect(parse("<<john var>=4 >>")).toEqual(
 
-			[{"type":"transclude","start":0,"end":16,"attributes":{"0":{"name":"0","type":"string","value":"var>=4","start":6,"end":13},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"var>=4","start":6,"end":13}],"isBlock":true,"rule":"macrocallblock"}]
+			[{"type":"transclude","start":0,"end":16,"attributes":{"0":{"name":"0","type":"string","value":"var>=4","start":6,"end":13,"isPositional":true},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"var>=4","start":6,"end":13,"isPositional":true}],"isBlock":true,"rule":"macrocallblock"}]
 
 		);
 

--- a/editions/tw5.com/tiddlers/system/DefaultTiddlers.tid
+++ b/editions/tw5.com/tiddlers/system/DefaultTiddlers.tid
@@ -3,10 +3,4 @@ modified: 20140912135951542
 title: $:/DefaultTiddlers
 type: text/vnd.tiddlywiki
 
-HelloThere
-[[Quick Start]]
-[[Find Out More]]
-[[TiddlyWiki on the Web]]
-[[Testimonials and Reviews]]
-GettingStarted
-Community
+[[Improvements to Macro Calls in v5.4.0]]

--- a/editions/tw5.com/tiddlers/v5.4.0/Improvements to Macro Calls.tid
+++ b/editions/tw5.com/tiddlers/v5.4.0/Improvements to Macro Calls.tid
@@ -1,0 +1,34 @@
+title: Improvements to Macro Calls in v5.4.0
+tags: v5.4.0
+
+<$macrocall $name='wikitext-example-without-html'
+src="""\define testmacro(one)
+Result: $one$.
+\end testmacro
+
+<<testmacro one:{{{ [[There]addprefix[Hello]] }}}>>
+"""/>
+
+<$macrocall $name='wikitext-example-without-html'
+src="""\function testfunction(one)
+[<one>addprefix[Hello]]
+\end testfunction
+
+<<testfunction one:{{{ [[re]addprefix[The]] }}}>>
+"""/>
+
+<$macrocall $name='wikitext-example-without-html'
+src="""\define testmacro(one)
+Result: $one$.
+\end testmacro
+
+<$text text=<<testmacro one:{{{ [[There]addprefix[Hello]] }}}>>/>
+"""/>
+
+<$macrocall $name='wikitext-example-without-html'
+src="""\function testfunction(one)
+[<one>addprefix[Hello]]
+\end testfunction
+
+<$text text=<<testfunction one:{{{ [[re]addprefix[The]] }}}>>/>
+"""/>

--- a/editions/tw5.com/tiddlers/v5.4.0/Improvements to Macro Calls.tid
+++ b/editions/tw5.com/tiddlers/v5.4.0/Improvements to Macro Calls.tid
@@ -6,7 +6,7 @@ src="""\define testmacro(one)
 Result: $one$.
 \end testmacro
 
-<<testmacro one:{{{ [[There]addprefix[Hello]] }}}>>
+<<testmacro one={{{ [[There]addprefix[Hello]] }}}>>
 """/>
 
 <$macrocall $name='wikitext-example-without-html'
@@ -14,7 +14,7 @@ src="""\function testfunction(one)
 [<one>addprefix[Hello]]
 \end testfunction
 
-<<testfunction one:{{{ [[re]addprefix[The]] }}}>>
+<<testfunction one={{{ [[re]addprefix[The]] }}}>>
 """/>
 
 <$macrocall $name='wikitext-example-without-html'
@@ -22,7 +22,7 @@ src="""\define testmacro(one)
 Result: $one$.
 \end testmacro
 
-<$text text=<<testmacro one:{{{ [[There]addprefix[Hello]] }}}>>/>
+<$text text=<<testmacro one={{{ [[There]addprefix[Hello]] }}}>>/>
 """/>
 
 <$macrocall $name='wikitext-example-without-html'
@@ -30,5 +30,5 @@ src="""\function testfunction(one)
 [<one>addprefix[Hello]]
 \end testfunction
 
-<$text text=<<testfunction one:{{{ [[re]addprefix[The]] }}}>>/>
+<$text text=<<testfunction one={{{ [[re]addprefix[The]] }}}>>/>
 """/>


### PR DESCRIPTION
# Introduction

This PR makes an important change to the handling of macro calls by finally allowing parameters to be specified as dynamic transclusions instead of just constant strings.

In other words, by changing the usual colon into an equals sign it is now possible to do things like this:

```
<<mymacro param={{Something}}>>
```

Or even this:

```
<div class=<<mymacro param={{Something}}>>>
```

Not to mention this:

```
<div class=<<mymacro param={{{ [<myvar>addprefix[https:] }}}>>>
```

We can even specify parameters for the inner call:

```
<div class=<<mymacro param={{{ [<innermacro p={{Something}}>addprefix[https:] }}}>>>
```

I am pleased about this change for obvious reasons: it removes a long-standing irregularity from TiddlyWiki's syntax, and it adds flexibility and expressiveness that will be appreciated by all wikitext authors.

The reason I am embarrassed is that it has taken so long to address this issue, particularly as it has turned out that the implementation is not enormously complex. In mitigation the changes in v5.3.0 laid a lot of the groundwork for this change.

# Background
In fact, "macro calls" has become an increasingly ill-fitting term since v5.3.0 when the same syntax was extended to allow it to be used to invoke functions and procedures. I propose we use the term "call" to refer generally to all three formulations, and "macro call", "procedure call" and "function call" for the specific variants.

The call syntax can be used in three different settings:

* As a standalone construction
* As a widget attribute value
* As a filter operand value

In all cases, it is now possible to use an equals sign instead of a colon to allow parameter values to be passed as a transclusion, filter expression or nested call.

# Backwards Compatibility
The backwards compatibility issues with this change are fairly extreme edge cases. In particular, previously a construction like this would have been interpreted as an unquoted parameter with the value "name=background":

```
<<mymacro name=background>>
```

So, this change will break code that invokes a macro with an unquoted parameter that contains an equals sign. There is no restriction on parameters with double or single quotes.

# Progress
This PR is not yet complete:

- [ ] Enforcing new syntax to only work with equals signs (currently equals and colon are considered equivalent)
- [ ] Calls within filters
- [ ] Documentation
- [x] Calls as attribute values
- [x] Standalone calls

# Idea: Block Parameters
I have been toying with the idea of further extending the call syntax to allow blocks to be passed (which would be $fill widgets under the covers). This would allow for things like an inline version of the tabs macro:

```
<<inline-tabs mode="vertical"
:> Help
Some useful and interesting content, including wikitext like <<now>>
:> About
More useful and interesting information.
>>
```
