### PR TITLE
Fix stray space after named end breaking parsing #8976

### DIFF
--- a/core/modules/parsers/wikiparser/rules/fnprocdef.js
+++ b/core/modules/parsers/wikiparser/rules/fnprocdef.js
@@ -50,7 +50,7 @@ exports.parse = function() {
 	var reEnd;
 	if(this.match[5]) {
 		// If so, it is a multiline definition and the end of the body is marked with \end
-		reEnd = new RegExp("((:?^|\\r?\\n)[^\\S\\n\\r]*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[2]) + ")?(?:$|\\r?\\n))","mg");
+		reEnd = new RegExp("((:?^|\\r?\\n)[^\\S\\n\\r]*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[2]) + ")?\\s*?(?:$|\\r?\\n))","mg");
 	} else {
 		// Otherwise, the end of the definition is marked by the end of the line
 		reEnd = /($|\r?\n)/mg;

--- a/core/modules/parsers/wikiparser/rules/macrodef.js
+++ b/core/modules/parsers/wikiparser/rules/macrodef.js
@@ -55,7 +55,7 @@ exports.parse = function() {
 	var reEnd;
 	if(this.match[3]) {
 		// If so, it is a multiline definition and the end of the body is marked with \end
-		reEnd = new RegExp("((?:^|\\r?\\n)[^\\S\\n\\r]*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[1]) + ")?(?:$|\\r?\\n))","mg");
+		reEnd = new RegExp("((?:^|\\r?\\n)[^\\S\\n\\r]*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[1]) + ")?\\s*?(?:$|\\r?\\n))","mg");
 	} else {
 		// Otherwise, the end of the definition is marked by the end of the line
 		reEnd = /($|\r?\n)/mg;

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -116,6 +116,22 @@ describe("WikiText parser tests", function() {
 		);
 	});
 
+	it("should parse macro definitions with end statements followed by spaces", function() {
+		expect(parse("\\define myMacro()\nnothing\n\\end   \n")).toEqual(
+
+			[{"type":"set","attributes":{"name":{"name":"name","type":"string","value":"myMacro"},"value":{"name":"value","type":"string","value":"nothing"}},"children":[],"params":[],"isMacroDefinition":true,"orderedAttributes":[{"name":"name","type":"string","value":"myMacro"},{"name":"value","type":"string","value":"nothing"}],"start":0,"end":33,"rule":"macrodef"}]
+
+		);
+	});
+
+	it("should parse macro definitions with named end statements followed by spaces", function() {
+		expect(parse("\\define myMacro()\nnothing\n\\end myMacro  \n")).toEqual(
+
+			[{"type":"set","attributes":{"name":{"name":"name","type":"string","value":"myMacro"},"value":{"name":"value","type":"string","value":"nothing"}},"children":[],"params":[],"isMacroDefinition":true,"orderedAttributes":[{"name":"name","type":"string","value":"myMacro"},{"name":"value","type":"string","value":"nothing"}],"start":0,"end":40,"rule":"macrodef"}]
+
+		);
+	});
+
 	it("should parse procedure definitions with no parameters", function() {
 		expect(parse("\\procedure myMacro()\nnothing\n\\end\n")).toEqual(
 
@@ -128,6 +144,22 @@ describe("WikiText parser tests", function() {
 		expect(parse("\\procedure myMacro() nothing\n")).toEqual(
 
 			[{"type":"set","attributes":{"name":{"name":"name","type":"string","value":"myMacro"},"value":{"name":"value","type":"string","value":"nothing"}},"children":[],"params":[],"orderedAttributes":[{"name":"name","type":"string","value":"myMacro"},{"name":"value","type":"string","value":"nothing"}],"isProcedureDefinition":true,"start":0,"end":28,"rule":"fnprocdef"}]
+
+		);
+	});
+
+	it("should parse procedure definitions with end statements followed by spaces", function() {
+		expect(parse("\\procedure myMacro()\nnothing\n\\end   \n")).toEqual(
+
+			[{"type":"set","attributes":{"name":{"name":"name","type":"string","value":"myMacro"},"value":{"name":"value","type":"string","value":"nothing"}},"children":[],"params":[],"orderedAttributes":[{"name":"name","type":"string","value":"myMacro"},{"name":"value","type":"string","value":"nothing"}],"isProcedureDefinition":true,"start":0,"end":36,"rule":"fnprocdef"}]
+
+		);
+	});
+
+	it("should parse procedure definitions with named end statements followed by spaces", function() {
+		expect(parse("\\procedure myMacro()\nnothing\n\\end myMacro  \n")).toEqual(
+
+			[{"type":"set","attributes":{"name":{"name":"name","type":"string","value":"myMacro"},"value":{"name":"value","type":"string","value":"nothing"}},"children":[],"params":[],"orderedAttributes":[{"name":"name","type":"string","value":"myMacro"},{"name":"value","type":"string","value":"nothing"}],"isProcedureDefinition":true,"start":0,"end":43,"rule":"fnprocdef"}]
 
 		);
 	});
@@ -151,6 +183,22 @@ describe("WikiText parser tests", function() {
 		expect(parse("\\function myMacro()\nnothing\n\\end\n")).toEqual(
 
 			[{"type":"set","attributes":{"name":{"name":"name","type":"string","value":"myMacro"},"value":{"name":"value","type":"string","value":"nothing"}},"children":[],"params":[],"orderedAttributes":[{"name":"name","type":"string","value":"myMacro"},{"name":"value","type":"string","value":"nothing"}],"isFunctionDefinition":true,"start":0,"end":32,"rule":"fnprocdef"}]
+
+		);
+	});
+
+	it("should parse function definitions with end statements followed by spaces", function() {
+		expect(parse("\\function myMacro()\nnothing\n\\end   \n")).toEqual(
+
+			[{"type":"set","attributes":{"name":{"name":"name","type":"string","value":"myMacro"},"value":{"name":"value","type":"string","value":"nothing"}},"children":[],"params":[],"orderedAttributes":[{"name":"name","type":"string","value":"myMacro"},{"name":"value","type":"string","value":"nothing"}],"isFunctionDefinition":true,"start":0,"end":35,"rule":"fnprocdef"}]
+
+		);
+	});
+
+	it("should parse function definitions with named end statements followed by spaces", function() {
+		expect(parse("\\function myMacro()\nnothing\n\\end myMacro  \n")).toEqual(
+
+			[{"type":"set","attributes":{"name":{"name":"name","type":"string","value":"myMacro"},"value":{"name":"value","type":"string","value":"nothing"}},"children":[],"params":[],"orderedAttributes":[{"name":"name","type":"string","value":"myMacro"},{"name":"value","type":"string","value":"nothing"}],"isFunctionDefinition":true,"start":0,"end":42,"rule":"fnprocdef"}]
 
 		);
 	});


### PR DESCRIPTION
This PR fixes:

- #8976
-  adds tests for procedures, functions, and macro definitions with spaces after the end statements, both with and without names