### PR TITLE
Remove system-ui & increase sans-serif priority for default font-family

### DIFF
--- a/themes/tiddlywiki/vanilla/settings.multids
+++ b/themes/tiddlywiki/vanilla/settings.multids
@@ -1,6 +1,6 @@
 title: $:/themes/tiddlywiki/vanilla/settings/
 
-fontfamily: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", system-ui, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"
+fontfamily: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", sans-serif, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"
 codefontfamily: ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace
 backgroundimageattachment: fixed
 backgroundimagesize: auto


### PR DESCRIPTION
I've found that #8951 can mess up browser's default font settings for different languages, so I removed `system-ui` from it.

After further investigation, I found that it's `Arial` font that applys improper font to arabic, so I increased the priority of `sans-serif` to follow browser default font settings as much as possible.