### PR TITLE
Fixed substitute attributes to allow more variables

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1173,7 +1173,7 @@ exports.getSubstitutedText = function(text,widget,options) {
 		output = $tw.utils.replaceString(output,new RegExp("\\$" + $tw.utils.escapeRegExp(substitute.name) + "\\$","mg"),substitute.value);
 	});
 	// Substitute any variable references with their values
-	return output.replace(/\$\(([^\)\$]+)\)\$/g, function(match,varname) {
+	return output.replace(/\$\((.+?)\)\$/g, function(match,varname) {
 		return widget.getVariable(varname,{defaultValue: ""})
 	});
 };

--- a/editions/test/tiddlers/tests/data/widgets/SubstitutedAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/SubstitutedAttributes.tid
@@ -7,9 +7,9 @@ title: Output
 
 \whitespace trim
 <$set name="var with spaces" value="spaces">
-<$let project="TiddlyWiki" disabled="true" var-with-dashes="dashes">
+<$let project="TiddlyWiki" disabled="true" $tiddler="Getting Started" var-with-dashes="dashes">
 <div class=`$(project)$ 
-${ [[Hello]addsuffix[There]] }$` attrib=`myvalue` otherattrib=`$(1)$` blankattrib=`` quoted="here" disabled=```$(disabled)$``` dashes=`$(var-with-dashes)$` spaces=`$(var with spaces)$`>
+${ [[Hello]addsuffix[There]] }$` attrib=`myvalue` otherattrib=`$(1)$` blankattrib=`` quoted="here" disabled=```$(disabled)$``` dollar=`p-$($tiddler)$-s` dashes=`$(var-with-dashes)$` spaces=`$(var with spaces)$`>
 </div>
 </$let>
 </$set>
@@ -18,4 +18,4 @@ ${ [[Hello]addsuffix[There]] }$` attrib=`myvalue` otherattrib=`$(1)$` blankattri
 title: ExpectedResult
 
 <p><div attrib="myvalue" blankattrib="" class="TiddlyWiki 
-HelloThere" dashes="dashes" disabled="true" otherattrib="" quoted="here" spaces="spaces"></div></p>
+HelloThere" dashes="dashes" disabled="true" dollar="p-Getting Started-s" otherattrib="" quoted="here" spaces="spaces"></div></p>


### PR DESCRIPTION
Dollar signs are a common pattern in variable names, especially as the first character. They represent more *administrative* variables. So it's coming as an annoyance that they cannot be used in substitution like ```<$button $tiddler=`$:/state/$($myVariable)$`>```.

Can't think of why it shouldn't. This change changes the regexp to lazily consume all characters until coming to the `)$`.