### PR TITLE
Always add `tc-popup-handle` class to $buttons that are popup handles

### DIFF
--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -55,7 +55,7 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 			$tw.utils.pushTop(classes,this.selectedClass.split(" "));
 		}
 	}
-	if(isPoppedUp) {
+	if(this.popup || this.popupTitle) {
 		$tw.utils.pushTop(classes,"tc-popup-handle");
 	}
 	domNode.className = classes.join(" ");


### PR DESCRIPTION
This is to solve the problem described in #9285.
With this change, the CSS class `tc-popup-handle` would always be assigned to all $buttons that have a popup or popupTitle attribute, not only if their associated popup is open.
Otherwise, $buttons that should support nested popups don't get the class until after their popup is triggered, which is too late for the popup system's click handling logic, as the popup system uses the `tc-popup-handle` class to determine popup nesting behavior. So instead, the parent popup is closed instead a child popup opened.

This PR is not strictly backwards-compatible: If CSS styles were assigned to `tc-popup-handle`, these styles would now apply to a different set of elements. However, the core does not style this class and uses it only for the popup system.