### PR TITLE
Add an option to disable CORS

### DIFF
--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -42,6 +42,8 @@ function Server(options) {
 	}
 	// Setup the default required plugins
 	this.requiredPlugins = this.get("required-plugins").split(',');
+	// Initialise CORS
+	this.corsDisable = this.get("cors-disable") === "yes";
 	// Initialise CSRF
 	this.csrfDisable = this.get("csrf-disable") === "yes";
 	// Initialize Gzip compression
@@ -256,6 +258,13 @@ Server.prototype.requestHandler = function(request,response,options) {
 	state.urlInfo = url.parse(request.url);
 	state.queryParameters = querystring.parse(state.urlInfo.query);
 	state.pathPrefix = options.pathPrefix || this.get("path-prefix") || "";
+	// Disable CORS
+	if(this.corsDisable) {
+		response.setHeader("Access-Control-Allow-Origin", "*");
+		response.setHeader("Access-Control-Allow-Headers", "*");
+		response.setHeader("Access-Control-Allow-Methods", "*");
+		response.setHeader("Access-Control-Expose-Headers", "*");
+	}
 	state.sendResponse = sendResponse.bind(self,request,response);
 	// Get the principals authorized to access this resource
 	state.authorizationType = options.authorizationType || this.methodMappings[request.method] || "readers";
@@ -277,6 +286,12 @@ Server.prototype.requestHandler = function(request,response,options) {
 	// Authorize with the authenticated username
 	if(!this.isAuthorized(state.authorizationType,state.authenticatedUsername)) {
 		response.writeHead(401,"'" + state.authenticatedUsername + "' is not authorized to access '" + this.servername + "'");
+		response.end();
+		return;
+	}
+	// Reply to OPTIONS
+	if(this.corsDisable && request.method === "OPTIONS") {
+		response.writeHead(204);
 		response.end();
 		return;
 	}


### PR DESCRIPTION
Please consider adding an option to the TiddlyWiki5 server that disables CORS (ie. don't check same-origin).

Typical scenario is : from local TW5 file, use both a saver eg. TiddlyFox, AND a syncer eg. a modified TiddlyWeb, that syncs to a TiddlyWiki5 server, that is either on the local machine, or only accessible through a secure VPN.

FYI, the GitLab saver can be used "as is" from a local TW5 file (I verified that by modifying the saver mechanism to allow two savers to proceed instead of just one), so they must have disabled CORS in their default configuration. I suppose they trust their authentication system. TiddlyWiki server authentication seems rather weak for now, that is why i would not expose the server directly to the Internet in its current state.

The use of a proxy server was discussed do handle CORS, and I suppose it could be used to authenticate as well, but I would rather use a simpler solution for my use case.