### PR TITLE
Titles sticky to menubar instead of document top

### DIFF
--- a/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9584 - stick stickytitles to menubar.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9584 - stick stickytitles to menubar.tid
@@ -1,0 +1,13 @@
+title: $:/changenotes/5.4.0/#9584
+created: 20260116062202184
+modified: 20260116062202184
+tags: $:/tags/ChangeNote
+change-type: enhancement
+change-category: usability
+description: The sticky tiddler titles account for the menubar
+release: 5.4.0
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9584
+github-contributors: BurningTreeC
+type: text/vnd.tiddlywiki
+
+This change makes the sticky tiddler titles stick to the menubar if present instead of sticking to the top of the document and being hidden by the menubar

--- a/plugins/tiddlywiki/menubar/startup.js
+++ b/plugins/tiddlywiki/menubar/startup.js
@@ -14,8 +14,6 @@ exports.platforms = ["browser"];
 exports.after = ["startup"];
 exports.synchronous = true;
 
-var menubarObserver = null;
-
 exports.startup = function() {
 	var menubarObserver = null;
 	var isTracking = false;

--- a/plugins/tiddlywiki/menubar/startup.js
+++ b/plugins/tiddlywiki/menubar/startup.js
@@ -20,7 +20,7 @@ exports.startup = function () {
 	var menubar = document.querySelector(".tc-menubar.tc-adjust-top-of-scroll");
 	if(!menubar) {
 		// No menubar found, set to 0
-		document.documentElement.style.setProperty("--tc-menubar-height","0px");
+		document.documentElement.style.setProperty("--tv-menubar-height","0px");
 		return;
 	}
 
@@ -33,10 +33,10 @@ exports.startup = function () {
 
 		if(isOverlapping) {
 			var height = menubar.getBoundingClientRect().height;
-			document.documentElement.style.setProperty("--tc-menubar-height", height + "px");
+			document.documentElement.style.setProperty("--tv-menubar-height", height + "px");
 		} else {
 			// Menubar is in normal flow, no offset needed
-			document.documentElement.style.setProperty("--tc-menubar-height","0px");
+			document.documentElement.style.setProperty("--tv-menubar-height","0px");
 		}
 	}
 

--- a/plugins/tiddlywiki/menubar/startup.js
+++ b/plugins/tiddlywiki/menubar/startup.js
@@ -31,7 +31,7 @@ exports.startup = function () {
 		var position = computedStyle.position;
 		var isOverlapping = position === "fixed" || position === "sticky" || position === "absolute";
 
-		if (isOverlapping) {
+		if(isOverlapping) {
 			var height = menubar.getBoundingClientRect().height;
 			document.documentElement.style.setProperty("--tc-menubar-height", height + "px");
 		} else {

--- a/plugins/tiddlywiki/menubar/startup.js
+++ b/plugins/tiddlywiki/menubar/startup.js
@@ -1,0 +1,57 @@
+/*\
+title: $:/plugins/tiddlywiki/menubar/startup.js
+type: application/javascript
+module-type: startup
+
+Startup module to track menubar height and set CSS variable for sticky positioning
+
+\*/
+
+"use strict";
+
+exports.name = "menubar-height-tracker";
+exports.platforms = ["browser"];
+exports.after = ["startup"];
+exports.synchronous = true;
+
+var menubarObserver = null;
+
+exports.startup = function () {
+	var menubar = document.querySelector(".tc-menubar.tc-adjust-top-of-scroll");
+	if(!menubar) {
+		// No menubar found, set to 0
+		document.documentElement.style.setProperty("--tc-menubar-height","0px");
+		return;
+	}
+
+	// Function to update the CSS variable
+	function updateMenubarHeight() {
+		// Only account for menubar if it's fixed, sticky, or absolute (overlapping content)
+		var computedStyle = window.getComputedStyle(menubar);
+		var position = computedStyle.position;
+		var isOverlapping = position === "fixed" || position === "sticky" || position === "absolute";
+
+		if (isOverlapping) {
+			var height = menubar.getBoundingClientRect().height;
+			document.documentElement.style.setProperty("--tc-menubar-height", height + "px");
+		} else {
+			// Menubar is in normal flow, no offset needed
+			document.documentElement.style.setProperty("--tc-menubar-height","0px");
+		}
+	}
+
+	// Initial update
+	updateMenubarHeight();
+
+	// Set up ResizeObserver to track menubar size changes
+	if(typeof ResizeObserver !== "undefined" && !menubarObserver) {
+		menubarObserver = new ResizeObserver(function () {
+			updateMenubarHeight();
+		});
+		menubarObserver.observe(menubar);
+	}
+
+	// Also update on window resize as fallback
+	window.addEventListener("resize",updateMenubarHeight);
+};
+

--- a/plugins/tiddlywiki/menubar/styles.tid
+++ b/plugins/tiddlywiki/menubar/styles.tid
@@ -217,7 +217,7 @@ nav.tc-menubar .tc-more-sidebar > .tc-tab-set > .tc-tab-buttons > button {
 <%if [{$:/themes/tiddlywiki/vanilla/options/stickytitles}match[yes]] %>
 
 .tc-tiddler-title {
-	top: var(--tc-menubar-height, 0px);
+	top: var(--tv-menubar-height, 0px);
 }
 
 <%endif%>

--- a/plugins/tiddlywiki/menubar/styles.tid
+++ b/plugins/tiddlywiki/menubar/styles.tid
@@ -40,7 +40,7 @@ tags: [[$:/tags/Stylesheet]]
 </$reveal>
 \end
 
-\rules only filteredtranscludeinline transcludeinline macrodef macrocallinline
+\rules only filteredtranscludeinline transcludeinline macrodef macrocallinline conditional
 
 nav.tc-menubar {
 	position: fixed;
@@ -212,3 +212,12 @@ nav.tc-menubar .tc-more-sidebar > .tc-tab-set > .tc-tab-buttons > button {
 	}
 
 }
+
+/* Adjust sticky tiddler titles to account for fixed menubar */
+<%if [{$:/themes/tiddlywiki/vanilla/options/stickytitles}match[yes]] %>
+
+.tc-tiddler-title {
+	top: var(--tc-menubar-height, 0px);
+}
+
+<%endif%>


### PR DESCRIPTION
By popular demand I try adding a startup module for the menubar plugin that tracks the height of the menubar and sets the css variable --tc-menubar-height that gets applied to the sticky titles so that they stick to the menubar and are not hidden by it