### PR TITLE
[Docs] Fix Filter Step Railroad diagram

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Step.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Step.tid
@@ -1,5 +1,5 @@
 created: 20150124182127000
-modified: 20230710074414361
+modified: 20250731101041336
 tags: [[Filter Run]]
 title: Filter Step
 type: text/vnd.tiddlywiki
@@ -11,10 +11,10 @@ In programming terms, it is akin to a function call to which the step's input is
 <$railroad text="""
 \start none
 \end none
-[:"!"]
+["!"]
 ( / "if omitted, defaults to: title" /|:
-( - | :[[operator|"Filter Operators"]] )
-{ [:":" [[suffix|"Filter Operators"]] ] } )
+( :[[operator|"Filter Operators"]] )
+[ {":" [: [[suffix|"Filter Operators"]] ] }] )
 { [[parameter|"Filter Parameter"]] + "," }
 """/>
 


### PR DESCRIPTION
This PR fixes the Filter Step railroad diagram. 

- The `: suffix` can be skipped
- There can be `::suffix` and
- `:suffix1:suffix2`

The `!` is optional and used rarely. 
There are some operators that have :suffixes but that are a view. -> The most common filter step is `operator parameter`, which this change now shows. 
 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>