### PR TITLE
fix disabled button if border colours are defined

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -96,6 +96,12 @@ html button {
 	fill: <<colour button-foreground>>;
 	background: <<colour button-background>>;
 	border-color: <<colour button-border>>;
+	cursor: pointer;
+}
+
+button:disabled {
+	cursor: default;
+	color: <<colour muted-foreground>>;
 }
 
 button:disabled svg {


### PR DESCRIPTION
This PR 

- sets a the `cursor: pointer` for **active** buttons
- sets `cursor:default` for **disabled** buttons
- sets foreground colour to muted for disabled buttons. 

- fixes #9090

![image](https://github.com/user-attachments/assets/87ab4a20-12d0-4be0-b541-36b422f953f0)

## Test code: 

```
<$button disabled=yes>
{{$:/core/images/close-all-button}} Disabled Button
</$button>

<$button disabled=no>
{{$:/core/images/done-button}} OK Button
</$button>


<$button class="tc-btn-invisible" disabled=yes>
{{$:/core/images/close-all-button}} Disabled Button 
</$button>

<$button class="tc-btn-invisible" disabled=no>
{{$:/core/images/done-button}} OK Button
</$button>

<$button disabled=yes style="border:solid 1px red;">
{{$:/core/images/close-all-button}} Disabled Button
</$button>

<$button disabled=no style="border:1px solid;">
{{$:/core/images/done-button}} OK Button
</$button>
```