### PR TITLE
Mediaquery filter

### DIFF
--- a/core/modules/filters/mediaquery.js
+++ b/core/modules/filters/mediaquery.js
@@ -25,71 +25,66 @@ exports.mediaquery = function(source,operator,options) {
 	
 	// Only evaluate in browser environment
 	if($tw.browser && mediaQuery && widget) {
-		try {
-			// Use window.matchMedia to evaluate the media query
-			var mql = window.matchMedia(mediaQuery);
+		// Use window.matchMedia to evaluate the media query
+		var mql = window.matchMedia(mediaQuery);
+		
+		// Process each input title
+		source(function(tiddler,title) {
+			if(mql.matches) {
+				results.push(title);
+			}
+		});
+		
+		// Set up a listener for changes if we have a widget context
+		if(widget && widget.wiki) {
+			// Create a unique key for this listener
+			var listenerKey = "mql_" + (++listenerCounter);
 			
-			// Process each input title
-			source(function(tiddler,title) {
-				if(mql.matches) {
-					results.push(title);
+			// Define the change handler
+			var changeHandler = function(e) {
+				// Force a refresh of the widget when media query changes
+				if(widget.refreshSelf) {
+					widget.refreshSelf();
+				} else if(widget.parentWidget && widget.parentWidget.refreshChildren) {
+					widget.parentWidget.refreshChildren();
 				}
-			});
+			};
 			
-			// Set up a listener for changes if we have a widget context
-			if(widget && widget.wiki) {
-				// Create a unique key for this listener
-				var listenerKey = "mql_" + (++listenerCounter);
-				
-				// Define the change handler
-				var changeHandler = function(e) {
-					// Force a refresh of the widget when media query changes
-					if(widget.refreshSelf) {
-						widget.refreshSelf();
-					} else if(widget.parentWidget && widget.parentWidget.refreshChildren) {
-						widget.parentWidget.refreshChildren();
+			// Add the listener (use modern addEventListener if available)
+			if(mql.addEventListener) {
+				mql.addEventListener("change", changeHandler);
+			} else if(mql.addListener) {
+				// Fallback for older browsers
+				mql.addListener(changeHandler);
+			}
+			
+			// Store reference for cleanup
+			mediaQueryListeners[listenerKey] = {
+				mql: mql,
+				handler: changeHandler,
+				widget: widget
+			};
+			
+			// Clean up listener when widget is destroyed
+			if(widget) {
+				// Hook into widget destruction
+				var originalRemoveChildDomNodes = widget.removeChildDomNodes;
+				widget.removeChildDomNodes = function() {
+					if(mediaQueryListeners[listenerKey]) {
+						var listener = mediaQueryListeners[listenerKey];
+						if(listener.mql.removeEventListener) {
+							listener.mql.removeEventListener("change", listener.handler);
+						} else if(listener.mql.removeListener) {
+							// Fallback for older browsers
+							listener.mql.removeListener(listener.handler);
+						}
+						delete mediaQueryListeners[listenerKey];
+					}
+					if(originalRemoveChildDomNodes) {
+						originalRemoveChildDomNodes.call(this);
 					}
 				};
-				
-				// Add the listener (use modern addEventListener if available)
-				if(mql.addEventListener) {
-					mql.addEventListener("change", changeHandler);
-				} else if(mql.addListener) {
-					// Fallback for older browsers
-					mql.addListener(changeHandler);
-				}
-				
-				// Store reference for cleanup
-				mediaQueryListeners[listenerKey] = {
-					mql: mql,
-					handler: changeHandler,
-					widget: widget
-				};
-				
-				// Clean up listener when widget is destroyed
-				if(widget) {
-					// Hook into widget destruction
-					var originalRemoveChildDomNodes = widget.removeChildDomNodes;
-					widget.removeChildDomNodes = function() {
-						if(mediaQueryListeners[listenerKey]) {
-							var listener = mediaQueryListeners[listenerKey];
-							if(listener.mql.removeEventListener) {
-								listener.mql.removeEventListener("change", listener.handler);
-							} else if(listener.mql.removeListener) {
-								// Fallback for older browsers
-								listener.mql.removeListener(listener.handler);
-							}
-							delete mediaQueryListeners[listenerKey];
-						}
-						if(originalRemoveChildDomNodes) {
-							originalRemoveChildDomNodes.call(this);
-						}
-					};
-				}
 			}
-		} catch(e) {
-			// Invalid media query, return empty results
-			return results;
 		}
 	}
 	

--- a/core/modules/filters/mediaquery.js
+++ b/core/modules/filters/mediaquery.js
@@ -1,0 +1,97 @@
+/*\
+title: $:/core/modules/filters/mediaquery.js
+type: application/javascript
+module-type: filteroperator
+
+Filter operator for evaluating CSS media queries
+
+\*/
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+// Store active media query listeners
+var mediaQueryListeners = {};
+var listenerCounter = 0;
+
+/*
+Export our filter function
+*/
+exports.mediaquery = function(source,operator,options) {
+	var results = [],
+		mediaQuery = operator.operand,
+		widget = options.widget;
+	
+	// Only evaluate in browser environment
+	if($tw.browser && mediaQuery && widget) {
+		try {
+			// Use window.matchMedia to evaluate the media query
+			var mql = window.matchMedia(mediaQuery);
+			
+			// Process each input title
+			source(function(tiddler,title) {
+				if(mql.matches) {
+					results.push(title);
+				}
+			});
+			
+			// Set up a listener for changes if we have a widget context
+			if(widget && widget.wiki) {
+				// Create a unique key for this listener
+				var listenerKey = "mql_" + (++listenerCounter);
+				
+				// Define the change handler
+				var changeHandler = function(e) {
+					// Force a refresh of the widget when media query changes
+					if(widget.refreshSelf) {
+						widget.refreshSelf();
+					} else if(widget.parentWidget && widget.parentWidget.refreshChildren) {
+						widget.parentWidget.refreshChildren();
+					}
+				};
+				
+				// Add the listener (use modern addEventListener if available)
+				if(mql.addEventListener) {
+					mql.addEventListener("change", changeHandler);
+				} else if(mql.addListener) {
+					// Fallback for older browsers
+					mql.addListener(changeHandler);
+				}
+				
+				// Store reference for cleanup
+				mediaQueryListeners[listenerKey] = {
+					mql: mql,
+					handler: changeHandler,
+					widget: widget
+				};
+				
+				// Clean up listener when widget is destroyed
+				if(widget) {
+					// Hook into widget destruction
+					var originalRemoveChildDomNodes = widget.removeChildDomNodes;
+					widget.removeChildDomNodes = function() {
+						if(mediaQueryListeners[listenerKey]) {
+							var listener = mediaQueryListeners[listenerKey];
+							if(listener.mql.removeEventListener) {
+								listener.mql.removeEventListener("change", listener.handler);
+							} else if(listener.mql.removeListener) {
+								// Fallback for older browsers
+								listener.mql.removeListener(listener.handler);
+							}
+							delete mediaQueryListeners[listenerKey];
+						}
+						if(originalRemoveChildDomNodes) {
+							originalRemoveChildDomNodes.call(this);
+						}
+					};
+				}
+			}
+		} catch(e) {
+			// Invalid media query, return empty results
+			return results;
+		}
+	}
+	
+	return results;
+};

--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -4,7 +4,7 @@ tags: $:/tags/Macro
 <!-- Needs to stay that way for backwards compatibility. See GH issue: #8326 -->
 \define colour(name)
 \whitespace trim
-<$transclude tiddler={{{ [[$:/palette]mediaquery[(prefers-color-scheme: light)]get[text]] :else[[$:/palettedark]get[text]] }}} index="$name$">
+<$transclude tiddler={{{ [[$:/palettedark]mediaquery[(prefers-color-scheme: dark)]get[text]] :else[[$:/palette]get[text]] }}} index="$name$">
 	<$transclude tiddler="$:/palettes/Vanilla" index="$name$">
 		<$transclude tiddler="$:/config/DefaultColourMappings/$name$"/>
 	</$transclude>

--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -4,7 +4,7 @@ tags: $:/tags/Macro
 <!-- Needs to stay that way for backwards compatibility. See GH issue: #8326 -->
 \define colour(name)
 \whitespace trim
-<$transclude tiddler={{$:/palette}} index="$name$">
+<$transclude tiddler={{{ [[$:/palette]mediaquery[(prefers-color-scheme: light)]get[text]] :else[[$:/palettedark]get[text]] }}} index="$name$">
 	<$transclude tiddler="$:/palettes/Vanilla" index="$name$">
 		<$transclude tiddler="$:/config/DefaultColourMappings/$name$"/>
 	</$transclude>

--- a/core/wiki/palettedark.tid
+++ b/core/wiki/palettedark.tid
@@ -1,3 +1,2 @@
 title: $:/palettedark
-
-$:/palettes/CupertinoDark
+text: $:/palettes/CupertinoDark

--- a/core/wiki/palettedark.tid
+++ b/core/wiki/palettedark.tid
@@ -1,0 +1,3 @@
+title: $:/palettedark
+
+$:/palettes/CupertinoDark

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -435,7 +435,7 @@ Tiddler frame in story river
 }
 
 :root {
-	color-scheme: {{{ [{$:/palette}get[color-scheme]] ~light }}};
+	color-scheme: {{{ [[$:/palette]mediaquery[(prefers-color-scheme: light)]get[text]get[color-scheme]] [[$:/palettedark]mediaquery[(prefers-color-scheme: dark)]get[text]get[color-scheme]] :else[[light]] }}};
 }
 
 /*


### PR DESCRIPTION
This PR adds a `mediaquery` filter operator to TiddlyWiki5

Example use:

```
{{{ [[$:/palette]mediaquery[(prefers-color-scheme: light)]get[text]get[color-scheme]] [[$:/palettedark]mediaquery[(prefers-color-scheme: dark)]get[text]get[color-scheme]] }}}
```

In this PR it's used to alter the `<<colour>>` macro and to determine the `color-scheme` on the `:root` element like above