### PR TITLE
[DOCS] Update TiddlyWiki Archive

### DIFF
--- a/editions/tw5.com/tiddlers/about/Archive.tid
+++ b/editions/tw5.com/tiddlers/about/Archive.tid
@@ -1,5 +1,5 @@
 created: 20231005205623086
-modified: 20241115193649399
+modified: 20250707164852800
 tags: About
 title: TiddlyWiki Archive
 
@@ -8,7 +8,7 @@ title: TiddlyWiki Archive
 5.1.10 5.1.11 5.1.12 5.1.13 5.1.14 5.1.15 5.1.16 5.1.17 5.1.18 5.1.19
 5.1.20 5.1.21 5.1.22 5.1.23
 5.2.0 5.2.1 5.2.2 5.2.3 5.2.4 5.2.5 5.2.6 5.2.7
-5.3.0 5.3.1 5.3.2 5.3.3 5.3.4 5.3.5 5.3.6
+5.3.0 5.3.1 5.3.2 5.3.3 5.3.4 5.3.5 5.3.6 5.3.7
 \end
 
 Older versions of TiddlyWiki are available in the [[archive|https://github.com/TiddlyWiki/tiddlywiki.com-gh-pages/tree/master/archive]]:

--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.3.7.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.3.7.tid
@@ -1,11 +1,11 @@
 caption: 5.3.7
 created: 20250707115023707
-modified: 20250707115023707
+description: $:/ControlPanel Wiki Information Tab, Updated [[CodeMirror Plugin]]s to v5.65.19, Support AVIF Images and Bug Fixes 
+modified: 20250707165341181
 released: 20250707115023707
 tags: ReleaseNotes
 title: Release 5.3.7
 type: text/vnd.tiddlywiki
-description: Under development
 
 //[[See GitHub for detailed change history of this release|https://github.com/TiddlyWiki/TiddlyWiki5/compare/v5.3.6...master]]//
 


### PR DESCRIPTION
- Update TiddlyWiki Archive tiddler
- Update the Release v5.3.7 description field
 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>