### PR TITLE
Markdown: Fix missing inline support and macrocall args parsing error

### DIFF
--- a/plugins/tiddlywiki/markdown/markdown-it-tiddlywiki.js
+++ b/plugins/tiddlywiki/markdown/markdown-it-tiddlywiki.js
@@ -133,25 +133,20 @@ function findNextMatch(ruleinfo,pos) {
 }
 
 // Add inline rule "macrocall" to parse <<macroname ...>>
-var MacroCallRegEx = /<<([^\s>"'=]+)[^>]*>>/g;
 function tw_macrocallinline(state,silent) {
-	var match, max, pos = state.pos;
+	var ruleinfo = pluginOpts.inlineRules.macrocallinline;
 
-	// Check start
-	max = state.posMax;
-	if(state.src.charCodeAt(pos) !== 0x3C || state.src.charCodeAt(pos+1) !== 0x3C /* << */|| pos + 3 >= max) {
+	var pos = state.pos;
+	var matchIndex = findNextMatch(ruleinfo,pos);
+	if(matchIndex === undefined || matchIndex !== pos) {
 		return false;
 	}
 
-	MacroCallRegEx.lastIndex = pos;
-	match = MacroCallRegEx.exec(state.src);
-	if(!match || match.index !== pos) { return false; }
-
 	if(!silent) {
 		var token = state.push('tw_expr','',0);
-		token.content = state.src.slice(pos,pos+match[0].length);
+		token.content = state.src.slice(pos,ruleinfo.rule.nextCall.end);
 	}
-	state.pos = MacroCallRegEx.lastIndex;
+	state.pos = ruleinfo.rule.nextCall.end;
 	return true;
 }
 
@@ -520,8 +515,10 @@ module.exports = function tiddlyWikiPlugin(markdown,options) {
 		if(pluginOpts.inlineRules.transcludeinline) {
 			md.inline.ruler.before('html_inline','tw_transcludeinline',tw_transcludeinline);
 		}
+		if(pluginOpts.inlineRules.macrocallinline) {
+			md.inline.ruler.before('html_inline','tw_macrocallinline',tw_macrocallinline);
+		}
 
-		md.inline.ruler.before('html_inline','tw_macrocallinline',tw_macrocallinline);
 		md.inline.ruler.at('html_inline',extendHtmlInline(md.inline.ruler.__rules__[md.inline.ruler.__find__('html_inline')].fn));
 		md.block.ruler.after('html_block','tw_block',tw_block,{
 			alt: [ 'paragraph', 'reference', 'blockquote' ]

--- a/plugins/tiddlywiki/markdown/styles.tid
+++ b/plugins/tiddlywiki/markdown/styles.tid
@@ -6,6 +6,9 @@ code-body: yes
 	display: block;
 	margin: 0px;
 }
+span.markdown {
+	display: inline;
+}
 .markdown hr {
   margin-top: 20px;
   margin-bottom: 20px;

--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -213,8 +213,15 @@ MarkdownParser.prototype.md = createMarkdownEngine(markdownOpts,pluginOpts);
 function MarkdownParser(type,text,options) {
 	var env = {}
 	var md = this.md;
-	var mdTree = md.parse(text,env);
-	var textToParse = '<div class="markdown">\n' + md.renderer.render(mdTree,md.options,env) + '</div>';
+	var mdTree, textToParse;
+
+	if(options.parseAsInline) {
+		mdTree = md.parseInline(text,env);
+		textToParse = '<span class="markdown">' + md.renderer.render(mdTree,md.options,env) + '</span>';
+	} else {
+		mdTree = md.parse(text,env);
+		textToParse = '<div class="markdown">\n' + md.renderer.render(mdTree,md.options,env) + '</div>';
+	}
 
 	if($tw.log.MARKDOWN) {
 		console.log(JSON.stringify(mdTree,null,2));

--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -216,8 +216,10 @@ function MarkdownParser(type,text,options) {
 	var mdTree = md.parse(text,env);
 	var textToParse = '<div class="markdown">\n' + md.renderer.render(mdTree,md.options,env) + '</div>';
 
-	//console.log(JSON.stringify(mdTree,null,2));
-	//console.log("\n----------------\n" + textToParse);
+	if($tw.log.MARKDOWN) {
+		console.log(JSON.stringify(mdTree,null,2));
+		console.log("\n----------------\n" + textToParse);
+	}
 
 	var wikiParser;
 


### PR DESCRIPTION
This PR includes the following changes:

* Fix markdown parser to respect parseAsInline option. (#8917)
* Fix improper parsing of macrocall, whenenver args contain `>` character.
* Use `$tw.log.MARKDOWN` flag to enable debug messages.