### PR TITLE
Fix modal help link style

### DIFF
--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -143,6 +143,7 @@ Modal.prototype.display = function(title,options) {
 		link.setAttribute("href",tiddler.fields.help);
 		link.setAttribute("target","_blank");
 		link.setAttribute("rel","noopener noreferrer");
+		link.setAttribute("class","tc-tiddlylink-external");
 		link.appendChild(this.srcDocument.createTextNode("Help"));
 		modalFooterHelp.appendChild(link);
 		modalFooterHelp.style.float = "left";


### PR DESCRIPTION
Only a small fix.

Apply `tc-tiddlylink-external` style to help links in modals.