### PR TITLE
WIP: Remove css props rather than setting transition to none

### DIFF
--- a/core/modules/storyviews/classic.js
+++ b/core/modules/storyviews/classic.js
@@ -47,16 +47,16 @@ ClassicStoryView.prototype.insert = function(widget) {
 		// Reset the margin once the transition is over
 		setTimeout(function() {
 			$tw.utils.setStyle(targetElement,[
-				{transition: "none"},
 				{marginBottom: ""}
 			]);
+  		targetElement.style.removeProperty('transition');
 		},duration);
 		// Set up the initial position of the element
 		$tw.utils.setStyle(targetElement,[
-			{transition: "none"},
 			{marginBottom: (-currHeight) + "px"},
 			{opacity: "0.0"}
 		]);
+		targetElement.style.removeProperty('transition');
 		$tw.utils.forceLayout(targetElement);
 		// Transition to the final position
 		$tw.utils.setStyle(targetElement,[
@@ -94,11 +94,11 @@ ClassicStoryView.prototype.remove = function(widget) {
 		setTimeout(removeElement,duration);
 		// Animate the closure
 		$tw.utils.setStyle(targetElement,[
-			{transition: "none"},
 			{transform: "translateX(0px)"},
 			{marginBottom:  currMarginBottom + "px"},
 			{opacity: "1.0"}
 		]);
+		targetElement.style.removeProperty('transition');
 		$tw.utils.forceLayout(targetElement);
 		$tw.utils.setStyle(targetElement,[
 			{transition: $tw.utils.roundTripPropertyName("transform") + " " + duration + "ms " + easing + ", " +

--- a/core/modules/storyviews/pop.js
+++ b/core/modules/storyviews/pop.js
@@ -38,9 +38,9 @@ PopStoryView.prototype.insert = function(widget) {
 	// Reset once the transition is over
 	setTimeout(function() {
 		$tw.utils.setStyle(targetElement,[
-			{transition: "none"},
 			{transform: "none"}
 		]);
+		targetElement.style.removeProperty('transition');
 		$tw.utils.setStyle(widget.document.body,[
 			{"overflow-x": ""}
 		]);
@@ -51,10 +51,10 @@ PopStoryView.prototype.insert = function(widget) {
 	]);
 	// Set up the initial position of the element
 	$tw.utils.setStyle(targetElement,[
-		{transition: "none"},
 		{transform: "scale(2)"},
 		{opacity: "0.0"}
 	]);
+	targetElement.style.removeProperty('transition');
 	$tw.utils.forceLayout(targetElement);
 	// Transition to the final position
 	$tw.utils.setStyle(targetElement,[
@@ -82,10 +82,10 @@ PopStoryView.prototype.remove = function(widget) {
 	setTimeout(removeElement,duration);
 	// Animate the closure
 	$tw.utils.setStyle(targetElement,[
-		{transition: "none"},
 		{transform: "scale(1)"},
 		{opacity: "1.0"}
 	]);
+	targetElement.style.removeProperty('transition');
 	$tw.utils.forceLayout(targetElement);
 	$tw.utils.setStyle(targetElement,[
 		{transition: $tw.utils.roundTripPropertyName("transform") + " " + duration + "ms ease-in-out, " +

--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -61,9 +61,9 @@ ZoominListView.prototype.navigateTo = function(historyInfo) {
 		{display: "block"},
 		{transformOrigin: "0 0"},
 		{transform: "translateX(0px) translateY(0px) scale(1)"},
-		{transition: "none"},
 		{opacity: "0.0"}
 	]);
+	stargetElement.style.removeProperty('transition');
 	// Get the position of the source node, or use the centre of the window as the source position
 	var sourceBounds = historyInfo.fromPageRect || {
 			left: window.innerWidth/2 - 2,
@@ -169,9 +169,10 @@ ZoominListView.prototype.remove = function(widget) {
 		{display: "block"},
 		{transformOrigin: "50% 50%"},
 		{transform: "translateX(0px) translateY(0px) scale(1)"},
-		{transition: "none"},
 		{zIndex: "0"}
 	]);
+	targetElement.style.removeProperty('transition');
+
 	// We'll move back to the previous or next element in the story
 	var toWidget = widget.previousSibling();
 	if(!toWidget) {

--- a/core/modules/utils/dom/animations/slide.js
+++ b/core/modules/utils/dom/animations/slide.js
@@ -22,7 +22,6 @@ function slideOpen(domNode,options) {
 	// Reset the margin once the transition is over
 	setTimeout(function() {
 		$tw.utils.setStyle(domNode,[
-			{transition: "none"},
 			{marginBottom: ""},
 			{marginTop: ""},
 			{paddingBottom: ""},
@@ -33,10 +32,10 @@ function slideOpen(domNode,options) {
 		if(options.callback) {
 			options.callback();
 		}
+		domNode.style.removeProperty('transition');
 	},duration);
 	// Set up the initial position of the element
 	$tw.utils.setStyle(domNode,[
-		{transition: "none"},
 		{marginTop: "0px"},
 		{marginBottom: "0px"},
 		{paddingTop: "0px"},
@@ -44,6 +43,7 @@ function slideOpen(domNode,options) {
 		{height: "0px"},
 		{opacity: "0"}
 	]);
+	domNode.style.removeProperty('transition');
 	$tw.utils.forceLayout(domNode);
 	// Transition to the final position
 	$tw.utils.setStyle(domNode,[
@@ -69,7 +69,6 @@ function slideClosed(domNode,options) {
 	// Clear the properties we've set when the animation is over
 	setTimeout(function() {
 		$tw.utils.setStyle(domNode,[
-			{transition: "none"},
 			{marginBottom: ""},
 			{marginTop: ""},
 			{paddingBottom: ""},
@@ -80,6 +79,7 @@ function slideClosed(domNode,options) {
 		if(options.callback) {
 			options.callback();
 		}
+		domNode.style.removeProperty('transition');
 	},duration);
 	// Set up the initial position of the element
 	$tw.utils.setStyle(domNode,[

--- a/plugins/tiddlywiki/cecily/cecily.js
+++ b/plugins/tiddlywiki/cecily/cecily.js
@@ -63,9 +63,9 @@ CecilyStoryView.prototype.remove = function(widget) {
 	},duration);
 	// Animate the closure
 	$tw.utils.setStyle(targetElement,[
-		{transition: "none"},
 		{opacity: "1.0"}
 	]);
+	targetElement.style.removeProperty('transition');
 	$tw.utils.forceLayout(targetElement);
 	$tw.utils.setStyle(targetElement,[
 		{transition: $tw.utils.roundTripPropertyName("transform") + " " + duration + "ms ease-in-out, " +


### PR DESCRIPTION
See the Talk discussion on [Prerelease animation](https://talk.tiddlywiki.org/t/13461) for more background.

This replaces a number of post-animations blocks that set an element's CSS `transition` property  to `none` with ones that remove that style property altogether.  If fixes an issue in which, after an element has been animated into the story river, `:hover` transitions stop working.

Although @saqimtiaz suggested looking also at `/core/modules/utils/dom/modal.js` and at `core/modules/utils/fakedom.js`, I didn't see any necessary changes there.   I did find two others, `slide.js` and `cecily.js`. 


Testing
-------

Do we have any automated testing feature that would help demonstrate the fix?  I don't know that I've ever seen a programmatic way to assert that a CSS animation runs on precipitating event.  Has anyone else?


One simple question
-----------------------

Should we add a function so that these lines would be replaced with `$tw.utils.removeStyle(targetElement, "transition")` (or possibly `removeStyles` using an array of names)?


A harder question
-----------------

Should we take this time to review all such JS animation resets and replace all the `$tw.util.setStyle` calls with a property removal instead?  There is a good argument to be make for doing so, but it is a substantial amount of work.  And it seems as if testing would be quite difficult.  Even recognizing when we're resetting to defaults rather than to arbitrary values might be difficult.  