### PR TITLE
Community Cards

### DIFF
--- a/community/docs/Community Cards.tid
+++ b/community/docs/Community Cards.tid
@@ -1,0 +1,9 @@
+title: Community Cards
+tags: Community
+modified: 20250522155415023
+created: 20250522155415023
+
+The formal purpose of the cards is to allow project plans and other community activities to be linked to the people who are involved in them. The informal purpose is to allow people to share their interests and activities in the TiddlyWiki community, and to help people in the TiddlyWiki community get to know each other better.
+
+* [[Submitting a Community Card]]
+* [[Displaying Community Cards]]

--- a/community/docs/Displaying Community Cards.tid
+++ b/community/docs/Displaying Community Cards.tid
@@ -1,0 +1,19 @@
+title: Displaying Community Cards
+tags: Community Cards
+modified: 20250522155415023
+created: 20250522155415023
+
+This is an inline card for <<community-card-pill title:"@Jermolene">> and <<community-card-pill title:"@ericshulman">> which can be used in the middle of a sentence.
+
+This is a stack of inline cards:
+
+<<community-card-pill-stack>>
+
+Here are a couple of full format cards:
+
+<<community-card title:"@MissingPerson">>
+
+<<community-card title:"@Jermolene">>
+
+<<community-card title:"@ericshulman">>
+

