### PR TITLE
fix: Warn if a hook function forgets return when it is of pipe mode

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2735,7 +2735,12 @@ $tw.hooks.invokeHook = function(hookName /*, value,... */) {
 	var args = Array.prototype.slice.call(arguments,1);
 	if($tw.utils.hop($tw.hooks.names,hookName)) {
 		for(var i = 0; i < $tw.hooks.names[hookName].length; i++) {
+			var previousValue = args[0];
 			args[0] = $tw.hooks.names[hookName][i].apply(null,args);
+			// Warn if a hook function forgets return when it is of pipe mode
+			if(args[0] === undefined && previousValue !== undefined) {
+				console.warn("Hook '" + hookName + "' handler at index " + i + " returned undefined. Expected the handler to return the value for the next hook in the chain. Handler function:", $tw.hooks.names[hookName][i].toString().substring(0, 200) + "...");
+			}
 		}
 	}
 	return args[0];

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2739,7 +2739,7 @@ $tw.hooks.invokeHook = function(hookName /*, value,... */) {
 			args[0] = $tw.hooks.names[hookName][i].apply(null,args);
 			// Warn if a hook function forgets return when it is of pipe mode
 			if(args[0] === undefined && previousValue !== undefined) {
-				console.warn("Hook '" + hookName + "' handler at index " + i + " returned undefined. Expected the handler to return the value for the next hook in the chain. Handler function:", $tw.hooks.names[hookName][i].toString().substring(0, 200) + "...");
+				console.warn("Hook '" + hookName + "' handler at index " + i + " returned undefined. Expected the handler to return the value for the next hook in the chain. Handler function:", $tw.hooks.names[hookName][i]);
 			}
 		}
 	}

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9519.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9519.tid
@@ -1,0 +1,10 @@
+title: $:/changenotes/5.5.0/#9519
+description: Warn when pipe-mode hook functions omit a return value
+release: 5.5.0
+tags: $:/tags/ChangeNote
+change-type: enhancement
+change-category: hackability
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9519
+github-contributors: linonetwo
+
+The boot kernel now warns when a pipe-mode hook function does not return a value, helping plugin authors find hooks that can break subsequent processing.


### PR DESCRIPTION
![69ec62492eefdf68a2121e1c79316c38](https://github.com/user-attachments/assets/ccc47b4f-def8-48e1-a28c-d24235721b5b)

Plugin author could forget to return value when calling hook. I'd like to discuss if it is necessary to warn them (in this case, it is me, my streams-outliner-lib plugin (based on @saqimtiaz's streams) forget to return the value).
Otherwise it will cause error on other authors' plugin (in this case, error is from my external-attachment-plugin)

https://github.com/saqimtiaz/streams/blob/main/plugins/streams/delete-hook/hook.js