### PR TITLE
[DOCS] Improve "range Operator" documentation. Make placeholder "terms" consistent with filter strings

### DIFF
--- a/editions/tw5.com/tiddlers/filters/range.tid
+++ b/editions/tw5.com/tiddlers/filters/range.tid
@@ -1,9 +1,9 @@
 caption: range
 created: 20171221184734665
-modified: 20230321133838310
+modified: 20250827142853527
 op-input: ignored
-op-neg-output: a series of evenly spaced numbers ranging from `<begin>` to `<end>` in reverse order
-op-output: a series of evenly spaced numbers ranging from `<begin>` to `<end>`
+op-neg-output: a series of evenly spaced numbers ranging from `[begin]` to `[end]` in reverse order
+op-output: a series of evenly spaced numbers ranging from `[begin]` to `[end]`
 op-parameter: a range specification, like `[1],[5]`
 op-parameter-name: N
 op-purpose: generate a range of numbers
@@ -23,42 +23,56 @@ The `range` operator produces a list of numbers counting up or down.  It is usef
 
 <<.from-version "5.2.0">> The range operator has been updated to use multiple parameters. Prior to this version, the range operator only had one parameter, with the three parts delimited by `,`, `;` or `:`.
 
+In the descriptions below the words `begin`, `end` and `step` are placeholders. 
+
 ```
-[range[<begin>]]
-[range[<begin>],[<end>]]
-[range[<begin>],[<end>],[<step>]]
+[range[end]]
+[range[begin],[end]]
+[range[begin],[end],[step]]
 ```
 
 The behaviour depends on the number of parameters:
 
-|Parameter |Output |h
-|`<end>` |Whole numbers up to `<end>` |
-|`<begin>,<end>` |Numbers from `<begin>` to `<end>`, spaced by whole numbers |
-|`<begin>,<end>,<step>` |Numbers from `<begin>` to `<end>` spaced out by `<step>` |
+|Parameter(s) Literal |Output |h
+|`[end]` |Whole numbers up to `[end]` eg: `[range[7]]`|
+|`[begin],[end]` |Numbers from `[begin]` to `[end]`, spaced by whole numbers eg: `[range[1],[10]]` |
+|`[begin],[end],[step]` |Numbers from `[begin]` to `[end]` spaced out by `[step]` eg: `[range[1],[7],[2]]` |
 
-Each part must be a number, and works as follows:
+|Parameter(s) Dynamic |Output |h
+|`<end>` |Whole numbers up to `<end>` eg: `[range<myRangeEnd>]`. The <<.var myRangeEnd>> variable has to be defined somewhere else with eg: <<.wid let>> widget |
+|`{begin},<end>` |Numbers from `{begin}` to `<end>` eg: `[range{myRangeStart},<myRangeEnd>]`. The <<.param myRangeStart>> will be transcluded from a tiddler "myRanageStart"  and <<.var myRangeEnd>> comes from a variable |
 
-* `<begin>`: start counting at this number.
-** Defaults to 1 if `<end>` is at least 1 (or -1 if `<end>` is at most -1).
-* `<end>`: stop counting at this number.
+Each parameter must be a number, and works as follows:
+
+* `[begin]`: start counting at this number.
+** Defaults to 1 if `[end]` is at least 1 (or -1 if `[end]` is at most -1).
+
+* `[end]`: stop counting at this number.
 ** This number will appear in the list unless it falls between two steps.
-* `<step>`: count up (or down) by this amount.
+
+* `[step]`: count up (or down) by this amount.
 ** Defaults to 1.
 ** Cannot be zero.
-** We always count from `<begin>` toward `<end>`, whether `<step>` is positive or negative.
+** We always count from `[begin]` toward `[end]`, whether `[step]` is positive or negative.
 
 The number of decimal points in the output is fixed, and based on the parameter with the //most// decimal points.
 
 To prevent the browser from freezing, `range` is currently limited to 10,000 values.
 
-!!Examples
+!! Examples
 
-<<range_example "7">>
+<<wikitext-example-without-html
+"""<$list variable=n filter="[range[7]]" join=", "><<n>></$list>""">>
 
-<<range_example "1],[10">>
+<<wikitext-example-without-html
+"""<$list variable=n filter="[range[3],[10]]" join=", "><<n>></$list>""">>
 
-<<range_example "17],[13">>
+<<wikitext-example-without-html
+"""<$list variable=n filter="[range[17],[13]]" join=", "><<n>></$list>""">>
 
-<<range_example "1.001],[5],[1">>
+<<wikitext-example-without-html
+"""<$list variable=n filter="[range[1.001],[8],[2]]" join=", "><<n>></$list>""">>
 
-<<range_example ".5],[1.4],[.004">>
+<<wikitext-example-without-html
+"""<$list variable=n filter="[range[.9],[1.1],[.004]]" join=", "><<n>></$list>""">>
+


### PR DESCRIPTION
- This PR improves the "range Operator" documentation. It makes the placeholder "terms" consistent with filter strings.
- Remove the custom example macro and replace it with the standard: `<<wikitext-example-without-html`
- In a second PR the examples, could be switched to its own tiddler, but tw5-docs-pr-maker can not define the path. So it will be an other PR. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>