### PR TITLE
Fix Jagged Filter Run Railroad Diagram

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Run.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Run.tid
@@ -9,11 +9,11 @@ type: text/vnd.tiddlywiki
 \end none
 ( "[" { [[<"Filter Step">|"Filter Step"]] } "]"
   |
-  [:{/"anything but [ ] or whitespace"/}]
+  {[:/"anything but [ ] or whitespace"/]}
   |
-  '"' [:{/'anything but "'/}] '"'
+  '"' {[:/'anything but "'/]} '"'
   |
-  "'" [:{/"anything but '"/}] "'"
+  "'" {[:/"anything but '"/]} "'"
 )
 """/>
 


### PR DESCRIPTION
The three bottom loops don’t actually allow smooth flow; their bottom halves are attached inside rather than outside. See Filter Step for comparison.

This simply inverts the nesting of `[: { ... } ]` to `{ [: ... ] }`.

### Before ###
<img width="410" height="206" alt="image" src="https://github.com/user-attachments/assets/65eee7d4-3f2b-4804-bcda-c1b6bd2838da" />

### After ###
<img width="401" height="204" alt="image" src="https://github.com/user-attachments/assets/05f76400-2485-471c-bbef-b59e4cb4220e" />

This was mentioned in a [talk thread][tt].

  [tt]: https://talk.tiddlywiki.org/t/filter-syntax-history/13058/9