### PR TITLE
Keyboard `event.key` instead of `event.keyCode`

### DIFF
--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -297,7 +297,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 	Propogate keydown events to our container for the keyboard widgets benefit
 	*/
 	EditTextWidget.prototype.propogateKeydownEvent = function(event) {
-		var newEvent = this.cloneEvent(event,["keyCode","code","which","key","metaKey","ctrlKey","altKey","shiftKey"]);
+		var newEvent = this.cloneEvent(event,["code","key","metaKey","ctrlKey","altKey","shiftKey"]);
 		return !this.parentDomNode.dispatchEvent(newEvent);
 	};
 

--- a/core/modules/keyboard.js
+++ b/core/modules/keyboard.js
@@ -9,374 +9,399 @@ Keyboard handling utilities
 
 "use strict";
 
-var namedKeys = {
-	"cancel": 3,
-	"help": 6,
-	"backspace": 8,
-	"tab": 9,
-	"clear": 12,
-	"return": 13,
-	"enter": 13,
-	"pause": 19,
-	"escape": 27,
-	"space": 32,
-	"page_up": 33,
-	"page_down": 34,
-	"end": 35,
-	"home": 36,
-	"left": 37,
-	"up": 38,
-	"right": 39,
-	"down": 40,
-	"printscreen": 44,
-	"insert": 45,
-	"delete": 46,
-	"0": 48,
-	"1": 49,
-	"2": 50,
-	"3": 51,
-	"4": 52,
-	"5": 53,
-	"6": 54,
-	"7": 55,
-	"8": 56,
-	"9": 57,
-	"firefoxsemicolon": 59,
-	"firefoxequals": 61,
-	"a": 65,
-	"b": 66,
-	"c": 67,
-	"d": 68,
-	"e": 69,
-	"f": 70,
-	"g": 71,
-	"h": 72,
-	"i": 73,
-	"j": 74,
-	"k": 75,
-	"l": 76,
-	"m": 77,
-	"n": 78,
-	"o": 79,
-	"p": 80,
-	"q": 81,
-	"r": 82,
-	"s": 83,
-	"t": 84,
-	"u": 85,
-	"v": 86,
-	"w": 87,
-	"x": 88,
-	"y": 89,
-	"z": 90,
-	"numpad0": 96,
-	"numpad1": 97,
-	"numpad2": 98,
-	"numpad3": 99,
-	"numpad4": 100,
-	"numpad5": 101,
-	"numpad6": 102,
-	"numpad7": 103,
-	"numpad8": 104,
-	"numpad9": 105,
-	"multiply": 106,
-	"add": 107,
-	"separator": 108,
-	"subtract": 109,
-	"decimal": 110,
-	"divide": 111,
-	"f1": 112,
-	"f2": 113,
-	"f3": 114,
-	"f4": 115,
-	"f5": 116,
-	"f6": 117,
-	"f7": 118,
-	"f8": 119,
-	"f9": 120,
-	"f10": 121,
-	"f11": 122,
-	"f12": 123,
-	"f13": 124,
-	"f14": 125,
-	"f15": 126,
-	"f16": 127,
-	"f17": 128,
-	"f18": 129,
-	"f19": 130,
-	"f20": 131,
-	"f21": 132,
-	"f22": 133,
-	"f23": 134,
-	"f24": 135,
-	"firefoxminus": 173,
-	"semicolon": 186,
-	"equals": 187,
-	"comma": 188,
-	"dash": 189,
-	"period": 190,
-	"slash": 191,
-	"backquote": 192,
-	"openbracket": 219,
-	"backslash": 220,
-	"closebracket": 221,
-	"quote": 222
+// Mapping of normalized key names to event.key values
+// Only includes keys that need special mapping
+const keyMap = {
+	"cancel": "Cancel",
+	"help": "Help",
+	"backspace": "Backspace",
+	"tab": "Tab",
+	"clear": "Clear",
+	"return": "Enter",
+	"enter": "Enter",
+	"pause": "Pause",
+	"escape": "Escape",
+	"space": " ",
+	"page_up": "PageUp",
+	"page_down": "PageDown",
+	"end": "End",
+	"home": "Home",
+	"left": "ArrowLeft",
+	"up": "ArrowUp",
+	"right": "ArrowRight",
+	"down": "ArrowDown",
+	"printscreen": "PrintScreen",
+	"insert": "Insert",
+	"delete": "Delete",
+	"multiply": "*",
+	"add": "+",
+	"separator": "Separator",
+	"subtract": "-",
+	"decimal": ".",
+	"divide": "/",
+	"f1": "F1",
+	"f2": "F2",
+	"f3": "F3",
+	"f4": "F4",
+	"f5": "F5",
+	"f6": "F6",
+	"f7": "F7",
+	"f8": "F8",
+	"f9": "F9",
+	"f10": "F10",
+	"f11": "F11",
+	"f12": "F12",
+	"f13": "F13",
+	"f14": "F14",
+	"f15": "F15",
+	"f16": "F16",
+	"f17": "F17",
+	"f18": "F18",
+	"f19": "F19",
+	"f20": "F20",
+	"f21": "F21",
+	"f22": "F22",
+	"f23": "F23",
+	"f24": "F24",
+	"firefoxminus": "-",
+	"semicolon": ";",
+	"equals": "=",
+	"comma": ",",
+	"dash": "-",
+	"minus": "-",
+	"period": ".",
+	"slash": "/",
+	"backquote": "`",
+	"openbracket": "[",
+	"backslash": "\\",
+	"closebracket": "]",
+	"quote": "'"
 };
 
-function KeyboardManager(options) {
-	var self = this;
-	options = options || "";
-	// Save the named key hashmap
-	this.namedKeys = namedKeys;
-	// Create a reverse mapping of code to keyname
-	this.keyNames = [];
-	$tw.utils.each(namedKeys,function(keyCode,name) {
-		self.keyNames[keyCode] = name.substr(0,1).toUpperCase() + name.substr(1);
-	});
-	// Save the platform-specific name of the "meta" key
-	this.metaKeyName = $tw.platform.isMac ? "cmd-" : "win-";
-	this.shortcutKeysList = [], // Stores the shortcut-key descriptors
-	this.shortcutActionList = [], // Stores the corresponding action strings
-	this.shortcutParsedList = []; // Stores the parsed key descriptors
-	this.shortcutPriorityList = []; // Stores the parsed shortcut priority
-	this.lookupNames = ["shortcuts"];
-	this.lookupNames.push($tw.platform.isMac ? "shortcuts-mac" : "shortcuts-not-mac")
-	this.lookupNames.push($tw.platform.isWindows ? "shortcuts-windows" : "shortcuts-not-windows");
-	this.lookupNames.push($tw.platform.isLinux ? "shortcuts-linux" : "shortcuts-not-linux");
-	this.updateShortcutLists(this.getShortcutTiddlerList());
-	$tw.wiki.addEventListener("change",function(changes) {
-		self.handleShortcutChanges(changes);
-	});
+// Create reverse mapping for display names
+const reverseKeyMap = {};
+for (const [name, key] of Object.entries(keyMap)) {
+	reverseKeyMap[key] = name.charAt(0).toUpperCase() + name.slice(1);
 }
 
-/*
-Return an array of keycodes for the modifier keys ctrl, shift, alt, meta
-*/
-KeyboardManager.prototype.getModifierKeys = function() {
-	return [
-		16, // Shift
-		17, // Ctrl
-		18, // Alt
-		20, // CAPS LOCK
-		91, // Meta (left)
-		93, // Meta (right)
-		224 // Meta (Firefox)
-	]
-};
-
-/*
-Parses a key descriptor into the structure:
-{
-	keyCode: numeric keycode
-	shiftKey: boolean
-	altKey: boolean
-	ctrlKey: boolean
-	metaKey: boolean
-}
-Key descriptors have the following format:
-	ctrl+enter
-	ctrl+shift+alt+A
-*/
-KeyboardManager.prototype.parseKeyDescriptor = function(keyDescriptor,options) {
-	var components = keyDescriptor.split(/\+|\-/),
-		info = {
-			keyCode: 0,
+class KeyboardManager {
+	constructor(options) {
+		options = options || "";
+		
+		// Save the key mappings
+		this.keyMap = keyMap;
+		this.reverseKeyMap = reverseKeyMap;
+		
+		// Save the platform-specific name of the "meta" key
+		this.metaKeyName = $tw.platform.isMac ? "cmd-" : "win-";
+		this.shortcutKeysList = []; // Stores the shortcut-key descriptors
+		this.shortcutActionList = []; // Stores the corresponding action strings
+		this.shortcutParsedList = []; // Stores the parsed key descriptors
+		this.shortcutPriorityList = []; // Stores the parsed shortcut priority
+		this.lookupNames = ["shortcuts"];
+		this.lookupNames.push($tw.platform.isMac ? "shortcuts-mac" : "shortcuts-not-mac");
+		this.lookupNames.push($tw.platform.isWindows ? "shortcuts-windows" : "shortcuts-not-windows");
+		this.lookupNames.push($tw.platform.isLinux ? "shortcuts-linux" : "shortcuts-not-linux");
+		this.updateShortcutLists(this.getShortcutTiddlerList());
+		
+		$tw.wiki.addEventListener("change", changes => {
+			this.handleShortcutChanges(changes);
+		});
+	}
+	
+	/*
+	Return an array of modifier key names
+	*/
+	getModifierKeys() {
+		return [
+			"Shift",
+			"Control",
+			"Alt",
+			"CapsLock",
+			"Meta",
+			"OS", // Some browsers use "OS" instead of "Meta"
+			"Win" // Some browsers use "Win" for Windows key
+		];
+	}
+	
+	/*
+	Normalize the event.key value to handle browser inconsistencies
+	*/
+	normalizeKey(key) {
+		// Handle special cases and normalize to lowercase for comparison
+		const normalizedKey = key.toLowerCase();
+		
+		// Map common variations
+		const keyNormalizationMap = {
+			"arrowleft": "left",
+			"arrowright": "right",
+			"arrowup": "up",
+			"arrowdown": "down",
+			"pageup": "page_up",
+			"pagedown": "page_down",
+			" ": "space",
+			"esc": "escape"
+		};
+		
+		return keyNormalizationMap[normalizedKey] || normalizedKey;
+	}
+	
+	/*
+	Parses a key descriptor into the structure:
+	{
+		key: string key value
+		shiftKey: boolean
+		altKey: boolean
+		ctrlKey: boolean
+		metaKey: boolean
+	}
+	Key descriptors have the following format:
+		ctrl+enter
+		ctrl+shift+alt+A
+	*/
+	parseKeyDescriptor(keyDescriptor, options = {}) {
+		const components = keyDescriptor.split(/\+|\-/);
+		const info = {
+			key: "",
 			shiftKey: false,
 			altKey: false,
 			ctrlKey: false,
 			metaKey: false
 		};
-	for(var t=0; t<components.length; t++) {
-		var s = components[t].toLowerCase(),
-			c = s.charCodeAt(0);
-		// Look for modifier keys
-		if(s === "ctrl") {
-			info.ctrlKey = true;
-		} else if(s === "shift") {
-			info.shiftKey = true;
-		} else if(s === "alt") {
-			info.altKey = true;
-		} else if(s === "meta" || s === "cmd" || s === "win") {
-			info.metaKey = true;
+		
+		for (const component of components) {
+			const s = component.toLowerCase();
+			
+			// Look for modifier keys
+			if (s === "ctrl") {
+				info.ctrlKey = true;
+			} else if (s === "shift") {
+				info.shiftKey = true;
+			} else if (s === "alt") {
+				info.altKey = true;
+			} else if (s === "meta" || s === "cmd" || s === "win") {
+				info.metaKey = true;
+			} else {
+				// Map the key name to event.key value
+				if (this.keyMap[s]) {
+					info.key = this.keyMap[s];
+				} else {
+					// For unmapped keys (like single letters and numbers), use as-is
+					info.key = s;
+				}
+			}
 		}
-		// Replace named keys with their code
-		if(this.namedKeys[s]) {
-			info.keyCode = this.namedKeys[s];
+		
+		if (options.keyDescriptor) {
+			info.keyDescriptor = options.keyDescriptor;
+		}
+		
+		if (info.key) {
+			return info;
+		} else {
+			return null;
 		}
 	}
-	if(options.keyDescriptor) {
-		info.keyDescriptor = options.keyDescriptor;
-	}
-	if(info.keyCode) {
-		return info;
-	} else {
-		return null;
-	}
-};
-
-/*
-Parse a list of key descriptors into an array of keyInfo objects. The key descriptors can be passed as an array of strings or a space separated string
-*/
-KeyboardManager.prototype.parseKeyDescriptors = function(keyDescriptors,options) {
-	var self = this;
-	options = options || {};
-	options.stack = options.stack || [];
-	var wiki = options.wiki || $tw.wiki;
-	if(typeof keyDescriptors === "string" && keyDescriptors === "") {
-		return [];
-	}
-	if(!$tw.utils.isArray(keyDescriptors)) {
-		keyDescriptors = keyDescriptors.split(" ");
-	}
-	var result = [];
-	$tw.utils.each(keyDescriptors,function(keyDescriptor) {
-		// Look for a named shortcut
-		if(keyDescriptor.substr(0,2) === "((" && keyDescriptor.substr(-2,2) === "))") {
-			if(options.stack.indexOf(keyDescriptor) === -1) {
-				options.stack.push(keyDescriptor);
-				var name = keyDescriptor.substring(2,keyDescriptor.length - 2),
-					lookupName = function(configName) {
-						var keyDescriptors = wiki.getTiddlerText("$:/config/" + configName + "/" + name);
-						if(keyDescriptors) {
+	
+	/*
+	Parse a list of key descriptors into an array of keyInfo objects. The key descriptors can be passed as an array of strings or a space separated string
+	*/
+	parseKeyDescriptors(keyDescriptors, options = {}) {
+		options.stack = options.stack || [];
+		const wiki = options.wiki || $tw.wiki;
+		
+		if (typeof keyDescriptors === "string" && keyDescriptors === "") {
+			return [];
+		}
+		
+		if (!$tw.utils.isArray(keyDescriptors)) {
+			keyDescriptors = keyDescriptors.split(" ");
+		}
+		
+		const result = [];
+		
+		for (const keyDescriptor of keyDescriptors) {
+			// Look for a named shortcut
+			if (keyDescriptor.startsWith("((") && keyDescriptor.endsWith("))")) {
+				if (options.stack.indexOf(keyDescriptor) === -1) {
+					options.stack.push(keyDescriptor);
+					const name = keyDescriptor.substring(2, keyDescriptor.length - 2);
+					
+					const lookupName = configName => {
+						const keyDescriptors = wiki.getTiddlerText(`$:/config/${configName}/${name}`);
+						if (keyDescriptors) {
 							options.keyDescriptor = keyDescriptor;
-							result.push.apply(result,self.parseKeyDescriptors(keyDescriptors,options));
+							result.push(...this.parseKeyDescriptors(keyDescriptors, options));
 						}
 					};
-				$tw.utils.each(self.lookupNames,function(platformDescriptor) {
-					lookupName(platformDescriptor);
-				});
+					
+					for (const platformDescriptor of this.lookupNames) {
+						lookupName(platformDescriptor);
+					}
+				}
+			} else {
+				result.push(this.parseKeyDescriptor(keyDescriptor, options));
 			}
-		} else {
-			result.push(self.parseKeyDescriptor(keyDescriptor,options));
 		}
-	});
-	return result;
-};
-
-KeyboardManager.prototype.getPrintableShortcuts = function(keyInfoArray) {
-	var self = this,
-		result = [];
-	$tw.utils.each(keyInfoArray,function(keyInfo) {
-		if(keyInfo) {
-			result.push((keyInfo.ctrlKey ? "ctrl-" : "") + 
-				   (keyInfo.shiftKey ? "shift-" : "") + 
-				   (keyInfo.altKey ? "alt-" : "") + 
-				   (keyInfo.metaKey ? self.metaKeyName : "") + 
-				   (self.keyNames[keyInfo.keyCode]));
+		
+		return result;
+	}
+	
+	getPrintableShortcuts(keyInfoArray) {
+		const result = [];
+		
+		for (const keyInfo of keyInfoArray) {
+			if (keyInfo) {
+				// Use reverse map for special keys, otherwise capitalize first letter
+				const keyName = this.reverseKeyMap[keyInfo.key] || 
+					(keyInfo.key.length === 1 ? keyInfo.key.toUpperCase() : keyInfo.key);
+				
+				result.push(
+					(keyInfo.ctrlKey ? "ctrl-" : "") + 
+					(keyInfo.shiftKey ? "shift-" : "") + 
+					(keyInfo.altKey ? "alt-" : "") + 
+					(keyInfo.metaKey ? this.metaKeyName : "") + 
+					keyName
+				);
+			}
 		}
-	});
-	return result;
-}
-
-KeyboardManager.prototype.checkKeyDescriptor = function(event,keyInfo) {
-	return keyInfo &&
-			event.keyCode === keyInfo.keyCode && 
-			event.shiftKey === keyInfo.shiftKey && 
-			event.altKey === keyInfo.altKey && 
-			event.ctrlKey === keyInfo.ctrlKey && 
+		
+		return result;
+	}
+	
+	checkKeyDescriptor(event, keyInfo) {
+		if (!keyInfo) return false;
+		
+		// Normalize the event key for comparison
+		const eventKey = event.key;
+		let compareKey = keyInfo.key;
+		
+		// Handle case sensitivity for letters
+		if (keyInfo.key.length === 1 && /[a-z]/i.test(keyInfo.key)) {
+			// For single letters, compare case-insensitively
+			return eventKey.toLowerCase() === compareKey.toLowerCase() &&
+				event.shiftKey === keyInfo.shiftKey &&
+				event.altKey === keyInfo.altKey &&
+				event.ctrlKey === keyInfo.ctrlKey &&
+				event.metaKey === keyInfo.metaKey;
+		}
+		
+		return eventKey === compareKey &&
+			event.shiftKey === keyInfo.shiftKey &&
+			event.altKey === keyInfo.altKey &&
+			event.ctrlKey === keyInfo.ctrlKey &&
 			event.metaKey === keyInfo.metaKey;
-};
-
-KeyboardManager.prototype.checkKeyDescriptors = function(event,keyInfoArray) {
-	return (this.getMatchingKeyDescriptor(event,keyInfoArray) !== null);
-};
-
-KeyboardManager.prototype.getMatchingKeyDescriptor = function(event,keyInfoArray) {
-	for(var t=0; t<keyInfoArray.length; t++) {
-		if(this.checkKeyDescriptor(event,keyInfoArray[t])) {
-			return keyInfoArray[t];
-		}
 	}
-	return null;
-};
-
-KeyboardManager.prototype.getEventModifierKeyDescriptor = function(event) {
-	return event.ctrlKey && !event.shiftKey	&& !event.altKey && !event.metaKey ? "ctrl" : 
-		event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey ? "shift" : 
-		event.ctrlKey && event.shiftKey && !event.altKey && !event.metaKey ? "ctrl-shift" : 
-		event.altKey && !event.shiftKey && !event.ctrlKey && !event.metaKey ? "alt" : 
-		event.altKey && event.shiftKey && !event.ctrlKey && !event.metaKey ? "alt-shift" : 
-		event.altKey && event.ctrlKey && !event.shiftKey && !event.metaKey ? "ctrl-alt" : 
-		event.altKey && event.shiftKey && event.ctrlKey && !event.metaKey ? "ctrl-alt-shift" : 
-		event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey ? "meta" : 
-		event.metaKey && event.ctrlKey && !event.shiftKey && !event.altKey ? "meta-ctrl" :
-		event.metaKey && event.ctrlKey && event.shiftKey && !event.altKey ? "meta-ctrl-shift" :
-		event.metaKey && event.ctrlKey && event.shiftKey && event.altKey ? "meta-ctrl-alt-shift" : "normal";
-};
-
-KeyboardManager.prototype.getShortcutTiddlerList = function() {
-	return $tw.wiki.getTiddlersWithTag("$:/tags/KeyboardShortcut");
-};
-
-KeyboardManager.prototype.updateShortcutLists = function(tiddlerList) {
-	this.shortcutTiddlers = tiddlerList;
-	for(var i=0; i<tiddlerList.length; i++) {
-		var title = tiddlerList[i],
-			tiddlerFields = $tw.wiki.getTiddler(title).fields;
-		this.shortcutKeysList[i] = tiddlerFields.key !== undefined ? tiddlerFields.key : undefined;
-		this.shortcutActionList[i] = tiddlerFields.text;
-		this.shortcutParsedList[i] = this.shortcutKeysList[i] !== undefined ? this.parseKeyDescriptors(this.shortcutKeysList[i]) : undefined;
-		this.shortcutPriorityList[i] = tiddlerFields.priority === "yes" ? true : false;
+	
+	checkKeyDescriptors(event, keyInfoArray) {
+		return this.getMatchingKeyDescriptor(event, keyInfoArray) !== null;
 	}
-};
-
-/*
-event: the keyboard event object
-options:
-	onlyPriority: true if only priority global shortcuts should be invoked
-*/
-KeyboardManager.prototype.handleKeydownEvent = function(event, options) {
-	options = options || {};
-	var key, action;
-	for(var i=0; i<this.shortcutTiddlers.length; i++) {
-		if(options.onlyPriority && this.shortcutPriorityList[i] !== true) {
-			continue;
-		}
-
-		if(this.shortcutParsedList[i] !== undefined && this.checkKeyDescriptors(event,this.shortcutParsedList[i])) {
-			key = this.shortcutParsedList[i];
-			action = this.shortcutActionList[i];
-		}
-	}
-	if(key !== undefined) {
-		event.preventDefault();
-		event.stopPropagation();
-		$tw.rootWidget.invokeActionString(action,$tw.rootWidget,event);
-		return true;
-	}
-	return false;
-};
-
-KeyboardManager.prototype.detectNewShortcuts = function(changedTiddlers) {
-	var shortcutConfigTiddlers = [],
-		handled = false;
-	$tw.utils.each(this.lookupNames,function(platformDescriptor) {
-		var descriptorString = "$:/config/" + platformDescriptor + "/";
-		Object.keys(changedTiddlers).forEach(function(configTiddler) {
-			var configString = configTiddler.substr(0, configTiddler.lastIndexOf("/") + 1);
-			if(configString === descriptorString) {
-				shortcutConfigTiddlers.push(configTiddler);
-				handled = true;
+	
+	getMatchingKeyDescriptor(event, keyInfoArray) {
+		for (const keyInfo of keyInfoArray) {
+			if (this.checkKeyDescriptor(event, keyInfo)) {
+				return keyInfo;
 			}
-		});
-	});
-	if(handled) {
-		return $tw.utils.hopArray(changedTiddlers,shortcutConfigTiddlers);
-	} else {
+		}
+		return null;
+	}
+	
+	getEventModifierKeyDescriptor(event) {
+		if (event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey) return "ctrl";
+		if (event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey) return "shift";
+		if (event.ctrlKey && event.shiftKey && !event.altKey && !event.metaKey) return "ctrl-shift";
+		if (event.altKey && !event.shiftKey && !event.ctrlKey && !event.metaKey) return "alt";
+		if (event.altKey && event.shiftKey && !event.ctrlKey && !event.metaKey) return "alt-shift";
+		if (event.altKey && event.ctrlKey && !event.shiftKey && !event.metaKey) return "ctrl-alt";
+		if (event.altKey && event.shiftKey && event.ctrlKey && !event.metaKey) return "ctrl-alt-shift";
+		if (event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey) return "meta";
+		if (event.metaKey && event.ctrlKey && !event.shiftKey && !event.altKey) return "meta-ctrl";
+		if (event.metaKey && event.ctrlKey && event.shiftKey && !event.altKey) return "meta-ctrl-shift";
+		if (event.metaKey && event.ctrlKey && event.shiftKey && event.altKey) return "meta-ctrl-alt-shift";
+		return "normal";
+	}
+	
+	getShortcutTiddlerList() {
+		return $tw.wiki.getTiddlersWithTag("$:/tags/KeyboardShortcut");
+	}
+	
+	updateShortcutLists(tiddlerList) {
+		this.shortcutTiddlers = tiddlerList;
+		
+		for (let i = 0; i < tiddlerList.length; i++) {
+			const title = tiddlerList[i];
+			const tiddlerFields = $tw.wiki.getTiddler(title).fields;
+			this.shortcutKeysList[i] = tiddlerFields.key !== undefined ? tiddlerFields.key : undefined;
+			this.shortcutActionList[i] = tiddlerFields.text;
+			this.shortcutParsedList[i] = this.shortcutKeysList[i] !== undefined ? this.parseKeyDescriptors(this.shortcutKeysList[i]) : undefined;
+			this.shortcutPriorityList[i] = tiddlerFields.priority === "yes" ? true : false;
+		}
+	}
+	
+	/*
+	event: the keyboard event object
+	options:
+		onlyPriority: true if only priority global shortcuts should be invoked
+	*/
+	handleKeydownEvent(event, options = {}) {
+		let key, action;
+		
+		for (let i = 0; i < this.shortcutTiddlers.length; i++) {
+			if (options.onlyPriority && this.shortcutPriorityList[i] !== true) {
+				continue;
+			}
+			
+			if (this.shortcutParsedList[i] !== undefined && this.checkKeyDescriptors(event, this.shortcutParsedList[i])) {
+				key = this.shortcutParsedList[i];
+				action = this.shortcutActionList[i];
+			}
+		}
+		
+		if (key !== undefined) {
+			event.preventDefault();
+			event.stopPropagation();
+			$tw.rootWidget.invokeActionString(action, $tw.rootWidget, event);
+			return true;
+		}
+		
 		return false;
 	}
-};
-
-KeyboardManager.prototype.handleShortcutChanges = function(changedTiddlers) {
-	var newList = this.getShortcutTiddlerList();
-	var hasChanged = $tw.utils.hopArray(changedTiddlers,this.shortcutTiddlers) ? true :
-		($tw.utils.hopArray(changedTiddlers,newList) ? true :
-		(this.detectNewShortcuts(changedTiddlers))
-	);
-	// Re-cache shortcuts if something changed
-	if(hasChanged) {
-		this.updateShortcutLists(newList);
+	
+	detectNewShortcuts(changedTiddlers) {
+		const shortcutConfigTiddlers = [];
+		let handled = false;
+		
+		for (const platformDescriptor of this.lookupNames) {
+			const descriptorString = `$:/config/${platformDescriptor}/`;
+			
+			for (const configTiddler of Object.keys(changedTiddlers)) {
+				const configString = configTiddler.substring(0, configTiddler.lastIndexOf("/") + 1);
+				if (configString === descriptorString) {
+					shortcutConfigTiddlers.push(configTiddler);
+					handled = true;
+				}
+			}
+		}
+		
+		if (handled) {
+			return $tw.utils.hopArray(changedTiddlers, shortcutConfigTiddlers);
+		} else {
+			return false;
+		}
 	}
-};
+	
+	handleShortcutChanges(changedTiddlers) {
+		const newList = this.getShortcutTiddlerList();
+		const hasChanged = $tw.utils.hopArray(changedTiddlers, this.shortcutTiddlers) ? true :
+			($tw.utils.hopArray(changedTiddlers, newList) ? true :
+			(this.detectNewShortcuts(changedTiddlers))
+		);
+		
+		// Re-cache shortcuts if something changed
+		if (hasChanged) {
+			this.updateShortcutLists(newList);
+		}
+	}
+}
 
 exports.KeyboardManager = KeyboardManager;

--- a/core/modules/widgets/edit-shortcut.js
+++ b/core/modules/widgets/edit-shortcut.js
@@ -9,145 +9,169 @@ Widget to display an editable keyboard shortcut
 
 "use strict";
 
-var Widget = require("$:/core/modules/widgets/widget.js").widget;
+const Widget = require("$:/core/modules/widgets/widget.js").widget;
 
-var EditShortcutWidget = function(parseTreeNode,options) {
-	this.initialise(parseTreeNode,options);
-};
-
-/*
-Inherit from the base widget class
-*/
-EditShortcutWidget.prototype = new Widget();
-
-/*
-Render this widget into the DOM
-*/
-EditShortcutWidget.prototype.render = function(parent,nextSibling) {
-	this.parentDomNode = parent;
-	this.computeAttributes();
-	this.execute();
-	this.inputNode = this.document.createElement("input");
-	// Assign classes
-	if(this.shortcutClass) {
-		this.inputNode.className = this.shortcutClass;
-	}
-	// Assign other attributes
-	if(this.shortcutStyle) {
-		this.inputNode.setAttribute("style",this.shortcutStyle);
-	}
-	if(this.shortcutTooltip) {
-		this.inputNode.setAttribute("title",this.shortcutTooltip);
-	}
-	if(this.shortcutPlaceholder) {
-		this.inputNode.setAttribute("placeholder",this.shortcutPlaceholder);
-	}
-	if(this.shortcutAriaLabel) {
-		this.inputNode.setAttribute("aria-label",this.shortcutAriaLabel);
-	}
-	if(this.isDisabled === "yes") {
-		this.inputNode.setAttribute("disabled", true);
-	}
-	// Assign the current shortcut
-	this.updateInputNode();
-	// Add event handlers
-	$tw.utils.addEventListeners(this.inputNode,[
-		{name: "keydown", handlerObject: this, handlerMethod: "handleKeydownEvent"}
-	]);
-	// Link into the DOM
-	parent.insertBefore(this.inputNode,nextSibling);
-	this.domNodes.push(this.inputNode);
-	// Focus the input Node if focus === "yes" or focus === "true"
-	if(this.shortcutFocus === "yes" || this.shortcutFocus === "true") {
-		this.focus();
-	}
-};
-
-/*
-Compute the internal state of the widget
-*/
-EditShortcutWidget.prototype.execute = function() {
-	this.shortcutTiddler = this.getAttribute("tiddler");
-	this.shortcutField = this.getAttribute("field");
-	this.shortcutIndex = this.getAttribute("index");
-	this.shortcutPlaceholder = this.getAttribute("placeholder");
-	this.shortcutDefault = this.getAttribute("default","");
-	this.shortcutClass = this.getAttribute("class");
-	this.shortcutStyle = this.getAttribute("style");
-	this.shortcutTooltip = this.getAttribute("tooltip");
-	this.shortcutAriaLabel = this.getAttribute("aria-label");
-	this.shortcutFocus = this.getAttribute("focus");
-	this.isDisabled = this.getAttribute("disabled", "no");
-};
-
-/*
-Update the value of the input node
-*/
-EditShortcutWidget.prototype.updateInputNode = function() {
-	if(this.shortcutField) {
-		var tiddler = this.wiki.getTiddler(this.shortcutTiddler);
-		if(tiddler && $tw.utils.hop(tiddler.fields,this.shortcutField)) {
-			this.inputNode.value = tiddler.getFieldString(this.shortcutField);
-		} else {
-			this.inputNode.value = this.shortcutDefault;
+class EditShortcutWidget extends Widget {
+	/*
+	Render this widget into the DOM
+	*/
+	render(parent, nextSibling) {
+		this.parentDomNode = parent;
+		this.computeAttributes();
+		this.execute();
+		this.inputNode = this.document.createElement("input");
+		
+		// Assign classes
+		if (this.shortcutClass) {
+			this.inputNode.className = this.shortcutClass;
 		}
-	} else if(this.shortcutIndex) {
-		this.inputNode.value = this.wiki.extractTiddlerDataItem(this.shortcutTiddler,this.shortcutIndex,this.shortcutDefault);
-	} else {
-		this.inputNode.value = this.wiki.getTiddlerText(this.shortcutTiddler,this.shortcutDefault);
-	}
-};
-
-/*
-Handle a dom "keydown" event
-*/
-EditShortcutWidget.prototype.handleKeydownEvent = function(event) {
-	// Ignore shift, ctrl, meta, alt
-	if(event.keyCode && $tw.keyboardManager.getModifierKeys().indexOf(event.keyCode) === -1) {
-		// Get the shortcut text representation
-		var value = $tw.keyboardManager.getPrintableShortcuts([{
-			ctrlKey: event.ctrlKey,
-			shiftKey: event.shiftKey,
-			altKey: event.altKey,
-			metaKey: event.metaKey,
-			keyCode: event.keyCode
-		}]);
-		if(value.length > 0) {
-			this.wiki.setText(this.shortcutTiddler,this.shortcutField,this.shortcutIndex,value[0]);
+		
+		// Assign other attributes
+		if (this.shortcutStyle) {
+			this.inputNode.setAttribute("style", this.shortcutStyle);
 		}
-		// Ignore the keydown if it was already handled
-		event.preventDefault();
-		event.stopPropagation();
-		return true;
-	} else {
-		return false;
-	}
-};
-
-/*
-focus the input node
-*/
-EditShortcutWidget.prototype.focus = function() {
-	if(this.inputNode.focus && this.inputNode.select) {
-		this.inputNode.focus();
-		this.inputNode.select();
-	}
-};
-
-/*
-Selectively refreshes the widget if needed. Returns true if the widget needed re-rendering
-*/
-EditShortcutWidget.prototype.refresh = function(changedTiddlers) {
-	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.placeholder || changedAttributes["default"] || changedAttributes["class"] || changedAttributes.style || changedAttributes.tooltip || changedAttributes["aria-label"] || changedAttributes.focus || changedAttributes.disabled) {
-		this.refreshSelf();
-		return true;
-	} else if(changedTiddlers[this.shortcutTiddler]) {
+		if (this.shortcutTooltip) {
+			this.inputNode.setAttribute("title", this.shortcutTooltip);
+		}
+		if (this.shortcutPlaceholder) {
+			this.inputNode.setAttribute("placeholder", this.shortcutPlaceholder);
+		}
+		if (this.shortcutAriaLabel) {
+			this.inputNode.setAttribute("aria-label", this.shortcutAriaLabel);
+		}
+		if (this.isDisabled === "yes") {
+			this.inputNode.setAttribute("disabled", true);
+		}
+		
+		// Assign the current shortcut
 		this.updateInputNode();
-		return true;
-	} else {
-		return false;
+		
+		// Add event handlers
+		$tw.utils.addEventListeners(this.inputNode, [
+			{name: "keydown", handlerObject: this, handlerMethod: "handleKeydownEvent"}
+		]);
+		
+		// Link into the DOM
+		parent.insertBefore(this.inputNode, nextSibling);
+		this.domNodes.push(this.inputNode);
+		
+		// Focus the input Node if focus === "yes" or focus === "true"
+		if (this.shortcutFocus === "yes" || this.shortcutFocus === "true") {
+			this.focus();
+		}
 	}
-};
+	
+	/*
+	Compute the internal state of the widget
+	*/
+	execute() {
+		this.shortcutTiddler = this.getAttribute("tiddler");
+		this.shortcutField = this.getAttribute("field");
+		this.shortcutIndex = this.getAttribute("index");
+		this.shortcutPlaceholder = this.getAttribute("placeholder");
+		this.shortcutDefault = this.getAttribute("default", "");
+		this.shortcutClass = this.getAttribute("class");
+		this.shortcutStyle = this.getAttribute("style");
+		this.shortcutTooltip = this.getAttribute("tooltip");
+		this.shortcutAriaLabel = this.getAttribute("aria-label");
+		this.shortcutFocus = this.getAttribute("focus");
+		this.isDisabled = this.getAttribute("disabled", "no");
+	}
+	
+	/*
+	Update the value of the input node
+	*/
+	updateInputNode() {
+		if (this.shortcutField) {
+			const tiddler = this.wiki.getTiddler(this.shortcutTiddler);
+			if (tiddler && $tw.utils.hop(tiddler.fields, this.shortcutField)) {
+				this.inputNode.value = tiddler.getFieldString(this.shortcutField);
+			} else {
+				this.inputNode.value = this.shortcutDefault;
+			}
+		} else if (this.shortcutIndex) {
+			this.inputNode.value = this.wiki.extractTiddlerDataItem(
+				this.shortcutTiddler,
+				this.shortcutIndex,
+				this.shortcutDefault
+			);
+		} else {
+			this.inputNode.value = this.wiki.getTiddlerText(this.shortcutTiddler, this.shortcutDefault);
+		}
+	}
+	
+	/*
+	Handle a dom "keydown" event
+	*/
+	handleKeydownEvent(event) {
+		// Get the list of modifier keys
+		const modifierKeys = $tw.keyboardManager.getModifierKeys();
+		
+		// Ignore if the pressed key is only a modifier key
+		if (event.key && modifierKeys.indexOf(event.key) === -1) {
+			// Get the shortcut text representation
+			const value = $tw.keyboardManager.getPrintableShortcuts([{
+				ctrlKey: event.ctrlKey,
+				shiftKey: event.shiftKey,
+				altKey: event.altKey,
+				metaKey: event.metaKey,
+				key: event.key
+			}]);
+			
+			if (value.length > 0) {
+				this.wiki.setText(
+					this.shortcutTiddler,
+					this.shortcutField,
+					this.shortcutIndex,
+					value[0]
+				);
+			}
+			
+			// Ignore the keydown if it was already handled
+			event.preventDefault();
+			event.stopPropagation();
+			return true;
+		} else {
+			return false;
+		}
+	}
+	
+	/*
+	focus the input node
+	*/
+	focus() {
+		if (this.inputNode.focus && this.inputNode.select) {
+			this.inputNode.focus();
+			this.inputNode.select();
+		}
+	}
+	
+	/*
+	Selectively refreshes the widget if needed. Returns true if the widget needed re-rendering
+	*/
+	refresh(changedTiddlers) {
+		const changedAttributes = this.computeAttributes();
+		
+		if (changedAttributes.tiddler || 
+			changedAttributes.field || 
+			changedAttributes.index || 
+			changedAttributes.placeholder || 
+			changedAttributes["default"] || 
+			changedAttributes["class"] || 
+			changedAttributes.style || 
+			changedAttributes.tooltip || 
+			changedAttributes["aria-label"] || 
+			changedAttributes.focus || 
+			changedAttributes.disabled) {
+			this.refreshSelf();
+			return true;
+		} else if (changedTiddlers[this.shortcutTiddler]) {
+			this.updateInputNode();
+			return true;
+		} else {
+			return false;
+		}
+	}
+}
 
 exports["edit-shortcut"] = EditShortcutWidget;


### PR DESCRIPTION
This PR adopts `event.key` in the `KeyboardManager` and in the `edit-shortcut` widget
It also changes the `KeyboardManager` to ES2017 syntax

These changes are related to #9140 (deprecation of `event.keyCode`)
