### PR TITLE
Adds an images filter

### DIFF
--- a/core/modules/filters/images.js
+++ b/core/modules/filters/images.js
@@ -1,0 +1,21 @@
+/*\
+title: $:/core/modules/filters/images.js
+type: application/javascript
+module-type: filteroperator
+
+Filter operator for returning all the images used in a image widgets in a tiddler
+
+\*/
+
+"use strict";
+
+/*
+Export our filter function
+*/
+exports.images = function(source,operator,options) {
+	var results = new $tw.utils.LinkedList();
+	source(function(tiddler,title) {
+		results.pushTop(options.wiki.getTiddlerImages(title));
+	});
+	return results.makeTiddlerIterator(options.wiki);
+};

--- a/editions/test/tiddlers/tests/data/filters/Images.tid
+++ b/editions/test/tiddlers/tests/data/filters/Images.tid
@@ -1,0 +1,28 @@
+title: Filters/images
+description: Test images operator
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Tiddler1
+
+TiddlyWiki <$image source="https://tiddlywiki.com/images/tiddlywiki-logo.png" alt="TiddlyWiki logo" width="100px" height="100px"/><$image source="Image4" alt="Image4" width="100px" height="100px"/>.
++
+title: Tiddler2
+
+This is an image <$image source="Image1"/> and this is another image [img[Image2]] but this image won't be picked up <img src="Image3" alt="Image3" width="100px" height="100px"/> nor will this one {{Image4}}
++
+title: Image4
+type: image/png
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=
++
+title: Output
+
+\whitespace trim
+(<$text text={{{ [[Tiddler1]images[]join[,]] }}}/>)
+(<$text text={{{ [[Tiddler2]images[]join[,]] }}}/>)
++
+title: ExpectedResult
+
+<p>(https://tiddlywiki.com/images/tiddlywiki-logo.png,Image4)
+(Image1,Image2)</p>


### PR DESCRIPTION
- This PR adds an images filter that returns all images used in a tiddler using an `$image` widget or the `[img[...]]` syntax.

-  It introduces a new wiki.extractFromParseTree method that is now used by extractImages, extractLinks and extractTranscludes.

Transclusions of image tiddlers are not picked up by the filter, neither are `<img>` HTML elements, as is consistent with the `links[]` operator which only returns links created by the `$link` widget.

There may however be value in supporting extractions of `<img>` HTML elements as well, possibly enabled by a suffix. Any thoughts on this are welcome.

