### PR TITLE
[5.4.0] Update eslint target to 2017 and do initial fixes

### DIFF
--- a/core/modules/widgets/scrollable.js
+++ b/core/modules/widgets/scrollable.js
@@ -181,7 +181,7 @@ ScrollableWidget.prototype.render = function(parent,nextSibling) {
 };
 
 ScrollableWidget.prototype.listenerFunction = function(event) {
-	self = this;
+	var self = this;
 	clearTimeout(this.timeout);
 	this.timeout = setTimeout(function() {
 		var existingTiddler = self.wiki.getTiddler(self.scrollableBind),

--- a/editions/test/tiddlers/tests/test-checkbox-widget.js
+++ b/editions/test/tiddlers/tests/test-checkbox-widget.js
@@ -103,7 +103,7 @@ Tests the checkbox widget thoroughly.
         ];
 
         var indexModeTests = fieldModeTests.map(data => {
-            var newData = {...data};
+            var newData = Object.assign({}, data);
             var newName = data.testName.replace('field mode', 'index mode');
             var tiddlerOneAlreadyExists = false;
             var newTiddlers = data.tiddlers.map(tiddler => {
@@ -274,14 +274,13 @@ Tests the checkbox widget thoroughly.
             listModeTests
             .filter(data => data.widgetText.includes("listField='colors'"))
             .map(data => {
-                var newData = {
-                    ...data,
-                    tiddlers: data.tiddlers.map(tiddler => ({...tiddler, list: tiddler.colors, colors: undefined})),
+                var newData = Object.assign({}, data, {
+                    tiddlers: data.tiddlers.map(tiddler => Object.assign({}, tiddler, {list: tiddler.colors, colors: undefined})),
                     widgetText: data.widgetText.replace("listField='colors'", "listField='list'"),
                     expectedChange: {
                         "Colors": { list: data.expectedChange.Colors.colors.split(' ') }
                     },
-                }
+                })
                 return newData;
             })
         );
@@ -289,20 +288,19 @@ Tests the checkbox widget thoroughly.
             listModeTests
             .filter(data => data.widgetText.includes("listField='colors'"))
             .map(data => {
-                var newData = {
-                    ...data,
-                    tiddlers: data.tiddlers.map(tiddler => ({...tiddler, tags: tiddler.colors, colors: undefined})),
+                var newData = Object.assign({}, data, {
+                    tiddlers: data.tiddlers.map(tiddler => Object.assign({}, tiddler, {tags: tiddler.colors, colors: undefined})),
                     widgetText: data.widgetText.replace("listField='colors'", "listField='tags'"),
                     expectedChange: {
                         "Colors": { tags: data.expectedChange.Colors.colors.split(' ') }
                     },
-                }
+                })
                 return newData;
             })
         );
 
         var indexListModeTests = listModeTests.map(data => {
-            var newData = {...data};
+            var newData = Object.assign({}, data);
             var newName = data.testName.replace('list mode', 'index list mode');
             var newTiddlers = data.tiddlers.map(tiddler => {
                 if (tiddler.hasOwnProperty('colors')) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,8 @@
 const globals = require("globals");
+/** @type {import("@eslint/js")} */
 const js = require("@eslint/js");
+/** @type {import("eslint")} */
+const eslint = require("eslint");
 
 const {
     FlatCompat,
@@ -21,6 +24,9 @@ module.exports = [{
         "core/modules/utils/diff-match-patch/diff_match_patch_uncompressed.js",
         "core/modules/utils/dom/csscolorparser.js",
         "plugins/tiddlywiki/*/files/",
+        "eslint.config.js",
+        "playwright.config.js",
+
     ],
 }, ...compat.extends("eslint:recommended"), {
     languageOptions: {
@@ -31,7 +37,7 @@ module.exports = [{
             $tw: "writable", // temporary
         },
 
-        ecmaVersion: 5,
+        ecmaVersion: 2017,
         sourceType: "commonjs",
     },
 
@@ -213,13 +219,13 @@ module.exports = [{
         "no-promise-executor-return": "error",
         "no-proto": "off",
         "no-restricted-exports": "error",
-        "no-restricted-globals": "error",
+        "no-restricted-globals": ["error", "self"],
         "no-restricted-imports": "error",
         "no-restricted-modules": "error",
         "no-restricted-properties": "error",
         "no-restricted-syntax": "error",
         "no-return-assign": "off",
-        "no-return-await": "error",
+        "no-return-await": "off",
         "no-script-url": "off",
         "no-self-compare": "off",
         "no-sequences": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ const eslint = require("eslint");
 const {
     FlatCompat,
 } = require("@eslint/eslintrc");
+const { fixupConfigRules } = require("@eslint/compat");
 
 const compat = new FlatCompat({
     baseDirectory: __dirname,
@@ -28,7 +29,10 @@ module.exports = [{
         "playwright.config.js",
 
     ],
-}, ...compat.extends("eslint:recommended"), {
+},
+...compat.extends("eslint:recommended"),
+...fixupConfigRules(compat.extends("plugin:es/restrict-to-es2017")),
+{
     languageOptions: {
         globals: {
             ...globals.browser,
@@ -37,7 +41,7 @@ module.exports = [{
             $tw: "writable", // temporary
         },
 
-        ecmaVersion: 2017,
+        ecmaVersion: 2025,
         sourceType: "commonjs",
     },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,21 +1,39 @@
-const globals = require("globals");
-/** @type {import("@eslint/js")} */
-const js = require("@eslint/js");
-/** @type {import("eslint")} */
-const eslint = require("eslint");
+//@ts-check
+// const globals = require("globals");
+// /** @type {import("@eslint/js")} */
+// const js = require("@eslint/js");
+// /** @type {import("eslint")} */
+// const eslint = require("eslint");
+// const { FlatCompat, } = require("@eslint/eslintrc");
+// const { fixupConfigRules } = require("@eslint/compat");
+import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
+import eslint from "eslint";
+import { FlatCompat } from "@eslint/eslintrc";
+import { fixupConfigRules } from "@eslint/compat";
+import esx from "eslint-plugin-es-x"
 
-const {
-    FlatCompat,
-} = require("@eslint/eslintrc");
-const { fixupConfigRules } = require("@eslint/compat");
+/** @type {import("eslint").Linter.Config} */
+const es2017rules = {
+    //@ts-ignore
+    plugins: esx.configs["flat/restrict-to-es2017"].plugins,
+    //@ts-ignore
+    rules: esx.configs["flat/restrict-to-es2017"].rules,
+    ignores: ["bin/**/*", "core-server/**/*"],
+};
+/** @type {import("eslint").Linter.Config} */
+const es2023rules = {
+    //@ts-ignore
+    plugins: esx.configs["flat/restrict-to-es2023"].plugins,
+    //@ts-ignore
+    rules: esx.configs["flat/restrict-to-es2023"].rules,
+    files: ["bin/**/*", "core-server/**/*"],
+};
 
-const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
-});
 
-module.exports = [{
+
+export default defineConfig([{
     ignores: [
         // Ignore "third party" code whose style we will not change.
         "boot/sjcl.js",
@@ -25,23 +43,15 @@ module.exports = [{
         "core/modules/utils/diff-match-patch/diff_match_patch_uncompressed.js",
         "core/modules/utils/dom/csscolorparser.js",
         "plugins/tiddlywiki/*/files/",
-        "eslint.config.js",
+        "eslint.config.mjs",
         "playwright.config.js",
-
     ],
+
 },
-...compat.extends("eslint:recommended"),
-...fixupConfigRules(compat.extends("plugin:es/restrict-to-es2017")),
+js.configs.recommended,
 {
     languageOptions: {
-        globals: {
-            ...globals.browser,
-            ...globals.commonjs,
-            ...globals.node,
-            $tw: "writable", // temporary
-        },
-
-        ecmaVersion: 2025,
+        ecmaVersion: "latest",
         sourceType: "commonjs",
     },
 
@@ -52,12 +62,10 @@ module.exports = [{
         "array-element-newline": "off",
         "arrow-body-style": "error",
         "arrow-parens": ["error", "as-needed"],
-
         "arrow-spacing": ["error", {
             after: true,
             before: true,
         }],
-
         "block-scoped-var": "off",
         "block-spacing": "off",
         "brace-style": "off",
@@ -101,38 +109,18 @@ module.exports = [{
         "init-declarations": "off",
         "jsx-quotes": "error",
         "key-spacing": "off",
-
         "keyword-spacing": ["error", {
             before: true,
             after: false,
-
             overrides: {
-                case: {
-                    after: true,
-                },
-
-                do: {
-                    after: true,
-                },
-
-                else: {
-                    after: true,
-                },
-
-                return: {
-                    after: true,
-                },
-
-                throw: {
-                    after: true,
-                },
-
-                try: {
-                    after: true,
-                },
+                case: { after: true },
+                do: { after: true },
+                else: { after: true },
+                return: { after: true },
+                throw: { after: true },
+                try: { after: true },
             },
         }],
-
         "line-comment-position": "off",
         "linebreak-style": "off",
         "lines-around-comment": "off",
@@ -162,11 +150,7 @@ module.exports = [{
         "no-catch-shadow": "off",
         "no-confusing-arrow": "error",
         "no-console": "off",
-
-        "no-constant-condition": ["error", {
-            checkLoops: false,
-        }],
-
+        "no-constant-condition": ["error", { checkLoops: false }],
         "no-constructor-return": "error",
         "no-continue": "off",
         "no-div-regex": "off",
@@ -180,13 +164,11 @@ module.exports = [{
         "no-extra-label": "off",
         "no-extra-parens": "off",
         "no-floating-decimal": "off",
-
         "no-implicit-coercion": ["error", {
             boolean: false,
             number: false,
             string: false,
         }],
-
         "no-implicit-globals": "off",
         "no-implied-eval": "error",
         "no-inline-comments": "off",
@@ -285,11 +267,7 @@ module.exports = [{
         "prefer-spread": "off",
         "prefer-template": "off",
         "quote-props": "off",
-
-        quotes: ["error", "double", {
-            avoidEscape: true,
-        }],
-
+        quotes: ["error", "double", { avoidEscape: true }],
         radix: "off",
         "require-atomic-updates": "error",
         "require-await": "error",
@@ -315,17 +293,12 @@ module.exports = [{
         "template-tag-spacing": "error",
         "unicode-bom": ["error", "never"],
         "valid-jsdoc": "off",
-
-        "valid-typeof": ["error", {
-            requireStringLiterals: false,
-        }],
-
+        "valid-typeof": ["error", { requireStringLiterals: false }],
         "vars-on-top": "off",
         "wrap-iife": "off",
         "wrap-regex": "off",
         "yield-star-spacing": "error",
         yoda: "off",
-
         // temporary rules
         "no-useless-escape": "off",
         "no-unused-vars": "off",
@@ -340,4 +313,8 @@ module.exports = [{
         "no-unreachable": "off",
         "no-self-assign": "off",
     },
-}];
+
+},
+    es2017rules,
+    es2023rules
+]);

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "wiki"
   ],
   "devDependencies": {
-    "@eslint/compat": "^1.3.2",
-    "@eslint/js": "^9.35.0",
-    "eslint": "^9.35.0",
-    "eslint-plugin-es": "^4.1.0",
-    "globals": "^16.4.0"
+    "@eslint/compat": "1.4.0",
+    "@eslint/js": "9.36.0",
+    "eslint": "9.36.0",
+    "eslint-plugin-es-x": "9.1.0",
+    "globals": "16.4.0"
   },
   "bundleDependencies": [],
   "license": "BSD",
@@ -38,7 +38,8 @@
   "scripts": {
     "dev": "node ./tiddlywiki.js ./editions/tw5.com-server --listen",
     "test": "node ./tiddlywiki.js ./editions/test --verbose --version --build index",
+    "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "lint": "eslint ."
+    "lint:check": "eslint . --fix-dry-run"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,11 @@
     "wiki"
   ],
   "devDependencies": {
-    "eslint": "^9.12.0",
-    "@eslint/js": "^9.12.0"
+    "@eslint/compat": "^1.3.2",
+    "@eslint/js": "^9.35.0",
+    "eslint": "^9.35.0",
+    "eslint-plugin-es": "^4.1.0",
+    "globals": "^16.4.0"
   },
   "bundleDependencies": [],
   "license": "BSD",

--- a/plugins/tiddlywiki/googleanalytics/googleanalytics.js
+++ b/plugins/tiddlywiki/googleanalytics/googleanalytics.js
@@ -25,7 +25,7 @@ exports.startup = function() {
 			var gaMeasurementID = $tw.wiki.getTiddlerText("$:/GoogleAnalyticsMeasurementID","").replace(/\n/g,"");
 			var url ="https://www.googletagmanager.com/gtag/js?id=" + gaMeasurementID;
 			window.dataLayer = window.dataLayer || [];
-			window.gtag = function() { window.dataLayer?.push(arguments); };
+			window.gtag = function() { if(window.dataLayer) window.dataLayer.push(arguments); };
 			window.gtag("js",new Date());
 			window.gtag("config",gaMeasurementID);
 			const scriptElement = window.document.createElement("script");

--- a/plugins/tiddlywiki/xlsx-utils/importer.js
+++ b/plugins/tiddlywiki/xlsx-utils/importer.js
@@ -133,7 +133,7 @@ XLSXImporter.prototype.processField = function(fieldImportSpecTitle) {
 							value = cell.v.toString();
 							break;
 						case "string":
-							// Intentional fall-through
+							// falls through
 						default:
 							value = cell.w;
 							break;


### PR DESCRIPTION
This updates the eslint target to 2017 and does a first pass on basic fixes.

I tried to break each action into separate commits. Inspect the diff of each commit. 