### PR TITLE
Fix create journal overwrite skinny tiddler

### DIFF
--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -255,6 +255,18 @@ Syncer.prototype.storeTiddler = function(tiddlerFields) {
 	// Save the tiddler
 	var tiddler = new $tw.Tiddler(tiddlerFields);
 	this.wiki.addTiddler(tiddler);
+	// If we've just loaded a full (fat) tiddler, hydrate any draft that was created from a skinny version
+	if(tiddlerFields && tiddlerFields.title && tiddlerFields.text !== undefined) {
+		var draftTitle = this.wiki.findDraft(tiddlerFields.title);
+		if(draftTitle) {
+			var draftTiddler = this.wiki.getTiddler(draftTitle);
+			if(draftTiddler && draftTiddler.hasField("_is_skinny")) {
+				// Copy the loaded text into the draft and remove the skinny marker so the editor can be shown
+				this.wiki.setText(draftTitle,"text",undefined,tiddlerFields.text);
+				this.wiki.setText(draftTitle,"_is_skinny",undefined,undefined);
+			}
+		}
+	}
 	// Save the tiddler revision and changeCount details
 	this.tiddlerInfo[tiddlerFields.title] = {
 		revision: this.getTiddlerRevision(tiddlerFields.title),

--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -255,16 +255,17 @@ Syncer.prototype.storeTiddler = function(tiddlerFields) {
 	// Save the tiddler
 	var tiddler = new $tw.Tiddler(tiddlerFields);
 	this.wiki.addTiddler(tiddler);
-	// If we've just loaded a full (fat) tiddler, hydrate any draft that was created from a skinny version
-	if(tiddlerFields && tiddlerFields.title && tiddlerFields.text !== undefined) {
-		var draftTitle = this.wiki.findDraft(tiddlerFields.title);
-		if(draftTitle) {
-			var draftTiddler = this.wiki.getTiddler(draftTitle);
-			if(draftTiddler && draftTiddler.hasField("_is_skinny")) {
-				// Copy the loaded text into the draft and remove the skinny marker so the editor can be shown
-				this.wiki.setText(draftTitle,"text",undefined,tiddlerFields.text);
-				this.wiki.setText(draftTitle,"_is_skinny",undefined,undefined);
-			}
+	// If there's a draft skinny tiddler, update its text. But skip in case the loaded tiddler never had any text.
+	if(tiddlerFields && tiddlerFields.text !== undefined) {
+		var draftTitle = this.wiki.findDraft(tiddlerFields.title),
+			draftTiddler = draftTitle && this.wiki.getTiddler(draftTitle);
+		if(draftTiddler && draftTiddler.hasField("_is_skinny")) {
+			// remove the skinny flag from draft
+			this.wiki.addTiddler(new $tw.Tiddler(tiddler,{
+				title: draftTitle,
+				"draft.title": draftTiddler.fields["draft.title"],
+				"draft.of": draftTiddler.fields["draft.of"]
+			}));
 		}
 	}
 	// Save the tiddler revision and changeCount details

--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -335,6 +335,11 @@ Syncer.prototype.handleLazyLoadEvent = function(title) {
 	if(!this.syncadaptor.supportsLazyLoading) {
 		return;
 	}
+	// If this is a skinny draft, load its original tiddler instead (the hydrate logic in storeTiddler will update the draft)
+	var tiddler = this.wiki.getTiddler(title);
+	if(tiddler && tiddler.hasField("draft.of") && tiddler.hasField("_is_skinny")) {
+		title = tiddler.fields["draft.of"];
+	}
 	// Don't lazy load the same tiddler twice
 	if(!this.titlesHaveBeenLazyLoaded[title]) {
 		// Don't lazy load if the tiddler isn't included in the sync filter

--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -46,25 +46,19 @@ title: $:/core/ui/EditTemplate
 	typeSelectionTiddler=<<qualify "$:/temp/Type/selected-item">>>
 <$keyboard key="((cancel-edit-tiddler))" actions=<<cancel-delete-tiddler-actions "cancel">> tag="div">
 <$keyboard key="((save-tiddler))" actions=<<save-tiddler-actions>> tag="div">
-<$let
-	originalTiddler={{{ [<currentTiddler>get[draft.of]] }}}>
-	draftIsSkinny={{{ [<currentTiddler>has:field[_is_skinny]then[yes]else[no]] }}}>
-	originalExists={{{ [<originalTiddler>is[tiddler]then[yes]else[no]] }}}>
->
-	<%if [<draftIsSkinny>match[yes]] :and[<originalExists>match[yes]] %>
-		<!-- Trigger lazy-loading of the underlying tiddler text (hidden) -->
-		<div hidden>
-			<$tiddler tiddler=<<originalTiddler>>>
-				{{||$:/core/ui/ViewTemplate/body/default}}
-			</$tiddler>
-		</div>
-		<div class="tc-tiddler-lazy-loading" />
-	<%else%>
-		<$list filter="[all[shadows+tiddlers]tag[$:/tags/EditTemplate]!has[draft.of]]" variable="listItem">
-			<$transclude tiddler=<<listItem>>/>
-		</$list>
-	<%endif%>
-</$let>
+<%if [<currentTiddler>has:field[_is_skinny]] %>
+	<!-- Trigger lazy-loading of the underlying tiddler text (hidden) -->
+	<div hidden>
+		<$tiddler tiddler=<<originalTiddler>>>
+			{{||$:/core/ui/ViewTemplate/body/default}}
+		</$tiddler>
+	</div>
+	<div class="tc-tiddler-lazy-loading" />
+<%else%>
+	<$list filter="[all[shadows+tiddlers]tag[$:/tags/EditTemplate]!has[draft.of]]" variable="listItem">
+		<$transclude tiddler=<<listItem>>/>
+	</$list>
+<%endif%>
 </$keyboard>
 </$keyboard>
 </$vars>

--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -47,11 +47,9 @@ title: $:/core/ui/EditTemplate
 <$keyboard key="((cancel-edit-tiddler))" actions=<<cancel-delete-tiddler-actions "cancel">> tag="div">
 <$keyboard key="((save-tiddler))" actions=<<save-tiddler-actions>> tag="div">
 <%if [<currentTiddler>has:field[_is_skinny]] %>
-	<!-- Trigger lazy-loading of the underlying tiddler text (hidden) -->
+	<!-- Trigger lazy-loading of the draft itself (syncer will fallback to original if draft doesn't exist on server) -->
 	<div hidden>
-		<$tiddler tiddler=<<originalTiddler>>>
-			{{||$:/core/ui/ViewTemplate/body/default}}
-		</$tiddler>
+		{{||$:/core/ui/ViewTemplate/body/default}}
 	</div>
 	<div class="tc-tiddler-lazy-loading" />
 <%else%>

--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -46,9 +46,25 @@ title: $:/core/ui/EditTemplate
 	typeSelectionTiddler=<<qualify "$:/temp/Type/selected-item">>>
 <$keyboard key="((cancel-edit-tiddler))" actions=<<cancel-delete-tiddler-actions "cancel">> tag="div">
 <$keyboard key="((save-tiddler))" actions=<<save-tiddler-actions>> tag="div">
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/EditTemplate]!has[draft.of]]" variable="listItem">
-<$transclude tiddler=<<listItem>>/>
-</$list>
+<$let
+	originalTiddler={{{ [<currentTiddler>get[draft.of]] }}}>
+	draftIsSkinny={{{ [<currentTiddler>has:field[_is_skinny]then[yes]else[no]] }}}>
+	originalExists={{{ [<originalTiddler>is[tiddler]then[yes]else[no]] }}}>
+>
+	<%if [<draftIsSkinny>match[yes]] :and[<originalExists>match[yes]] %>
+		<!-- Trigger lazy-loading of the underlying tiddler text (hidden) -->
+		<div hidden>
+			<$tiddler tiddler=<<originalTiddler>>>
+				{{||$:/core/ui/ViewTemplate/body/default}}
+			</$tiddler>
+		</div>
+		<div class="tc-tiddler-lazy-loading" />
+	<%else%>
+		<$list filter="[all[shadows+tiddlers]tag[$:/tags/EditTemplate]!has[draft.of]]" variable="listItem">
+			<$transclude tiddler=<<listItem>>/>
+		</$list>
+	<%endif%>
+</$let>
 </$keyboard>
 </$keyboard>
 </$vars>

--- a/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9491.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9491.tid
@@ -1,0 +1,10 @@
+title: $:/changenotes/5.4.0/#9491
+description: Show loading indicator editing a lazy-loaded tiddler
+release: 5.4.0
+tags: $:/tags/ChangeNote
+change-type: bugfix
+change-category: usability
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9491
+github-contributors: linonetwo
+
+When editing a tiddler that is still being lazy-loaded, the editor now blocks input and put text into draft when loaded.

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9491.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9491.tid
@@ -1,6 +1,6 @@
-title: $:/changenotes/5.4.0/#9491
+title: $:/changenotes/5.5.0/#9491
 description: Show loading indicator editing a lazy-loaded tiddler
-release: 5.4.0
+release: 5.5.0
 tags: $:/tags/ChangeNote
 change-type: bugfix
 change-category: usability


### PR DESCRIPTION
![fca02e05d7bc499d886c645f79e2e2aapreview jpeg~tplv-a9rns2rl98-image_pre_watermark_1_5b](https://github.com/user-attachments/assets/80b1a150-5787-4467-ab4b-f2e3b32a7d90)


<details>
<img width="726" height="746" alt="截屏2025-12-13 21 49 25" src="https://github.com/user-attachments/assets/96ad3f92-6adf-426b-9c6a-7febf19b267d" />
</details> 

If Journal haven't been loaded, edit mode will be empty, and may dangerously oveerwrite existing Journal.