### PR TITLE
[bugfix] Fix word break in code blocks

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -320,6 +320,7 @@ pre > code {
 	padding: 0.5em;
 	border: none;
 	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
+	word-break: break-all;
 	background-color: inherit;
 	color: inherit;
 	overflow-x: auto;


### PR DESCRIPTION
This PR also targets v5.3.8 bugfix release.

Fix a problem of wrapping in codeblocks, so that it looks the same as in a code editor.

Before:

After:
