### PR TITLE
Ensure normalize.css is always applied

### DIFF
--- a/core/reset.tid
+++ b/core/reset.tid
@@ -1,4 +1,6 @@
-title: $:/themes/tiddlywiki/vanilla/reset
+title: $:/core/reset
+list-before: 
+tags: [[$:/tags/Stylesheet]]
 type: text/css
 
 /*! modern-normalize v2.0.0 | MIT License | https://github.com/sindresorhus/modern-normalize */

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1,6 +1,6 @@
 title: $:/themes/tiddlywiki/vanilla/base
 tags: [[$:/tags/Stylesheet]]
-list-before:
+list-after: $:/core/reset
 code-body: yes
 
 \define custom-background-datauri()
@@ -64,12 +64,6 @@ $else$
 \end
 
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline macrocallblock
-
-/*
-** Start with the normalize CSS reset, and then belay some of its effects
-*/
-
-{{$:/themes/tiddlywiki/vanilla/reset}}
 
 input[type="search"] {
 	outline-offset: initial;


### PR DESCRIPTION
Currently normalize.css is only included in the vanilla theme, so it won't be applied when user switch to another theme that isn't based on vanilla. This PR moves it from vaniila to the core to ensure it is always applied.