### PR TITLE
Modules in draft tidders should not be executed

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1560,7 +1560,7 @@ $tw.Wiki.prototype.defineShadowModules = function() {
 		if(!self.tiddlerExists(title) && tiddler.hasField("module-type")) {
 			if(tiddler.hasField("draft.of")) {
 				// Report a fundamental problem
-				console.log(`Plugins should not contain a DRAFT OF: ${tiddler.fields.title}`);
+				console.warn(`TiddlyWiki: Plugins should not contain tiddlers with a 'draft.of' field: ${tiddler.fields.title}`);
 				return;
 			}
 			// Define the module

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1530,7 +1530,8 @@ Define all modules stored in ordinary tiddlers
 */
 $tw.Wiki.prototype.defineTiddlerModules = function() {
 	this.each(function(tiddler,title) {
-		if(tiddler.hasField("module-type")) {
+		// Modules in draft tiddlers are disabled
+		if(tiddler.hasField("module-type") && (!tiddler.hasField("draft.of"))) {
 			switch(tiddler.fields.type) {
 				case "application/javascript":
 					// We only define modules that haven't already been defined, because in the browser modules in system tiddlers are defined in inline script
@@ -1557,6 +1558,11 @@ $tw.Wiki.prototype.defineShadowModules = function() {
 	this.eachShadow(function(tiddler,title) {
 		// Don't define the module if it is overidden by an ordinary tiddler
 		if(!self.tiddlerExists(title) && tiddler.hasField("module-type")) {
+			if(tiddler.hasField("draft.of")) {
+				// Report a fundamental problem
+				console.log(`Plugins should not contain a DRAFT OF: ${tiddler.fields.title}`);
+				return;
+			}
 			// Define the module
 			$tw.modules.define(tiddler.fields.title,tiddler.fields["module-type"],tiddler.fields.text);
 		}


### PR DESCRIPTION
This PR fixes a long standing bug #971

- #971

In the light of LLMs and our users using them more and more to create their own plugins, we should fix this issue. Those issues are extreamly hard to find. So we should be conservative here. 

This PR 

- Checks for drafts in $tw.Wiki.prototype.defineTiddlerModules
- It also reports and blocks draft modules that come from plugins

