### PR TITLE
[Docs] Fix typo in DefaultTiddlers

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/DefaultTiddlers.tid
+++ b/editions/tw5.com/tiddlers/concepts/DefaultTiddlers.tid
@@ -9,7 +9,7 @@ type: text/vnd.tiddlywiki
 There are two ways default tiddlers can be defined:
 
 * A [[title-list|Title List]] eg: `TiddlerTitle` and `[[Title with spaces]]`
-* [[Filter expressions|Filter Expression], using filter operators eg: `[tag[HelloThere]]`
+* [[Filter expressions|Filter Expression]], using filter operators eg: `[tag[HelloThere]]`
 
 The resulting list of titles is then inserted into the [[story river|Story River]].
 


### PR DESCRIPTION
This PR fixes a typo in DefaultTiddlers 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>