### PR TITLE
Fix duplicated code introduced with PR #7596

### DIFF
--- a/core/modules/widgets/list.js
+++ b/core/modules/widgets/list.js
@@ -519,36 +519,3 @@ ListJoinWidget.prototype.render = function() {}
 ListJoinWidget.prototype.refresh = function() { return false; }
 
 exports["list-join"] = ListJoinWidget;
-
-/*
-Make <$list-template> and <$list-empty> widgets that do nothing
-*/
-var ListTemplateWidget = function(parseTreeNode,options) {
-	// Main initialisation inherited from widget.js
-	this.initialise(parseTreeNode,options);
-};
-ListTemplateWidget.prototype = new Widget();
-ListTemplateWidget.prototype.render = function() {}
-ListTemplateWidget.prototype.refresh = function() { return false; }
-
-exports["list-template"] = ListTemplateWidget;
-
-var ListEmptyWidget = function(parseTreeNode,options) {
-	// Main initialisation inherited from widget.js
-	this.initialise(parseTreeNode,options);
-};
-ListEmptyWidget.prototype = new Widget();
-ListEmptyWidget.prototype.render = function() {}
-ListEmptyWidget.prototype.refresh = function() { return false; }
-
-exports["list-empty"] = ListEmptyWidget;
-
-var ListJoinWidget = function(parseTreeNode,options) {
-	// Main initialisation inherited from widget.js
-	this.initialise(parseTreeNode,options);
-};
-ListJoinWidget.prototype = new Widget();
-ListJoinWidget.prototype.render = function() {}
-ListJoinWidget.prototype.refresh = function() { return false; }
-
-exports["list-join"] = ListJoinWidget;


### PR DESCRIPTION
This PR fixes duplicated code introduced with PR #7596

@Jermolene ... It seems with the PR the list-widget at list.js got some duplicated code. Probably a copy / paste error.

The diff can be found at: https://github.com/TiddlyWiki/TiddlyWiki5/pull/7596/files#diff-84d7615380b839e5f59710d02054015b26ef44974913aa1a2dbffdb518392caa

--------

I did find the problem since I did try to refine the linting rules used at the moment. 