### PR TITLE
Extends server routes to support multiple methods

### DIFF
--- a/core/modules/server/routes/delete-tiddler.js
+++ b/core/modules/server/routes/delete-tiddler.js
@@ -8,7 +8,7 @@ DELETE /recipes/default/tiddlers/:title
 \*/
 "use strict";
 
-exports.method = "DELETE";
+exports.methods = ["DELETE"];
 
 exports.path = /^\/bags\/default\/tiddlers\/(.+)$/;
 

--- a/core/modules/server/routes/get-favicon.js
+++ b/core/modules/server/routes/get-favicon.js
@@ -8,7 +8,7 @@ GET /favicon.ico
 \*/
 "use strict";
 
-exports.method = "GET";
+exports.methods = ["GET"];
 
 exports.path = /^\/favicon.ico$/;
 

--- a/core/modules/server/routes/get-file.js
+++ b/core/modules/server/routes/get-file.js
@@ -8,7 +8,7 @@ GET /files/:filepath
 \*/
 "use strict";
 
-exports.method = "GET";
+exports.methods = ["GET"];
 
 exports.path = /^\/files\/(.+)$/;
 

--- a/core/modules/server/routes/get-index.js
+++ b/core/modules/server/routes/get-index.js
@@ -8,7 +8,7 @@ GET /
 \*/
 "use strict";
 
-exports.method = "GET";
+exports.methods = ["GET"];
 
 exports.path = /^\/$/;
 

--- a/core/modules/server/routes/get-login-basic.js
+++ b/core/modules/server/routes/get-login-basic.js
@@ -8,7 +8,7 @@ GET /login-basic -- force a Basic Authentication challenge
 \*/
 "use strict";
 
-exports.method = "GET";
+exports.methods = ["GET"];
 
 exports.path = /^\/login-basic$/;
 

--- a/core/modules/server/routes/get-status.js
+++ b/core/modules/server/routes/get-status.js
@@ -8,7 +8,7 @@ GET /status
 \*/
 "use strict";
 
-exports.method = "GET";
+exports.methods = ["GET"];
 
 exports.path = /^\/status$/;
 

--- a/core/modules/server/routes/get-tiddler-html.js
+++ b/core/modules/server/routes/get-tiddler-html.js
@@ -8,7 +8,7 @@ GET /:title
 \*/
 "use strict";
 
-exports.method = "GET";
+exports.methods = ["GET"];
 
 exports.path = /^\/([^\/]+)$/;
 

--- a/core/modules/server/routes/get-tiddler.js
+++ b/core/modules/server/routes/get-tiddler.js
@@ -8,7 +8,7 @@ GET /recipes/default/tiddlers/:title
 \*/
 "use strict";
 
-exports.method = "GET";
+exports.methods = ["GET"];
 
 exports.path = /^\/recipes\/default\/tiddlers\/(.+)$/;
 

--- a/core/modules/server/routes/get-tiddlers-json.js
+++ b/core/modules/server/routes/get-tiddlers-json.js
@@ -10,7 +10,7 @@ GET /recipes/default/tiddlers.json?filter=<filter>
 
 var DEFAULT_FILTER = "[all[tiddlers]!is[system]sort[title]]";
 
-exports.method = "GET";
+exports.methods = ["GET"];
 
 exports.path = /^\/recipes\/default\/tiddlers.json$/;
 

--- a/core/modules/server/routes/put-tiddler.js
+++ b/core/modules/server/routes/put-tiddler.js
@@ -8,7 +8,7 @@ PUT /recipes/default/tiddlers/:title
 \*/
 "use strict";
 
-exports.method = "PUT";
+exports.methods = ["PUT"];
 
 exports.path = /^\/recipes\/default\/tiddlers\/(.+)$/;
 


### PR DESCRIPTION
This PR extends server routes to support multiple methods by introducing a new `exports.methods` property that can be an array of  supported methods.:`export.method = ["COPY","MOVE"];`

If this property is not present, we fallback to `exports.method` for backwards compatiblity.

The change is backwards compatible. The use case is to be able to have a handler that can handle multiple methods, this is especially useful if the routes are being handed off to a common class that handles them all.

All existing core server routes have been updated to use `exports.methods` instead of `exports.method`