### PR TITLE
fix(filter): optimize tag[] and !tag[] with Set for O(1) lookup

### DIFF
--- a/core/modules/filters/tag.js
+++ b/core/modules/filters/tag.js
@@ -22,12 +22,11 @@ exports.tag = function(source,operator,options) {
 		});
 	} else {
 		// Old semantics:
-		var tiddlers;
 		if(operator.prefix === "!") {
 			// Returns a copy of the input if operator.operand is missing
-			tiddlers = options.wiki.getTiddlersWithTag(operator.operand);
+			const excludeTagSet = new Set(options.wiki.getTiddlersWithTag(operator.operand));
 			source(function(tiddler,title) {
-				if(tiddlers.indexOf(title) === -1) {
+				if(!excludeTagSet.has(title)) {
 					results.push(title);
 				}
 			});
@@ -39,9 +38,9 @@ exports.tag = function(source,operator,options) {
 					return indexedResults;
 				}
 			} else {
-				tiddlers = options.wiki.getTiddlersWithTag(operator.operand);
+				const includeTagSet = new Set(options.wiki.getTiddlersWithTag(operator.operand));
 				source(function(tiddler,title) {
-					if(tiddlers.indexOf(title) !== -1) {
+					if(includeTagSet.has(title)) {
 						results.push(title);
 					}
 				});

--- a/editions/test/tiddlers/tests/test-tags.js
+++ b/editions/test/tiddlers/tests/test-tags.js
@@ -172,6 +172,63 @@ describe("Tag tests", function() {
 			expect(wiki.filterTiddlers("[tag[sortTag]]").join(",")).toBe("__proto__,A");
 		});
 
+		it("should correctly filter with !tag[] (negation) on a non-indexed source", function() {
+			// !tag[] must use O(1) hashset lookup, not indexOf on array
+			// Tiddlers tagged "one": TiddlerOne, Tiddler Three — all others appear in negation
+			expect(wiki.filterTiddlers("[!tag[one]sort[title]]").join(",")).toBe(
+				"$:/TiddlerFive,$:/TiddlerTwo,a fourth tiddler,one,Tiddler10,Tiddler11,Tiddler8,Tiddler9,TiddlerSeventh,TiddlerSix"
+			);
+			// Every tiddler in the positive result should NOT be in the negative result
+			var positiveResult = wiki.filterTiddlers("[tag[one]]");
+			var negativeResult = wiki.filterTiddlers("[!tag[one]]");
+			positiveResult.forEach(function(title) {
+				expect(negativeResult.indexOf(title)).toBe(-1);
+			});
+			// Non-tagged tiddlers should be in the negative result
+			expect(negativeResult.indexOf("TiddlerSix")).not.toBe(-1);
+		});
+
+		it("should correctly filter tag[] when chained (non-indexed source)", function() {
+			// When tag[] follows another operator, source.byTag is unavailable;
+			// the fix ensures O(1) hashset lookup instead of Array.indexOf
+			expect(wiki.filterTiddlers("[prefix[Tiddler]tag[one]sort[title]]").join(",")).toBe("Tiddler Three,TiddlerOne");
+			// prefix[Tiddler] matches: Tiddler Three(one), TiddlerOne(one), Tiddler10, Tiddler11, Tiddler8, Tiddler9, TiddlerSeventh, TiddlerSix
+			expect(wiki.filterTiddlers("[prefix[Tiddler]!tag[one]sort[title]]").join(",")).toBe("Tiddler10,Tiddler11,Tiddler8,Tiddler9,TiddlerSeventh,TiddlerSix");
+		});
+
+		it("should produce consistent results between tag[] and !tag[] for large sets", function() {
+			// Create a wiki with many tiddlers to stress-test the O(1) lookup path
+			var bigWiki = new $tw.Wiki(wikiOptions);
+			var taggedTitles = [], untaggedTitles = [];
+			for(var i = 0; i < 50; i++) {
+				var title = "Tagged" + i;
+				taggedTitles.push(title);
+				bigWiki.addTiddler({title: title, tags: ["myTag"]});
+			}
+			for(var j = 0; j < 50; j++) {
+				var title2 = "Untagged" + j;
+				untaggedTitles.push(title2);
+				bigWiki.addTiddler({title: title2, tags: []});
+			}
+			var positiveResults = bigWiki.filterTiddlers("[tag[myTag]]");
+			var negativeResults = bigWiki.filterTiddlers("[!tag[myTag]]");
+			// All tagged tiddlers should appear in positive result
+			taggedTitles.forEach(function(title) {
+				expect(positiveResults.indexOf(title)).not.toBe(-1);
+				expect(negativeResults.indexOf(title)).toBe(-1);
+			});
+			// All untagged tiddlers should appear in negative result
+			untaggedTitles.forEach(function(title) {
+				expect(negativeResults.indexOf(title)).not.toBe(-1);
+				expect(positiveResults.indexOf(title)).toBe(-1);
+			});
+			// Chained: prefix filter + tag[], ensures non-indexed source path
+			var chainedPositive = bigWiki.filterTiddlers("[prefix[Tagged]tag[myTag]]");
+			var chainedNegative = bigWiki.filterTiddlers("[prefix[Tagged]!tag[myTag]]");
+			expect(chainedPositive.length).toBe(50);
+			expect(chainedNegative.length).toBe(0);
+		});
+
 	}
 
 });

--- a/editions/test/tiddlers/tests/test-tags.js
+++ b/editions/test/tiddlers/tests/test-tags.js
@@ -172,63 +172,6 @@ describe("Tag tests", function() {
 			expect(wiki.filterTiddlers("[tag[sortTag]]").join(",")).toBe("__proto__,A");
 		});
 
-		it("should correctly filter with !tag[] (negation) on a non-indexed source", function() {
-			// !tag[] must use O(1) hashset lookup, not indexOf on array
-			// Tiddlers tagged "one": TiddlerOne, Tiddler Three — all others appear in negation
-			expect(wiki.filterTiddlers("[!tag[one]sort[title]]").join(",")).toBe(
-				"$:/TiddlerFive,$:/TiddlerTwo,a fourth tiddler,one,Tiddler10,Tiddler11,Tiddler8,Tiddler9,TiddlerSeventh,TiddlerSix"
-			);
-			// Every tiddler in the positive result should NOT be in the negative result
-			var positiveResult = wiki.filterTiddlers("[tag[one]]");
-			var negativeResult = wiki.filterTiddlers("[!tag[one]]");
-			positiveResult.forEach(function(title) {
-				expect(negativeResult.indexOf(title)).toBe(-1);
-			});
-			// Non-tagged tiddlers should be in the negative result
-			expect(negativeResult.indexOf("TiddlerSix")).not.toBe(-1);
-		});
-
-		it("should correctly filter tag[] when chained (non-indexed source)", function() {
-			// When tag[] follows another operator, source.byTag is unavailable;
-			// the fix ensures O(1) hashset lookup instead of Array.indexOf
-			expect(wiki.filterTiddlers("[prefix[Tiddler]tag[one]sort[title]]").join(",")).toBe("Tiddler Three,TiddlerOne");
-			// prefix[Tiddler] matches: Tiddler Three(one), TiddlerOne(one), Tiddler10, Tiddler11, Tiddler8, Tiddler9, TiddlerSeventh, TiddlerSix
-			expect(wiki.filterTiddlers("[prefix[Tiddler]!tag[one]sort[title]]").join(",")).toBe("Tiddler10,Tiddler11,Tiddler8,Tiddler9,TiddlerSeventh,TiddlerSix");
-		});
-
-		it("should produce consistent results between tag[] and !tag[] for large sets", function() {
-			// Create a wiki with many tiddlers to stress-test the O(1) lookup path
-			var bigWiki = new $tw.Wiki(wikiOptions);
-			var taggedTitles = [], untaggedTitles = [];
-			for(var i = 0; i < 50; i++) {
-				var title = "Tagged" + i;
-				taggedTitles.push(title);
-				bigWiki.addTiddler({title: title, tags: ["myTag"]});
-			}
-			for(var j = 0; j < 50; j++) {
-				var title2 = "Untagged" + j;
-				untaggedTitles.push(title2);
-				bigWiki.addTiddler({title: title2, tags: []});
-			}
-			var positiveResults = bigWiki.filterTiddlers("[tag[myTag]]");
-			var negativeResults = bigWiki.filterTiddlers("[!tag[myTag]]");
-			// All tagged tiddlers should appear in positive result
-			taggedTitles.forEach(function(title) {
-				expect(positiveResults.indexOf(title)).not.toBe(-1);
-				expect(negativeResults.indexOf(title)).toBe(-1);
-			});
-			// All untagged tiddlers should appear in negative result
-			untaggedTitles.forEach(function(title) {
-				expect(negativeResults.indexOf(title)).not.toBe(-1);
-				expect(positiveResults.indexOf(title)).toBe(-1);
-			});
-			// Chained: prefix filter + tag[], ensures non-indexed source path
-			var chainedPositive = bigWiki.filterTiddlers("[prefix[Tagged]tag[myTag]]");
-			var chainedNegative = bigWiki.filterTiddlers("[prefix[Tagged]!tag[myTag]]");
-			expect(chainedPositive.length).toBe(50);
-			expect(chainedNegative.length).toBe(0);
-		});
-
 	}
 
 });

--- a/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9715.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9715.tid
@@ -2,6 +2,7 @@ title: $:/changenotes/5.4.0/#9715
 change-type: performance
 change-category: filters
 tags: $:/tags/ChangeNote
+github-contributors: linonetwo
 release: 5.4.0
 description: Optimized tag[] and !tag[] filter operators to use Set for O(1) lookup, matching search:tags[] performance.
 github-links: [[https://github.com/Jermolene/TiddlyWiki5/pull/9715]]

--- a/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9715.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9715.tid
@@ -1,0 +1,7 @@
+title: $:/changenotes/5.4.0/#9715
+change-type: performance
+change-category: filters
+tags: $:/tags/ChangeNote
+release: 5.4.0
+description: Optimized tag[] and !tag[] filter operators to use Set for O(1) lookup, matching search:tags[] performance.
+github-links: [[https://github.com/Jermolene/TiddlyWiki5/pull/9715]]


### PR DESCRIPTION
https://talk.tiddlywiki.org/t/performance-tip-search-tags-tag/15012

fixes https://github.com/TiddlyWiki/TiddlyWiki5/issues/9837

simply use `new Set` to speed up `indexof`