### PR TITLE
[Docs] Add Filter Syntax History

### DIFF
--- a/editions/tw5.com/tiddlers/Filter Syntax History.tid
+++ b/editions/tw5.com/tiddlers/Filter Syntax History.tid
@@ -1,0 +1,48 @@
+created: 20250730112934080
+modified: 20250730121207166
+tags: 
+title: Filter Syntax History
+
+Derived from a post at [[Talk Tiddlywiki|https://talk.tiddlywiki.org/t/filter-syntax-history/13058]] written by Jeremy. 
+
+---
+
+The story starts with the [[double square bracket link syntax|Linking in WikiText]] used in wikitext for links. This was already an established usage in wikis. 
+
+I switched the order of pretty links because
+
+* I thought Wikipedia’s `[[link address|link text]]` was the wrong way around because it broke up sentences: `The file is [[https://example.com/thing|here]]` seems less readable than 
+
+* `The file is [[here|https://example.com/thing]]`. Obviously now I wish I hadn’t been so big headed, and had just gone with Wikipedia’s established usage.
+
+Anyhow, one way to look at the [[double square bracket link syntax|Linking in WikiText]] is that it establishes a way to quote page/tiddler titles so that they may contain spaces, and don’t have to use CamelCase.
+
+Thus, in ~TiddlyWiki Classic, when I was implementing the DefaultTiddlers feature it was natural to use double square brackets to quote titles containing spaces.
+
+Then, when I was starting to think about ~TiddlyWiki 5 I wanted to extend the implementation of DefaultTiddlers so that more complex logic could be expressed while retaining backwards compatibility.
+
+A trick that I am apt to use in such situations is to try to engineer things so that the current behaviour is re-interpreted as a shortcut syntax for a new, richer syntax that provides more flexibility. In this case, the idea was that in filters we would interpret `[[mytiddler]]` as //a shortcut// for `[title[mytiddler]]`. Then we could put any keywords we like in place of "title", giving us an infinitely extensible syntax.
+
+A similar example is the way that we implemented [[filter run prefixes|Filter Run Prefix]] by retrospectively defining the absence of a prefix as implying a default prefix.
+
+We implemented a very, very simple first version of the filter syntax in ~TiddlyWiki Classic that supported things like `[tag[mytag]]`, but it wasn’t until ~TiddlyWiki 5 that it evolved into something approaching a programming language. 
+
+As others have probably expressed much more eloquently, a characteristic of the programming languages that I love is that they start with a small number of ''principles that are consistently applied and combined''. In the case of ~TiddlyWiki, the list would be very roughly:
+
+* Double square brackets for [[linking and quoting|Linking in WikiText]]
+* Curly braces for [[transclusion|Transclusion in WikiText]]
+* Angle brackets for [[macros|Procedures]] (which evolved in variables)
+* Double exclamation marks to indicate fields `{{!!myfield}}`
+* Double hashes to indicate indexes `{{##myindex}}`
+* Smashing together adjacent filter operations by removing the combining `][`
+* The dollar sign as a rough signifier of data [[owned by the system|SystemTiddlers]] rather than the user
+
+As I have written about elsewhere I was privileged to know Joe Armstrong, the co-inventor of Erlang, in the last few years of his life – we were working together on a book about TiddlyWiki when he passed away in 2019.
+
+Joe had contacted me out of the blue ten years before to express his admiration for ~TiddlyWiki, and we had developed a friendship. He was actually a big fan of TW5’s filter syntax, and used to make me feel better about it by joking that I had (re-)invented the monad, which sounded impressive to me. That doesn’t make the filter language any easier to learn, but it does mean that it is worth learning: it’s a real language, based on the same principles as other languages.
+
+I find it pleasing that the TW5 filter language has its roots in decisions that were taken in the TWC days. It’s still hard to learn, but that’s an ongoing paradox of programming: 
+
+<<<.tc-big-quote
+People want to do complicated things, and complicated things are complicated. It’s hard to see how we could have made filters any simpler without depriving users of the possibility of doing complicated things.
+<<<

--- a/editions/tw5.com/tiddlers/concepts/DefaultTiddlers.tid
+++ b/editions/tw5.com/tiddlers/concepts/DefaultTiddlers.tid
@@ -1,5 +1,5 @@
 created: 20180306113011255
-modified: 20180306161225140
+modified: 20250730113615235
 tags: Concepts
 title: DefaultTiddlers
 type: text/vnd.tiddlywiki
@@ -9,9 +9,9 @@ type: text/vnd.tiddlywiki
 There are two ways default tiddlers can be defined:
 
 * A [[title-list|Title List]] eg: `TiddlerTitle` and `[[Title with spaces]]`
-* [[Filter expressions|Filter Expression], using filter operators eg: `[tag[HelloThere]]`
+* [[Filter expressions|Filter Expression]], using filter operators eg: `[tag[HelloThere]]`
 
 The resulting list of titles is then inserted into the [[story river|Story River]].
 
-The [[control panel|$:/ControlPanel]] ''-> Info -> Basics -> Default tiddler'' setting includes a text box for direct access to $:/DefaultTiddlers.
+The [[control panel|$:/ControlPanel]] ''-> Info -> Basics -> Default tiddler'' setting includes a text box for direct access to $:/DefaultTiddlers
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Syntax.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Syntax.tid
@@ -1,6 +1,6 @@
 created: 20140210141217955
 list: [[Filter Expression]] [[Filter Run]] [[Filter Step]] [[Filter Parameter]] [[Filter Whitespace]]
-modified: 20230710074340943
+modified: 20250730121946423
 tags: Filters
 title: Filter Syntax
 type: text/vnd.tiddlywiki
@@ -22,3 +22,5 @@ The "Filter Syntax" description starts with:
 """/>
 
 <<.tip "The railroad boxes as the one above can be used to navigate">>
+
+<<.tip "Also see: [[Filter Syntax History]]">>


### PR DESCRIPTION
This PR adds a new tiddler: "Filter Syntax History" derived from Talk https://talk.tiddlywiki.org/t/filter-syntax-history/13058

- Since DefaultTiddlers is linked, and had a typo. I also fixed the typo there. 
- Add a new link to Filter Syntax
 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small> 