### PR TITLE
Get-file web server route now support streaming

### DIFF
--- a/core/modules/server/routes/get-file.js
+++ b/core/modules/server/routes/get-file.js
@@ -20,49 +20,49 @@ exports.handler = function(request,response,state) {
 		fullPath = path.resolve(basePath,filename),
 		extension = path.extname(fullPath);
 
+	// Check that the filename is inside the wiki files folder
 	if(path.relative(basePath,fullPath).indexOf("..") === 0) {
 		return state.sendResponse(403,{"Content-Type": "text/plain"},"Access denied");
 	}
 	fs.stat(fullPath, function(err, stats) {
 		if(err) {
-			$tw.utils.error("Error accessing file " + fullPath + ": " + err.toString());
-			return state.sendResponse(404,{"Content-Type": "text/plain"},"File '" + filename + "' not found");
-		}
-		var type = ($tw.config.fileExtensionInfo[extension] ? $tw.config.fileExtensionInfo[extension].type : "application/octet-stream");
-		var responseHeaders = {
-			"Content-Type": type,
-			"Accept-Ranges": "bytes" 
-		};
-		// Handle range requests
-		var rangeHeader = request.headers.range;
-		if(rangeHeader) {
-			var parts = rangeHeader.replace(/bytes=/, "").split("-"),
-				start = parseInt(parts[0], 10),
-				end = parts[1] ? parseInt(parts[1], 10) : stats.size - 1,
-				chunksize = (end - start) + 1;
-
-			responseHeaders["Content-Range"] = `bytes ${start}-${end}/${stats.size}`;
-			responseHeaders["Content-Length"] = chunksize;
-			response.writeHead(206, responseHeaders);
-			var stream = fs.createReadStream(fullPath, {start, end});
+			state.sendResponse(404,{"Content-Type": "text/plain"},"File '" + filename + "' not found");
+			return;
+		} else {
+			var type = ($tw.config.fileExtensionInfo[extension] ? $tw.config.fileExtensionInfo[extension].type : "application/octet-stream"),
+				responseHeaders = {
+					"Content-Type": type,
+					"Accept-Ranges": "bytes"
+				};
+			var rangeHeader = request.headers.range,
+				stream;
+			if(rangeHeader) {
+				// Handle range requests
+				var parts = rangeHeader.replace(/bytes=/, "").split("-"),
+					start = parseInt(parts[0], 10),
+					end = parts[1] ? parseInt(parts[1], 10) : stats.size - 1,
+					chunksize = (end - start) + 1;
+				responseHeaders["Content-Range"] = "bytes " + start + "-" + end + "/" + stats.size;
+				responseHeaders["Content-Length"] = chunksize;
+				response.writeHead(206, responseHeaders);
+				stream = fs.createReadStream(fullPath, {start: start, end: end});
+			} else {
+				responseHeaders["Content-Length"] = stats.size;
+				response.writeHead(200, responseHeaders);
+				stream = fs.createReadStream(fullPath);
+			}
+			// Common stream error handling
 			stream.on("error", function(err) {
-				$tw.utils.error("Error reading file " + fullPath + ": " + err.toString());
 				if(!response.headersSent) {
 					response.writeHead(500, {"Content-Type": "text/plain"});
 					response.end("Read error");
+				} else {
+					response.destroy();
 				}
 			});
-			stream.pipe(response);
-		} else {
-			// Handle regular requests
-			responseHeaders["Content-Length"] = stats.size;
-			response.writeHead(200, responseHeaders);
-			var stream = fs.createReadStream(fullPath);
-			stream.on("error", function(err) {
-				$tw.utils.error("Error reading file " + fullPath + ": " + err.toString());
+			stream.on("end", function() {
 				if(!response.headersSent) {
-					response.writeHead(500, {"Content-Type": "text/plain"});
-					response.end("Read error");
+					response.end();
 				}
 			});
 			stream.pipe(response);

--- a/core/modules/server/routes/get-file.js
+++ b/core/modules/server/routes/get-file.js
@@ -19,7 +19,6 @@ exports.handler = function(request,response,state) {
 		baseFilename = path.resolve(state.boot.wikiPath,"files"),
 		filename = path.resolve(baseFilename,suppliedFilename),
 		extension = path.extname(filename);
-
 	// Check that the filename is inside the wiki files folder
 	if(path.relative(baseFilename,filename).indexOf("..") === 0) {
 		return state.sendResponse(403,{"Content-Type": "text/plain"},"Access denied");

--- a/core/modules/server/routes/get-file.js
+++ b/core/modules/server/routes/get-file.js
@@ -15,28 +15,57 @@ exports.path = /^\/files\/(.+)$/;
 exports.handler = function(request,response,state) {
 	var path = require("path"),
 		fs = require("fs"),
-		util = require("util"),
-		suppliedFilename = $tw.utils.decodeURIComponentSafe(state.params[0]),
-		baseFilename = path.resolve(state.boot.wikiPath,"files"),
-		filename = path.resolve(baseFilename,suppliedFilename),
-		extension = path.extname(filename);
-	// Check that the filename is inside the wiki files folder
-	if(path.relative(baseFilename,filename).indexOf("..") !== 0) {
-		// Send the file
-		fs.readFile(filename,function(err,content) {
-			var status,content,type = "text/plain";
-			if(err) {
-				console.log("Error accessing file " + filename + ": " + err.toString());
-				status = 404;
-				content = "File '" + suppliedFilename + "' not found";
-			} else {
-				status = 200;
-				content = content;
-				type = ($tw.config.fileExtensionInfo[extension] ? $tw.config.fileExtensionInfo[extension].type : "application/octet-stream");
-			}
-			state.sendResponse(status,{"Content-Type": type},content);
-		});
-	} else {
-		state.sendResponse(404,{"Content-Type": "text/plain"},"File '" + suppliedFilename + "' not found");
+		filename = $tw.utils.decodeURIComponentSafe(state.params[0]),
+		basePath = path.resolve(state.boot.wikiPath,"files"),
+		fullPath = path.resolve(basePath,filename),
+		extension = path.extname(fullPath);
+
+	if(path.relative(basePath,fullPath).indexOf("..") === 0) {
+		return state.sendResponse(403,{"Content-Type": "text/plain"},"Access denied");
 	}
+	fs.stat(fullPath, function(err, stats) {
+		if(err) {
+			$tw.utils.error("Error accessing file " + fullPath + ": " + err.toString());
+			return state.sendResponse(404,{"Content-Type": "text/plain"},"File '" + filename + "' not found");
+		}
+		var type = ($tw.config.fileExtensionInfo[extension] ? $tw.config.fileExtensionInfo[extension].type : "application/octet-stream");
+		var responseHeaders = {
+			"Content-Type": type,
+			"Accept-Ranges": "bytes" 
+		};
+		// Handle range requests
+		var rangeHeader = request.headers.range;
+		if(rangeHeader) {
+			var parts = rangeHeader.replace(/bytes=/, "").split("-"),
+				start = parseInt(parts[0], 10),
+				end = parts[1] ? parseInt(parts[1], 10) : stats.size - 1,
+				chunksize = (end - start) + 1;
+
+			responseHeaders["Content-Range"] = `bytes ${start}-${end}/${stats.size}`;
+			responseHeaders["Content-Length"] = chunksize;
+			response.writeHead(206, responseHeaders);
+			var stream = fs.createReadStream(fullPath, {start, end});
+			stream.on("error", function(err) {
+				$tw.utils.error("Error reading file " + fullPath + ": " + err.toString());
+				if(!response.headersSent) {
+					response.writeHead(500, {"Content-Type": "text/plain"});
+					response.end("Read error");
+				}
+			});
+			stream.pipe(response);
+		} else {
+			// Handle regular requests
+			responseHeaders["Content-Length"] = stats.size;
+			response.writeHead(200, responseHeaders);
+			var stream = fs.createReadStream(fullPath);
+			stream.on("error", function(err) {
+				$tw.utils.error("Error reading file " + fullPath + ": " + err.toString());
+				if(!response.headersSent) {
+					response.writeHead(500, {"Content-Type": "text/plain"});
+					response.end("Read error");
+				}
+			});
+			stream.pipe(response);
+		}
+	});
 };

--- a/core/modules/server/routes/get-file.js
+++ b/core/modules/server/routes/get-file.js
@@ -21,7 +21,7 @@ exports.handler = function(request,response,state) {
 		extension = path.extname(filename);
 	// Check that the filename is inside the wiki files folder
 	if(path.relative(baseFilename,filename).indexOf("..") === 0) {
-		return state.sendResponse(403,{"Content-Type": "text/plain"},"Access denied");
+		return state.sendResponse(404,{"Content-Type": "text/plain"},"File '" + suppliedFilename + "' not found");
 	}
 	fs.stat(filename, function(err, stats) {
 		if(err) {

--- a/editions/tw5.com/tiddlers/webserver/WebServer API_ Get File.tid
+++ b/editions/tw5.com/tiddlers/webserver/WebServer API_ Get File.tid
@@ -1,5 +1,5 @@
 created: 20181002123907518
-modified: 20181002124345482
+modified: 20250605000000000
 tags: [[WebServer API]]
 title: WebServer API: Get File
 type: text/vnd.tiddlywiki
@@ -15,11 +15,22 @@ Parameters:
 
 * ''pathname'' - URI encoded path to the file
 
+Headers:
+
+* ''Range'' - <<.from-version "5.3.7">> (optional) Request specific byte ranges using the format `bytes=start-end`. Supports partial content delivery for media streaming.
+
 Response:
 
 * 200 OK
 *> `Content-Type: <content-type>` (determined from file extension)
-*> Body: data retrieved from file
+*> `Content-Length: <file-size>`
+*> `Accept-Ranges: bytes`
+*> Body: complete file data
+* 206 Partial Content (when Range header is provided)
+*> `Content-Type: <content-type>` (determined from file extension)
+*> `Content-Length: <range-size>`
+*> `Content-Range: bytes <start>-<end>/<total-size>`
+*> `Accept-Ranges: bytes`
+*> Body: requested byte range data
 * 403 Forbidden
 * 404 Not Found
-


### PR DESCRIPTION
Support video Range HTTP header and straming large file. I've tested it, now video in ./files folder can be loaded partially with 206 Partial Content, also allow downloader to resume download things.

This will add more code to the core, so I make it a separate PR incase you don't like it. I currently only need #9075 , and this PR is only a byproduct.

I'm not sure how we could add test for server route. I test this manually with agent like this:

![图片](https://github.com/user-attachments/assets/a2b6b382-96cc-4388-9e13-8d07abe5d670)
