### PR TITLE
Implement the tv-debug = yes to show transclusion variable

### DIFF
--- a/core/modules/widgets/element.js
+++ b/core/modules/widgets/element.js
@@ -9,6 +9,8 @@ Element widget
 
 "use strict";
 
+const { transclude } = require("./transclude");
+
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
 var ElementWidget = function(parseTreeNode,options) {
@@ -74,6 +76,11 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 	// Create the DOM node and render children
 	var domNode = this.document.createElementNS(this.namespace,this.tag);
 	this.assignAttributes(domNode,{excludeEventAttributes: true});
+	if (this.getVariable("tv-debug") === "yes") {
+		if (domNode) {
+			domNode.setAttribute("data-debug-xxxx", this.getVariable("transclusion"));
+		}
+	}
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);
 	this.domNodes.push(domNode);

--- a/editions/tw5.com/tiddlers/$__StoryList_1.tid
+++ b/editions/tw5.com/tiddlers/$__StoryList_1.tid
@@ -1,0 +1,3 @@
+list: [[Quick Start]]
+title: $:/StoryList
+type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/define-debug-mode.tid
+++ b/editions/tw5.com/tiddlers/define-debug-mode.tid
@@ -1,0 +1,7 @@
+created: 20250804121707719
+modified: 20250804121722010
+tags: $:/tags/Global
+title: define-debug-mode
+type: text/vnd.tiddlywiki
+
+\define tv-debug() yes


### PR DESCRIPTION
This PR fixes #6345

- #6345
- If a variable `tv-debug="yes"` DOM elements show the transclusion variable in `data-debug-xxxx`
- For testing I did use `data-debug-xxxx` because it is easier to see `data-debug` is almost invisible 
- This PR is a draft since it does set `tv-debug=yes` globally, which is only there for testing

<img width="1548" height="926" alt="image" src="https://github.com/user-attachments/assets/d68a3f9e-3ccf-40e3-a007-957fe1e3a986" />
