### PR TITLE
[DOC] ContentType Info and Links - Add Compount Tiddler Type

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/CompoundTiddlers.tid
+++ b/editions/tw5.com/tiddlers/concepts/CompoundTiddlers.tid
@@ -1,5 +1,5 @@
 created: 20240507221902644
-modified: 20240729082610287
+modified: 20250814073256942
 tags: Concepts
 title: CompoundTiddlers
 type: text/vnd.tiddlywiki
@@ -8,7 +8,7 @@ Compound tiddlers are a special type of tiddler that can store one or more paylo
 
 The compound tiddler format is extremely simple, and includes the notable flaw that it does not permit tiddlers that contain a plus sign (`+`) on a line by itself. It is not intended as a general purpose way of storing tiddler data.
 
-Compound tiddlers are identified by having their type field set to `text/vnd.tiddlywiki-multiple`.
+Compound tiddlers are identified by having their [[type field|ContentType]] set to `text/vnd.tiddlywiki-multiple`.
 
 The content of a compound tiddler consists of a sequence of tiddlers separated by a plus sign (`+`) on a line by itself. Each tiddler uses the same format as [[.tid files|TiddlerFiles]].
 

--- a/editions/tw5.com/tiddlers/definitions/ContentType.tid
+++ b/editions/tw5.com/tiddlers/definitions/ContentType.tid
@@ -1,5 +1,5 @@
 created: 20130828185900000
-modified: 20150221120839000
+modified: 20250814073940003
 tags: Definitions
 title: ContentType
 type: text/vnd.tiddlywiki
@@ -11,19 +11,20 @@ In TiddlyWiki, the `type` field gives the content type to apply to the main `tex
 !! List of Common Content Types
 
 |!Group |!Type |!Content of `type` field |
-|^''Developer'' |Data dictionary |application/x-tiddler-dictionary|
-|~|~JavaScript code |application/javascript|
-|~|JSON data |application/json|
-|~|Static stylesheet |text/css|
+|^''Developer'' |[[Data dictionary|DictionaryTiddlers]] |application/x-tiddler-dictionary|
+|~|[[Compound Tiddler|CompoundTiddlers]] |text/vnd.tiddlywiki-multiple|
+|~|JavaScript code |application/javascript|
+|~|[[JSON data|JSONTiddlers]] |application/json|
+|~|[[Static stylesheet|Using Stylesheets]] |text/css|
 |^''Image''|GIF image |image/gif|
 |~|ICO format icon file |image/x-icon|
 |~|JPEG image |image/jpeg|
 |~|PDF image |application/pdf|
 |~|PNG image |image/png|
 |~|Structured Vector Graphics image |image/svg+xml|
-|^''Text''|HTML markup |text/html|
+|^''Text''|[[HTML markup|HyperText Markup Language]] |text/html|
 |~|[[CSS|Cascading Style Sheets]] stylesheet |text/css|
 |~|[[Comma-separated values|Comma-Separated Values]] |text/csv|
 |~|Plain text |text/plain|
-|~|~TiddlyWiki 5 |text/vnd.tiddlywiki|
-|~|~TiddlyWiki Classic |text/x-tiddlywiki|
+|~|[[TiddlyWiki 5|WikiText]] |text/vnd.tiddlywiki|
+|~|[[TiddlyWiki Classic|TiddlyWikiClassic]] |text/x-tiddlywiki|


### PR DESCRIPTION
- Add Compound Tiddler datatype info to [ContentType](https://tiddlywiki.com/#ContentType) tiddler
- Add internal links to "Type" column in the table
 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>