### PR TITLE
Add output directory to eslint ignore configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,7 @@ export default defineConfig([{
         "plugins/tiddlywiki/*/files/",
         "eslint.config.mjs",
         "playwright.config.js",
+        "**/output/**"
     ],
 
 },


### PR DESCRIPTION
This PR adds the `**/output/**` directory to eslint ignore configuration

