### PR TITLE
[DOCS] Button widget role attribute

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
@@ -1,6 +1,6 @@
 caption: button
 created: 20131024141900000
-modified: 20231113093304323
+modified: 20250720030349018
 tags: Widgets TriggeringWidgets
 title: ButtonWidget
 type: text/vnd.tiddlywiki
@@ -39,6 +39,7 @@ The content of the `<$button>` widget is displayed within the button.
 |popupTitle |Title of a state tiddler for a popup that is toggled when the button is clicked. In difference to the <<.attr popup>> attribute, ''no'' TextReference is used. See PopupMechanism for details |
 |popupAbsCoords |<<.from-version "5.2.4">> If set to ''yes'' writes absolute coordinates to the tiddler referenced by the <<.attr popup>>. If set to ''no'' (the default) uses relative coordinates. See [[Coordinate Systems]] for details |
 |aria-label |Optional [[Accessibility]] label |
+|role |<<.from-version "5.2.3">> Optional [[ARIA role|https://developer.mozilla.org/zh-CN/docs/Web/Accessibility/ARIA/Reference/Roles]] |
 |tooltip |Optional tooltip |
 |class |An optional CSS class name to be assigned to the HTML element|
 |data-* |<<.from-version "5.3.2">> Optional [[data attributes|https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes]] to be assigned to the HTML element |


### PR DESCRIPTION
Button widget supports role attribute in v5.2.3, but it wasn't documented.