--- a/community/docs/Submitting a Community Card.tid
+++ b/community/docs/Submitting a Community Card.tid
@@ -1,0 +1,36 @@
+title: Submitting a Community Card
+tags: Community Cards
+modified: 20250522155415023
+created: 20250522155415023
+
+Anyone associated with the TiddlyWiki community can submit a Community Card. The submission process currently involves making a GitHub pull request but we intend to provide a more user-friendly submission process in the future.
+
+Pull requests to add or update a community card should be made against the `tiddlywiki-com` branch of the [[TiddlyWiki repository|https://github.com/TiddlyWiki/TiddlyWiki5]] in the directory `community/people`.
+
+The card should be a TiddlyWiki tiddler with the following fields:
+
+|!Field |!Required|!Description |
+|`title`|Yes |The username of the person represented by the card, starting with `@` (e.g. `@Jermolene`). This is the title of the card and should be unique |
+|`tags`|Yes |The tags for the card, including `Community/Person` |
+|`fullname`|Yes |The full name of the person or group represented by the card |
+|`avatar`|Yes |The base64 representation of the 32x32 avatar image for the person represented by the card |
+|`first-sighting`|No |The date of the first sighting in the community of the person represented by the card. This should be in ISO 8601 format (YYYY-MM-DD) |
+|`talk.tiddlywiki.org`|Yes |The username of the person or group on the TiddlyWiki Talk forum |
+|`github`|No |The username of the person or group on GitHub |
+|`linkedin`|No |The URL of the LinkedIn profile for the person or group represented by the card |
+|`flickr`|No |The URL of the Flickr profile for the person or group represented by the card |
+|`homepage`|No |The URL of the homepage for the person or group represented by the card |
+|`email`|No |The email address of the person or group represented by the card |
+|`text`|Yes |The text of the card. This should include a brief description of the person or group represented by the card, and any other relevant information |
+
+! Rules for Community Cards
+
+Community cards must observe the following rules. It is intended to enforce them with an automated script, but for the moment they will be manually checked.
+
+* `title` must be unique and start with `@`
+* `tags` must include `Community/Person`
+* `fullname` must be provided
+* `avatar` must be a base64 representation of a 32x32 image, with a limit of 1KB.  [[Squoosh|https://squoosh.app/]] is recommended for resizing and compressing images
+* `first-sighting` should be in ISO 8601 format (YYYY-MM-DD)
+* `talk.tiddlywiki.org` must be provided
+* `text` total size must not exceed 2KB

--- a/community/people/EricShulman.tid
+++ b/community/people/EricShulman.tid
@@ -1,0 +1,29 @@
+title: @ericshulman
+tags: Community/Person Community/Team/Contributors
+fullname: Eric Shulman
+first-sighting: 2005-06-21
+talk.tiddlywiki.org: ericshulman
+github: ericshulman
+homepage: tiddlytools.com
+email: elsdesign@gmail.com
+avatar: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAQAAADZc7J/AAAD/ElEQVR42o2Tf2iUdRzH37e7rOa222233bab3mqKU9QihCAi+isKwX/sh5UQhGYQhNAvQowRUoghQWDOIJtQmOY0M92ZmVGm0WbTyZI1Nnft99S1jc3dPT9efffg/bHdLn19Hp4HPjzv9/fz+fL5aE58PwUkjzzFVC4P/G/k6E445Pc+uceeaqnv7Ogd6Rq68PPhrc+vkiERWOLT/+Ib8uQHNiXax3BIM0mC+CEtl2G7X9mIeCV+9Ejrr2MAtgkH14SNBRZXrYYPNF86nsXCkx/8dATAsp0JhknQTYJrTHg5SNI0qMekb+aw8Hr74WCKpNNu/0Kck5ymkRMcZz/1Jv5g2CUFbZYelrbMvlBMonHvJK3JuPsdTQxwExc8XG7SxF7OcxGScP6wRGCG/Asjf39VPydTzbQyRBrXBKToBCP/nQQ9VpIDO6SumU3EjUFLzX766HMG0mIvoJnXEbU47GGXc4TGBs3zWp5Jh7F47omdf56hy9lLIz3gyYfZSQMJztFEH3KEDg+bf1dkzkO9Savks7H9NLqnuEw3MEU314nTwABj/MV2R6y8JL+0wKdM8MtX23aFy04dF5mg08QI6XYsemmzRfiMDP5Mg1emK4ienZxi0p0gBfRwhSHAxgXGGeS6tYUdu6TPA3Ofr3Mfj9Bv4zHMDaCTMcBlnG4cJqx64sagN9Ngw3RJoa5R+MftI8k1Wm7NcSsH6KKPFGBbG1n1srQ+06DWpJ59cRhsGKGbo0wBFpDgNGcBcHGsl9BuSZmjfCRHWnv0BtgOcJVWwAZG2cw+3uErAKacZ6hq32PkGWuNSaxsHgIHxqjje5I4/Ms2dCt+BHpcUT4ai0j5sw22TCea2sCBbz3BOjaRFj+JeAE46IoHxlUmlfrmWuZT+8Ae935fjljDe3zpLdEJxGriLHdFtL8mKC2cbbAgIOXVBemwBhHibZq4xN/0YgPrESsRsiMs+C1zEwwFxqBqs4hY2yhlKeIUab5GLEM8SLlVRslu77jZhEwL/ofKKZ4uknxiiLO0cYFGFpJPMTGiRO0iQqtNrX7NxueTcahqv4/FTpgwFYinOcoxtiLKWEwF+U6Mqv5FuVlWSQHzvBWmKmUqIEg1YiMfIu6lhjKCRK0YkXelwoDmIjztWrCot5KQs5R5zKccIVZQwl3cTaVdQVGnfOkrzFbDuvuJWTVuBcXcQ5iFlFFAmBynlBKKH/f6z06pX6r6pJoSQlaeW2gsighi3na1E6HwNSkUUHbS45FXG7ajhIi68+1cO98qtqqJEHzTW6LbEfUstER1ef2llBKhiGqKW7VGUk6lT7dnmS/gnZMf1KPaoI16VWsrA1KhX3dObo5m9VqQpff/AFTcI4hMzFV+AAAAAElFTkSuQmCC
+
+\define wiki(text,topic) [[$text$|https://en.wikipedia.org/wiki/$topic$]]
+
+''Hello! My name is Eric Shulman''. I am the author of ''[[www.TiddlyTools.com|http://www.TiddlyTools.com]] (Small Tools for Big Ideas! &trade;)'', a popular collection of original plugins, macros, widgets, templates and stylesheets for TiddlyWiki that I have created and shared with the TiddlyWiki community.
+
+<<<
+Think of TiddlyTools as a ''virtual hardware store and "demonstration showroom"'', offering tools, parts and techniques that provide a rich variety of new functionality and feature enhancements to help you ''turn a general-purpose TiddlyWiki "info-house" into a comfortable, custom-built "info-home"''.
+
+The TiddlyWiki core system provides the basic structure and utilities: the foundation, framing, walls, roof, windows/doors, plumbing, heating, and electrical systems. Then, TiddlyTools helps you with all the "finish work": the appliances, fixtures, lighting, cabinets, furniture, paint, wallpaper, carpeting, etc. ''to best suit your specific needs and personal style''.
+<<<
+
+Since the early days of TiddlyWiki (April 2005), I have worked closely with its inventor, [[Jeremy Ruston|https://jermolene.com/]], to help develop and improve TiddlyWiki's core functions. I am also a key contributor and administrator of the online TiddlyWiki [[Discourse|https://talk.TiddlyWiki.org]] and [[GoogleGroups|https://groups.google.com/forum/#!forum/tiddlywiki]] discussion forums, providing ongoing assistance to the worldwide TiddlyWiki community. I have written over 15,000 detailed responses to individual questions posted online.  For several years I was also the lead developer and maintainer of the [[TiddlyWiki Classic|https://classic.tiddlywiki.com/]] codebase.
+
+I was born and raised in suburban Long Island, NY, and attended [[Carnegie Mellon University (CMU)|https://www.cmu.edu/]] in Pittsburgh, PA, where I studied ''Computer Science, Cognitive Psychology, Sociology, Human Factors Design, and Artificial Intelligence''. As an undergraduate at CMU, I was privileged to work with some of the major luminaries in early software research and design, including <<wiki "Herbert Simon" "Herbert_A._Simon">>, <<wiki "Allen Newell" "Allen_Newell">>, <<wiki "James Gosling" "James_Gosling">>, and <<wiki "Raj Reddy" "Raj_Reddy">>. I was also employed in several Computer Science Department research projects, including the development of speech recognition technologies, graphical interface systems, and interactive applications for instruction in physics, art and music. I received a ''Bachelor of Science in "Interactive Systems Design"'' from CMU in 1985.
+
+During my early post-graduate years, I worked for several notable software development companies, including 
+<<wiki "Honeywell Information Systems" "Honeywell#Honeywell_Information_Systems">> and <<wiki "Lotus Software" "Lotus_Software">>. I was an integral member of the <<wiki "1-2-3 spreadsheet" 
+"Lotus_1-2-3">> development team where I helped create the first GUI-based application interfaces for Microsoft Windows and IBM OS/2.
+
+Since 1998, I have been an ''independent design consultant'', living and working in Silicon Valley, where I apply more than 40 years of experience to provide ''analysis, design and software development services'' for commercial companies and not-for-profit organizations, with emphasis on ''information architecture'' and ''interaction/visual design standards'' to improve ease-of-use for new and existing software products and online environments.

--- a/community/people/Jermolene.tid
+++ b/community/people/Jermolene.tid
@@ -1,0 +1,20 @@
+title: @Jermolene
+tags: Community/Person
+fullname: Jeremy Ruston
+first-sighting: 2004-09-20
+talk.tiddlywiki.org: jeremyruston
+github: Jermolene
+linkedin: www.linkedin.com/in/jermy
+flickr: www.flickr.com/photos/jermy/
+homepage: jermolene.com
+email: jeremy@jermolene.com
+avatar: /9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAgICAgJCAkKCgkNDgwODRMREBARExwUFhQWFBwrGx8bGx8bKyYuJSMlLiZENS8vNUROQj5CTl9VVV93cXecnNEBCAgICAkICQoKCQ0ODA4NExEQEBETHBQWFBYUHCsbHxsbHxsrJi4lIyUuJkQ1Ly81RE5CPkJOX1VVX3dxd5yc0f/CABEIACAAIAMBIgACEQEDEQH/xAAtAAEBAAMAAAAAAAAAAAAAAAAHBgIEBQEBAQEBAAAAAAAAAAAAAAAAAgQBBf/aAAwDAQACEAMQAAAANF4uTuPRhD2nBLnUiJvKM0DtMKy//8QAKxAAAgIBAwMDAQkAAAAAAAAAAQIDBBEABRITITEiMkFxFEJRUmFicoGR/9oACAEBAAE/AInTA6gUGP4ZOQbW1bPsmyUq1q+gmvFPUzZPDkPamtwqU75ks04JakroVcg5RwRjg66NUx25KbzqJYyMngfqSuq0M3NZYIebJIvZozIvI/iNPcp/aalSdJXsS4VcKeIzlvU3jVTcYLNiaGISrjkhWQYDfQ63pYAzCDBsOiu7Dsx4EHH6r2w2ttimjd2IsNErhhJHKI04/uzqxuCxpBYVVWKSHqwMyMSQ33SB7dUJFmlkMYRgnqZgCMf7rf8AeEt3A9YOhjXAb2k8u7dtT1RZeOtXmYxiOPj4ZWY/lb51skqUNnNW/wBNzC7IpB6gQeeB/jq/fqGOaLbowuYn5MAQOw8LjW5Vmeo0qIsqYLLKjHIZmwv9fB1//8QAHxEAAQMEAwEAAAAAAAAAAAAAEQABAgMSIWExMkFR/9oACAECAQE/AD9iTy2lJmHUB8BVKM4SNSOj46a29saX/8QAHREAAgICAwEAAAAAAAAAAAAAAQIAAwQRITGBkf/aAAgBAwEBPwDHpFpJZtamVSiBWT2Yt7hmCDsb+TKtsKqpGg3M/9k=
+
+I'm the original inventor of TiddlyWiki. You can hire me through my consultancy company [[Intertwingled Innovations|https://intertwingledinnovations.com]] or contact me directly.
+
+Further information:
+
+* A recording of the [[keynote I gave at QCon London in April 2024|https://www.infoq.com/presentations/bbc-micro/]], and the [[discussion on talk.tiddlywiki.org|https://talk.tiddlywiki.org/t/recording-of-jeremys-keynote-at-qcon-london-april-2024/10505]]. The talk mixes some nostalgia about my teenage activities with the BBC Micro with thoughts on the development of the software industry and insights gained from working with TiddlyWiki
+* An [[interview with me in The Inquirer|https://web.archive.org/web/20111103225832/http://www.theinquirer.net/inquirer/feature/2105529/bt-software-engineer-tells-telco-source]] by Wendy Grossman
+* A [[hilarious interview with me|https://www.youtube.com/watch?v=auyIhw8MTmQ]] from British television in 1983
+* Here's a video of a presentation I did in 2007 called [["How to Start an Open Source Project"|http://vimeo.com/856110]].

--- a/community/project/TiddlyWiki Project.tid
+++ b/community/project/TiddlyWiki Project.tid
@@ -1,0 +1,35 @@
+title: TiddlyWiki Project
+modified: 20250522155415023
+created: 20250522155415023
+tags: Community
+
+The TiddlyWiki Project is the coordinated, ongoing effort to maintain and improve TiddlyWiki, and to support the TiddlyWiki community.
+
+<$list filter="[tag[Community/Team]]">
+
+<div class="tc-community-card tc-community-card-team">
+	<$link to=<<currentTiddler>> class="tc-community-card-header-link">
+		<div class="tc-community-card-header">
+			<<display-jpeg-field "avatar">>
+			<<display-text-field "title" showLabel:"no">>
+		</div>
+	</$link>
+	<div class="tc-community-card-info">
+		<div class="tc-community-card-field-text">
+			<span class="tc-community-card-field-text-name">leader</span>
+			<span class="tc-community-card-field-text-value"><$transclude $variable="community-card-pill" title={{!!leader}}/></span>
+		</div>
+		<div class="tc-community-card-field-text">
+			<span class="tc-community-card-field-text-name">team</span>
+			<span class="tc-community-card-field-text-value"><$transclude $variable="community-card-pill-stack" personFilter={{!!team}}/></span>
+		</div>
+	</div>
+	<div class="tc-community-card-body">
+		<$transclude $tiddler=<<currentTiddler>> $field="text" $mode="block"/>
+	</div>
+</div>
+
+<$transclude $mode="block"/>
+
+</$list>
+

--- a/community/project/teams/Core Team.tid
+++ b/community/project/teams/Core Team.tid
@@ -1,0 +1,8 @@
+title: Core Team
+tags: Community/Team
+modified: 20250522155415023
+created: 20250522155415023
+leader: @Jermolene
+team: @saqimtiaz
+
+The core team is responsible for the maintenance and development of the TiddlyWiki core and official plugins.

--- a/community/project/teams/MultiWikiServer Team.tid
+++ b/community/project/teams/MultiWikiServer Team.tid
@@ -1,0 +1,8 @@
+title: MultiWikiServer Team
+tags: Community/Team
+modified: 20250522155415023
+created: 20250522155415023
+leader: @Arlen22
+team: 
+
+The MultiWikiServer development repository is at https://github.com/TiddlyWiki/MultiWikiServer

--- a/community/project/teams/Project Team.tid
+++ b/community/project/teams/Project Team.tid
@@ -1,0 +1,14 @@
+title: Project Team
+tags: Community/Team
+modified: 20250522155415023
+created: 20250522155415023
+leader: @Jermolene
+team: @saqimtiaz @ericshulman
+
+The project team is responsible for the overall TiddlyWiki project, its vision, mission and values, and ensuring that it meets the needs of the community.
+
+Areas of responsibility include:
+
+* Communicating and demonstrating the vision, mission and values of the project
+* Continuously improve the development process and practices of the project
+* more to come...

--- a/community/project/teams/Succession Team.tid
+++ b/community/project/teams/Succession Team.tid
@@ -1,0 +1,15 @@
+title: Succession Team
+tags: Community/Team
+modified: 20250522155415023
+created: 20250522155415023
+leader: @Jermolene
+team: @saqimtiaz @ericshulman
+
+The Succession Team is responsible for ensuring that personnel changes do not impact access to the external infrastructure used by the project. This is achieved by ensuring that the members of the succession team share ownership of the resources. The Succession Team is not expected to use their access rights apart from managing access in the event of personnel changes.
+
+The infrastructure includes:
+
+* talk.tiddlywiki.org
+* github.com/TiddlyWiki
+* tiddlywiki.com DNS
+* Netlify account for PR previews

--- a/community/project/teams/tagCommunityTeam.tid
+++ b/community/project/teams/tagCommunityTeam.tid
@@ -1,0 +1,5 @@
+title: Community/Team
+modified: 20250522155415023
+created: 20250522155415023
+list: [[Project Team]] [[Core Team]] [[Documentation Team]] [[MultiWikiServer Team]] [[Succession Team]]
+

--- a/community/readme.md
+++ b/community/readme.md
@@ -1,0 +1,3 @@
+# Community Records and Resources
+
+These raw tiddlers comprise the community records and resources for the TiddlyWiki project. They are packaged as a root directory outside of the usual "editions" folder so that they can be shared with other wikis.

--- a/community/tools/cards/DefaultColourMappings.multids
+++ b/community/tools/cards/DefaultColourMappings.multids
@@ -1,0 +1,13 @@
+title: $:/config/DefaultColourMappings/
+
+community-card-background: #ffffee
+community-card-foreground: #441111
+community-card-dark-shadow: #bcbdbd
+community-card-shadow: #d4d4d5
+community-card-header-background: #9e3060
+community-card-header-foreground: #ddddee
+community-card-team-header-background: #306090
+community-card-team-header-foreground: #ddeedd
+community-card-info-background: #f3f38b
+community-card-info-foreground: #444411
+community-card-field-name-foreground: #888844

--- a/community/tools/cards/Procedures.tid
+++ b/community/tools/cards/Procedures.tid
@@ -1,0 +1,79 @@
+title: $:/tiddlywiki/community/cards/Procedures
+tags: $:/tags/Global
+
+\procedure display-jpeg-field(fieldName,mode:"block")
+<$genesis $type={{{ [<mode>match[block]then[div]else[span]] }}} class={{{ tc-community-card-field-image [[tc-community-card-field-image-]addsuffix<fieldName>] +[join[ ]] }}}>
+	<%if [<currentTiddler>has<fieldName>] %>
+		<img src={{{ [<currentTiddler>get<fieldName>addprefix[data:image/jpeg;base64,]] }}} width="32"/>
+	<%else%>
+		{{$:/core/images/warning}}
+	<%endif%>
+</$genesis>
+\end display-jpeg-field
+
+\procedure display-text-field(fieldName,showLabel:"yes",linkPrefix,displayPrefix,mode:"block")
+<%if [<currentTiddler>has<fieldName>] :or[<fieldName>match[title]] %>
+	<$genesis $type={{{ [<mode>match[block]then[div]else[span]] }}} class={{{ tc-community-card-field-text [[tc-community-card-field-text-]addsuffix<fieldName>] +[join[ ]] }}}>
+		<%if [<showLabel>match[yes]] %>
+		<span class="tc-community-card-field-text-name"><$text text=<<fieldName>>/></span>
+		<%endif%>
+		<%if [<linkPrefix>!match[]] %>
+			<a
+				href={{{ [<currentTiddler>get<fieldName>addprefix<linkPrefix>] }}}
+				class="tc-community-card-field-text-value"
+				rel="noopener noreferrer"
+				target="_blank"
+			>
+				<$text text={{{ [<currentTiddler>get<fieldName>] :else[<fieldName>match[title]then<currentTiddler>] +[addprefix<displayPrefix>] }}}/>
+			</a>
+		<%else%>
+			<span class="tc-community-card-field-text-value">
+				<$text text={{{ [<currentTiddler>get<fieldName>] :else[<fieldName>match[title]then<currentTiddler>] +[addprefix<displayPrefix>] }}}/>
+			</span>
+		<%endif%>
+	</$genesis>
+<%endif%>
+\end display-text-field
+
+\procedure community-card(title)
+	<$let currentTiddler=<<title>>>
+		<div class="tc-community-card">
+			<$link to=<<currentTiddler>> class="tc-community-card-header-link">
+				<div class="tc-community-card-header">
+					<<display-jpeg-field "avatar">>
+					<<display-text-field "title" showLabel:"no">>
+				</div>
+			</$link>
+			<div class="tc-community-card-info">
+				<<display-text-field "fullname">>
+				<<display-text-field "first-sighting">>
+				<<display-text-field "talk.tiddlywiki.org" linkPrefix:"https://talk.tiddlywiki.org/u/" displayPrefix:"@">>
+				<<display-text-field "github" linkPrefix:"https://github.com/" displayPrefix:"@">>
+				<<display-text-field "linkedin" linkPrefix:"https://">>
+				<<display-text-field "flickr" linkPrefix:"https://">>
+				<<display-text-field "homepage" linkPrefix:"https://">>
+				<<display-text-field "email" linkPrefix:"mailto:">>
+			</div>
+			<div class="tc-community-card-body">
+				<$transclude $tiddler=<<currentTiddler>> $field="text" $mode="block"/>
+			</div>
+		</div>
+	</$let>
+\end community-card
+
+\procedure community-card-pill(title)
+	<$let currentTiddler=<<title>>>
+		<$link to=<<currentTiddler>> class="tc-community-card-pill">
+			<<display-jpeg-field "avatar" mode:"inline">>
+			<<display-text-field "title" showLabel:"no" mode:"inline">>
+		</$link>
+	</$let>
+\end community-card-pill
+
+\procedure community-card-pill-stack(personFilter:"[tag[Community/Person]]")
+	<div class="tc-community-card-pill-stack">
+		<$list filter=<<personFilter>>>
+			<$transclude $variable="community-card-pill" title=<<currentTiddler>> mode="block"/>
+		</$list>
+	</div>
+\end community-card-pill-stack

--- a/community/tools/cards/Styles.tid
+++ b/community/tools/cards/Styles.tid
@@ -1,0 +1,151 @@
+title: $:/tiddlywiki/community/cards/Styles
+tags: $:/tags/Stylesheet
+
+.tc-community-card {
+	display: flex;
+	flex-direction: column;
+	flex-wrap: wrap;
+	justify-content: center;
+	border-radius: 8px;
+	width: 100%;
+	background: <<colour community-card-background>>;
+	color: <<colour community-card-foreground>>;
+	box-shadow: 0 1px 3px 0 <<colour community-card-shadow>>, 0 0 0 1px <<colour community-card-shadow>>;
+	transition: box-shadow 0.3s ease,transform .3s ease;
+}
+
+.tc-community-card:hover {
+	box-shadow: 0 1px 6px 0 <<colour community-card-dark-shadow>>, 0 0 0 1px <<colour community-card-shadow>>;
+	transform: translateY(-2px);
+}
+
+.tc-community-card .tc-community-card-header-link {
+	background-color: <<colour community-card-header-background>>;
+	color: <<colour community-card-header-foreground>>;
+	border-top-left-radius: 8px;
+	border-top-right-radius: 8px;
+}
+
+.tc-community-card.tc-community-card-team .tc-community-card-header-link {
+	background: <<colour community-card-team-header-background>>;
+	color: <<colour community-card-team-header-foreground>>;
+}
+
+
+
+.tc-community-card .tc-community-card-header-link:hover {
+	text-decoration: none;
+	background-color: <<colour community-card-header-foreground>>;
+	color: <<colour community-card-header-background>>;
+}
+
+.tc-community-card-header {
+	margin: 0;
+	padding: 0.5em;
+	display: flex;
+	flex-direction: row;
+	flex-wrap: nowrap;
+	justify-content: flex-start;
+	align-items: center;
+	line-height: 0;
+}
+
+.tc-community-card-header .tc-community-card-field-text-title {
+	font-size: 1.5em;
+	font-weight: bold;
+}
+
+.tc-community-card-header .tc-community-card-field-image {
+	display: table-row;
+	width: auto;
+	max-width: 100%;
+	margin-right: 12px;
+}
+
+.tc-community-card-info {
+	display: table;
+	width: auto;
+	max-width: 100%;
+	padding: 8px;
+	margin: 0;
+	background-color: <<colour community-card-info-background>>;
+	color: <<colour community-card-info-foreground>>;
+}
+
+.tc-community-card-body {
+	padding: 0 8px;
+}
+
+.tc-community-card .tc-community-card-field-text {
+	display: table-row;
+}
+
+.tc-community-card .tc-community-card-field-text-name,
+.tc-community-card .tc-community-card-field-text-value {
+	display: table-cell;
+	padding: 2px 6px 2px 0;
+	vertical-align: top;
+}
+
+.tc-community-card .tc-community-card-field-text-name {
+	color: <<colour community-card-field-name-foreground>>;
+	white-space: nowrap;
+	text-align: right;
+	padding-right: 8px;
+}
+
+.tc-community-card .tc-community-card-field-text-value {
+	word-break: break-word;
+	font-weight: bold;
+	width: 100%;
+}
+
+a.tc-community-card-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	width: auto;
+	min-width:0;
+	max-width: none;
+	align-self: auto;
+	font-size: 0.9em;
+	line-height: 1;
+	vertical-align: middle;
+	padding: 4px;
+	border-radius: 4px;
+	background: <<colour community-card-header-background>>;
+	color: <<colour community-card-header-foreground>>;
+	fill: <<colour community-card-header-foreground>>;
+	box-shadow: 0 1px 3px 0 <<colour community-card-shadow>>, 0 0 0 1px <<colour community-card-shadow>>;
+	transition: box-shadow 0.3s ease,transform .3s ease;
+}
+
+a.tc-community-card-pill:hover {
+	text-decoration: none;
+	box-shadow: 0 1px 6px 0 <<colour community-card-dark-shadow>>, 0 0 0 1px <<colour community-card-shadow>>;
+	transform: translateY(-2px);
+	background: <<colour community-card-header-foreground>>;
+	color: <<colour community-card-header-background>>;
+	fill: <<colour community-card-header-background>>;
+}
+
+a.tc-community-card-pill .tc-community-card-field-image img,
+a.tc-community-card-pill .tc-community-card-field-image svg {
+	width: 16px;
+	height: 16px;
+	vertical-align: middle;
+	display: inline-block;
+}
+
+a.tc-community-card-pill .tc-community-card-field-text {
+	display: inline;
+}
+
+.tc-community-card-pill-stack {
+	display: inline-flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 4px;
+	margin: 0;
+	padding: 0;
+}

--- a/community/tools/cards/ViewTemplateBodyCascade.tid
+++ b/community/tools/cards/ViewTemplateBodyCascade.tid
@@ -1,0 +1,5 @@
+title: $:/tiddlywiki/community/cards/ViewTemplateBodyCascade
+tags: $:/tags/ViewTemplateBodyFilter
+list-before:
+
+[tag[Community/Person]then[$:/tiddlywiki/community/cards/ViewTemplateBodyTemplatePerson]]

--- a/community/tools/cards/ViewTemplateBodyTemplatePerson.tid
+++ b/community/tools/cards/ViewTemplateBodyTemplatePerson.tid
@@ -1,0 +1,3 @@
+title: $:/tiddlywiki/community/cards/ViewTemplateBodyTemplatePerson
+
+<$transclude $variable="community-card" title=<<currentTiddler>>/>

--- a/editions/prerelease/tiddlers/system/DefaultTiddlers.tid
+++ b/editions/prerelease/tiddlers/system/DefaultTiddlers.tid
@@ -2,11 +2,7 @@ created: 20131127215321439
 modified: 20140912135951542
 title: $:/DefaultTiddlers
 
-[[TiddlyWiki Pre-release]]
-HelloThere
-[[Quick Start]]
-[[Find Out More]]
-[[TiddlyWiki on the Web]]
-[[Testimonials and Reviews]]
-GettingStarted
-Community
+[[Community]]
+[[Community Cards]]
+[[Displaying Community Cards]]
+[[Submitting a Community Card]]

--- a/editions/tw5.com/tiddlers/about/Funding TiddlyWiki.tid
+++ b/editions/tw5.com/tiddlers/about/Funding TiddlyWiki.tid
@@ -10,7 +10,7 @@ Nonetheless, TiddlyWiki is a relatively big, complex machine that requires a sig
 The people in the community that do the work have widely varying needs:
 
 * At one end, a good proportion of the work on TiddlyWiki is performed by community members on a purely voluntary basis. For those people, the satisfaction of helping others is sufficient reward. Indeed, for many people, unpaid voluntary activities are a satisfying antidote to everyday paid work
-* At the other extreme, JeremyRuston and some other contributors are trying to make a full-time living working on TiddlyWiki by offering commercial products and services around it
+* At the other extreme, [[@Jermolene]] and some other contributors are trying to make a full-time living working on TiddlyWiki by offering commercial products and services around it
 * In between, there are other people who would appreciate an ocassional token to reward them for their work
 
 To support these needs in the community, we have two initiatives:

--- a/editions/tw5.com/tiddlers/community/Community.tid
+++ b/editions/tw5.com/tiddlers/community/Community.tid
@@ -1,11 +1,9 @@
 created: 20130909151600000
-modified: 20210322152237662
+modified: 20250522155415023
 tags: TableOfContents Welcome
 title: Community
 type: text/vnd.tiddlywiki
 
-<<.tip "The latest and most useful links are now being gathered in the [[Community Links Aggregator]].">>
+The TiddlyWiki community is an enthusiastic group of users and developers who work together to make TiddlyWiki better, and help each other get the best out of it.
 
-Once all the relevant links have been transferred over these entries will be removed from the main tiddlywiki.com site.
-
-<<tabs "Forums Latest Tutorials [[Community Editions]] [[Community Plugins]] [[Community Themes]] [[Community Palettes]] [[Other Resources]] Examples Articles Meetups" "Latest">>
+<<tabs "Forums Developers [[TiddlyWiki Project]] Latest Tutorials [[Community Editions]] [[Community Plugins]] [[Community Themes]] [[Community Palettes]] [[Other Resources]] Examples Articles Meetups" "TiddlyWiki Project">>

--- a/editions/tw5.com/tiddlers/community/Forums.tid
+++ b/editions/tw5.com/tiddlers/community/Forums.tid
@@ -4,32 +4,12 @@ tags: Community
 title: Forums
 type: text/vnd.tiddlywiki
 
-! Official Forums
+TalkTW, the official TiddlyWiki forum is a place to talk about ~TiddlyWiki: requests for help, [[announcements|https://talk.tiddlywiki.org/c/announcements/20]] of new releases and plugins, debating new features, or just sharing experiences. You can participate via the associated website, or subscribe via email.
 
-!! https://talk.tiddlywiki.org/
+https://talk.tiddlywiki.org/
 
-<<<
-The new official forum for talking about ~TiddlyWiki: requests for help, [[announcements|https://talk.tiddlywiki.org/c/announcements/20]] of new releases and plugins, debating new features, or just sharing experiences. You can participate via the associated website, or subscribe via email.
+Other Forums:
 
-''talk.tiddlywiki.org'' is a community run service that we host and maintain ourselves. The modest running costs are covered by community contributions.
-<<<
-
-!!! Google Groups
-
-<<<
-For the convenience of existing users, we also continue to operate the original ~TiddlyWiki group (hosted on Google Groups since 2005): https://groups.google.com/group/TiddlyWiki
-<<<
-
-! Developer Forums
-
-{{Developers}}
-
-! Other Forums
-
-* [[TiddlyWiki Subreddit|https://www.reddit.com/r/TiddlyWiki5/]]
-* Chat with Gitter at https://gitter.im/TiddlyWiki/public !
 * Chat on Discord at https://discord.gg/HFFZVQ8
-
-!! Documentation
-
-There is also a discussion group specifically for discussing TiddlyWiki documentation improvement initiatives: https://groups.google.com/group/tiddlywikidocs
+* [[TiddlyWiki Subreddit|https://www.reddit.com/r/TiddlyWiki5/]]
+* Chat with Gitter at https://gitter.im/TiddlyWiki/public

--- a/editions/tw5.com/tiddlers/communitycards/tiddlywiki.files
+++ b/editions/tw5.com/tiddlers/communitycards/tiddlywiki.files
@@ -1,0 +1,10 @@
+{
+	"directories": [
+		{
+			"path": "../../../../community",
+			"isTiddlerFile": true,
+			"filesRegExp": "^(?!readme\\.md$)(?!\\.DS_Store$).+",
+			"searchSubdirectories": true
+		}
+	]
+}

--- a/editions/tw5.com/tiddlers/concepts/TiddlyWiki.tid
+++ b/editions/tw5.com/tiddlers/concepts/TiddlyWiki.tid
@@ -10,4 +10,4 @@ type: text/vnd.tiddlywiki
 
 People love using ~TiddlyWiki. Because it can be used without any complicated server infrastructure, and because it is [[open source|OpenSource]], it has brought unprecedented freedom to everyone to keep their precious information under their own control.
 
-~TiddlyWiki was originally created by JeremyRuston and is now a thriving [[open source|License]] project with a busy [[Community]] of independent developers.
+~TiddlyWiki was originally created by [[@Jermolene]] and is now a thriving [[open source|License]] project with a busy [[Community]] of independent developers.

--- a/editions/tw5.com/tiddlers/definitions/BT.tid
+++ b/editions/tw5.com/tiddlers/definitions/BT.tid
@@ -3,4 +3,4 @@ modified: 20211117195517318
 tags: Definitions
 title: BT
 
-BT (née British Telecom) is the UK's largest telecommunications company. In 2007, [[Osmosoft]] was acquired by BT. JeremyRuston subsequently left BT in 2011.
+BT (née British Telecom) is the UK's largest telecommunications company. In 2007, [[Osmosoft]] was acquired by BT. [[@Jermolene]] subsequently left BT in 2011.

--- a/editions/tw5.com/tiddlers/definitions/JeremyRuston.tid
+++ b/editions/tw5.com/tiddlers/definitions/JeremyRuston.tid
@@ -4,16 +4,4 @@ tags: Definitions
 title: JeremyRuston
 type: text/vnd.tiddlywiki
 
-I'm the original inventor of TiddlyWiki. You can hire me through [[Intertwingled Innovations]], and find me on these services:
-
-* jeremy (at) jermolene (dot) com
-* [[Jermolene on GitHub|https://github.com/Jermolene]]
-* [[Jermy on LinkedIn|http://www.linkedin.com/in/jermy]]
-* [[Jermy on Flickr|http://www.flickr.com/photos/jermy/]]
-
-Further information:
-
-* A recording of the [[keynote I gave at QCon London in April 2024|https://www.infoq.com/presentations/bbc-micro/]], and the [[discussion on talk.tiddlywiki.org|https://talk.tiddlywiki.org/t/recording-of-jeremys-keynote-at-qcon-london-april-2024/10505]]. The talk mixes some nostalgia about my teenage activities with the BBC Micro with thoughts on the development of the software industry and insights gained from working with TiddlyWiki
-* An [[interview with me in The Inquirer|http://www.theinquirer.net/inquirer/feature/2105529/bt-software-engineer-tells-telco-source]] by Wendy Grossman
-* A [[hilarious interview with me|https://www.youtube.com/watch?v=auyIhw8MTmQ]] from British television in 1983
-* Here's a video of a presentation I did in 2007 called [["How to Start an Open Source Project"|http://vimeo.com/856110]].
+See [[@Jermolene]].

--- a/editions/tw5.com/tiddlers/definitions/Jermolene.tid
+++ b/editions/tw5.com/tiddlers/definitions/Jermolene.tid
@@ -3,4 +3,4 @@ modified: 201308281902
 tags: Definitions
 title: Jermolene
 
-Alias for JeremyRuston.
+See [[@Jermolene]].

--- a/editions/tw5.com/tiddlers/definitions/Osmosoft.tid
+++ b/editions/tw5.com/tiddlers/definitions/Osmosoft.tid
@@ -3,7 +3,7 @@ modified: 20211119004632506
 tags: Definitions
 title: Osmosoft
 
-Founded in 2004 by JeremyRuston, Osmosoft was originally a consultancy for software services around TiddlyWiki. Notable engagements included working with Socialtext on [[Socialtext Unplugged|https://www.socialtext.net/open/socialtext_unplugged]].
+Founded in 2004 by [[@Jermolene]], Osmosoft was originally a consultancy for software services around TiddlyWiki. Notable engagements included working with Socialtext on [[Socialtext Unplugged|https://www.socialtext.net/open/socialtext_unplugged]].
 
 In 2007, Osmosoft was acquired by [[BT]] and became the champions for open source within the enterprise. As part of BT, Osmosoft has worked on a diverse range of projects within BT and for BT's customers.
 

--- a/editions/tw5.com/tiddlers/system/DefaultTiddlers.tid
+++ b/editions/tw5.com/tiddlers/system/DefaultTiddlers.tid
@@ -3,10 +3,7 @@ modified: 20140912135951542
 title: $:/DefaultTiddlers
 type: text/vnd.tiddlywiki
 
-HelloThere
-[[Quick Start]]
-[[Find Out More]]
-[[TiddlyWiki on the Web]]
-[[Testimonials and Reviews]]
-GettingStarted
-Community
+[[Community]]
+[[Community Cards]]
+[[Displaying Community Cards]]
+[[Submitting a Community Card]]


### PR DESCRIPTION
The [original Project 2036 post](https://talk.tiddlywiki.org/t/project-2036-the-future-of-tiddlywiki/12207) includes this paragraph:

> That means organising ourselves a little more formally so that others can start to form teams and partnerships to take on all the other things that need doing. I am delighted that this has already happened with MWS: @Arlen22 has stepped up to take the lead, and is surging ahead with an improved implementation, working with others in the community to do so

It is undoubtedly going to take some time to organise things differently, and we will need enough people who are willing to help.

A basic attribute of formal organisations is that things are written down: the organisation chart, lists of team members, goals

One simple thing that I think will give us a useful foundation for these efforts is to introduce community @usernames for use on TiddlyWiki.

We want to be able to say "This feature is being worked on by @X's team with @Y and @Z helping". At the moment, we use a number of different usernames within the community, particularly TalkTW and GitHub. That makes it hard to unambiguously refer to a user.

