### PR TITLE
Change camel-case hint, since it is disabled by default now.

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -147,7 +147,7 @@ Settings/AutoSave/Disabled/Description: Do not save changes automatically
 Settings/AutoSave/Enabled/Description: Save changes automatically
 Settings/AutoSave/Hint: Attempt to automatically save changes during editing when using a supporting saver
 Settings/CamelCase/Caption: Camel Case Wiki Links
-Settings/CamelCase/Hint: You can globally disable automatic linking of ~CamelCase phrases. Requires reload to take effect
+Settings/CamelCase/Hint: Requires reload to take effect
 Settings/CamelCase/Description: Enable automatic ~CamelCase linking
 Settings/Caption: Settings
 Settings/EditorToolbar/Caption: Editor Toolbar


### PR DESCRIPTION
This PR fixes #9208

[[BUG] Faulty settings text](https://github.com/TiddlyWiki/TiddlyWiki5/issues/9208#top) #9208

New text looks like this:

<img width="1159" height="178" alt="image" src="https://github.com/user-attachments/assets/1e4f6642-38a9-4ba7-9003-e7eb0d50b3a6" />
