### PR TITLE
Extends server route exports to allow ordering

### DIFF
--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -74,6 +74,11 @@ function Server(options) {
 		// console.log("Loading server route " + title);
 		self.addRoute(routeDefinition);
 	});
+	this.routes.sort((a, b) => {
+		const priorityA = a.info?.priority ?? 100,
+			priorityB = b.info?.priority ?? 100;
+		return priorityB - priorityA;
+	});
 	// Initialise the http vs https
 	this.listenOptions = null;
 	this.protocol = "http";


### PR DESCRIPTION
This PR adds support for an `info` property to server `route` module exports. The `info` object may include a `priority` field, which determines the route’s order of precedence. This helps avoid ugly hacks like having to name route tiddlers as `$:_plugins/sq/myroute.js` to have it take precedence over core routes.

Priorities are numeric and follow a descending order: routes with higher priority values are processed first, similar to how `saver` modules are prioritized.

To maintain backward compatibility with existing code, any module that omits `info` or `info.priority` is assigned a default priority of 100. Core server routes will also be updated to explicitly use this default value of 100.

On a related note, is there a minimum node version that we target? The optional chaining operator and nullish coalescing operators are supported in Node 14+.