### PR TITLE
Improve TW CLI text output and formattedtext 

### DIFF
--- a/core-server/commands/help.js
+++ b/core-server/commands/help.js
@@ -28,8 +28,8 @@ Command.prototype.execute = function() {
 	}
 	// Wikify the help as formatted text (ie block elements generate newlines)
 	text = this.commander.wiki.renderTiddler("text/plain-formatted",helpBase + subhelp);
-	// Remove any leading linebreaks
-	text = text.replace(/^(\r?\n)*/g,"");
+	// Remove any leading linebreaks and add a single one for spacing
+	text = "\n" + text.replace(/^(\r?\n)*/g,"");
 	this.commander.streams.output.write(text);
 };
 

--- a/core-server/commands/help.js
+++ b/core-server/commands/help.js
@@ -30,6 +30,10 @@ Command.prototype.execute = function() {
 	text = this.commander.wiki.renderTiddler("text/plain-formatted",helpBase + subhelp);
 	// Remove any leading linebreaks and add a single one for spacing
 	text = "\n" + text.replace(/^(\r?\n)*/g,"");
+	// Show version in main help
+	if(subhelp === "default") {
+		text = "\nTiddlyWiki version: " + $tw.version + "\n" + text;
+	}
 	// Collapse runs of blank lines into a single blank line
 	text = text.replace(/(\r?\n){3,}/g,"\n\n");
 	// Ensure trailing newline

--- a/core-server/commands/help.js
+++ b/core-server/commands/help.js
@@ -30,6 +30,12 @@ Command.prototype.execute = function() {
 	text = this.commander.wiki.renderTiddler("text/plain-formatted",helpBase + subhelp);
 	// Remove any leading linebreaks and add a single one for spacing
 	text = "\n" + text.replace(/^(\r?\n)*/g,"");
+	// Collapse runs of blank lines into a single blank line
+	text = text.replace(/(\r?\n){3,}/g,"\n\n");
+	// Ensure trailing newline
+	if(!/\n$/.test(text)) {
+		text = text + "\n";
+	}
 	this.commander.streams.output.write(text);
 };
 

--- a/core/language/en-GB/Help/listen.tid
+++ b/core/language/en-GB/Help/listen.tid
@@ -11,25 +11,33 @@ The listen command uses NamedCommandParameters:
 
 All parameters are optional with safe defaults, and can be specified in any order. The recognised parameters are:
 
-* ''host'' - optional hostname to serve from (defaults to "127.0.0.1" aka "localhost")
-* ''path-prefix'' - optional prefix for paths
-* ''port'' - port number on which to listen; non-numeric values are interpreted as a system environment variable from which the port number is extracted (defaults to "8080")
-* ''credentials'' - pathname of credentials CSV file (relative to wiki folder)
-* ''anon-username'' - the username for signing edits for anonymous users
-* ''username'' - optional username for basic authentication
-* ''password'' - optional password for basic authentication
-* ''authenticated-user-header'' - optional name of request header to be used for trusted authentication.
-* ''readers'' - comma-separated list of principals allowed to read from this wiki
-* ''writers'' - comma-separated list of principals allowed to write to this wiki
-* ''csrf-disable'' - set to "yes" to disable CSRF checks (defaults to "no")
-* ''root-tiddler'' - the tiddler to serve at the root (defaults to "$:/core/save/all")
-* ''root-render-type'' - the content type to which the root tiddler should be rendered (defaults to "text/plain")
-* ''root-serve-type'' - the content type with which the root tiddler should be served (defaults to "text/html")
-* ''tls-cert'' - pathname of TLS certificate file (relative to wiki folder)
-* ''tls-key'' - pathname of TLS key file (relative to wiki folder)
-* ''debug-level'' - optional debug level; set to "debug" to view request details (defaults to "none")
-* ''gzip'' - set to "yes" to enable gzip compression for some http endpoints (defaults to "no")
-* ''use-browser-cache'' - set to "yes" to allow the browser to cache responses to save bandwidth (defaults to "no")
+```
+  host                       hostname to serve from (default: "127.0.0.1")
+  path-prefix                prefix for paths
+  port                       port number to listen on; non-numeric values are
+                             interpreted as an environment variable name
+                             (default: "8080")
+  credentials                pathname of credentials CSV file (relative to
+                             wiki folder)
+  anon-username              username for signing edits for anonymous users
+  username                   username for basic authentication
+  password                   password for basic authentication
+  authenticated-user-header  request header for trusted authentication
+  readers                    comma-separated list of principals allowed to read
+  writers                    comma-separated list of principals allowed to write
+  csrf-disable               set to "yes" to disable CSRF checks (default: "no")
+  root-tiddler               tiddler to serve at the root
+                             (default: "$:/core/save/all")
+  root-render-type           content type to render the root tiddler
+                             (default: "text/plain")
+  root-serve-type            content type to serve the root tiddler
+                             (default: "text/html")
+  tls-cert                   pathname of TLS certificate file
+  tls-key                    pathname of TLS key file
+  debug-level                set to "debug" for request details (default: "none")
+  gzip                       set to "yes" for gzip compression (default: "no")
+  use-browser-cache          set to "yes" to allow browser caching (default: "no")
+```
 
 For information on opening up your instance to the entire local network, and possible security concerns, see the WebServer tiddler at TiddlyWiki.com.
 

--- a/core/language/en-GB/Help/render.tid
+++ b/core/language/en-GB/Help/render.tid
@@ -35,5 +35,13 @@ Notes:
 
 Examples:
 
-* `--render '[!is[system]]' '[encodeuricomponent[]addprefix[tiddlers/]addsuffix[.html]]'` -- renders all non-system tiddlers as files in the subdirectory "tiddlers" with URL-encoded titles and the extension HTML
-* `--render '.' 'tiddlers.json' 'text/plain' '$:/core/templates/exporters/JsonFile' 'exportFilter' '[tag[HelloThere]]'` -- renders the tiddlers tagged "HelloThere" to a JSON file named "tiddlers.json"
+```
+  Render all non-system tiddlers as files in the subdirectory "tiddlers" with URL-encoded titles and the extension HTML:
+
+    --render '[!is[system]]' '[encodeuricomponent[]addprefix[tiddlers/]addsuffix[.html]]'
+
+  Render the tiddlers tagged "HelloThere" to a JSON file named "tiddlers.json"
+
+    --render '.' 'tiddlers.json' 'text/plain' '$:/core/templates/exporters/JsonFile' 'exportFilter' '[tag[HelloThere]]'
+```
+

--- a/core/language/en-GB/Help/render.tid
+++ b/core/language/en-GB/Help/render.tid
@@ -11,12 +11,16 @@ A name and value for an additional variable may optionally also be specified.
 --render <tiddler-filter> [<filename-filter>] [<render-type>] [<template>] [ [<name>] [<value>] ]*
 ```
 
-* ''tiddler-filter'': A filter identifying the tiddler(s) to be rendered
-* ''filename-filter'': Optional filter transforming tiddler titles into pathnames. If omitted, defaults to `[is[tiddler]addsuffix[.html]]`, which uses the unchanged tiddler title as the filename
-* ''render-type'': Optional render type: `text/html` (the default) returns the full HTML text and `text/plain` just returns the text content (ie it ignores HTML tags and other unprintable material)
-* ''template'': Optional template through which each tiddler is rendered
-* ''name'': Name of optional variables
-* ''value'': Value of optional variables
+```
+  tiddler-filter    filter identifying the tiddler(s) to be rendered
+  filename-filter   filter transforming titles into pathnames
+                    (default: [is[tiddler]addsuffix[.html]])
+  render-type       text/html (default) for full HTML, or text/plain for
+                    text content only
+  template          template tiddler through which each tiddler is rendered
+  name              name of optional variables
+  value             value of optional variables
+```
 
 By default, the filename is resolved relative to the `output` subdirectory of the edition directory. The `--output` command can be used to direct output to a different directory.
 

--- a/core/language/en-GB/Help/save.tid
+++ b/core/language/en-GB/Help/save.tid
@@ -7,8 +7,11 @@ Saves individual tiddlers identified by a filter in their raw text or binary for
 --save <tiddler-filter> <filename-filter>
 ```
 
-* ''tiddler-filter'': A filter identifying the tiddler(s) to be saved
-* ''filename-filter'': Optional filter transforming tiddler titles into pathnames. If omitted, defaults to `[is[tiddler]]`, which uses the unchanged tiddler title as the filename
+```
+  tiddler-filter    filter identifying the tiddler(s) to be saved
+  filename-filter   filter transforming titles into pathnames
+                    (default: [is[tiddler]])
+```
 
 By default, the filename is resolved relative to the `output` subdirectory of the edition directory. The `--output` command can be used to direct output to a different directory.
 

--- a/core/language/en-GB/Help/save.tid
+++ b/core/language/en-GB/Help/save.tid
@@ -25,4 +25,8 @@ Notes:
 
 Examples:
 
-* `--save "[!is[system]is[image]]" "[encodeuricomponent[]addprefix[tiddlers/]]"` -- saves all non-system image tiddlers as files in the subdirectory "tiddlers" with URL-encoded titles
+```
+  Saves all non-system image tiddlers as files in the subdirectory "tiddlers" with URL-encoded titles
+
+    --save "[!is[system]is[image]]" "[encodeuricomponent[]addprefix[tiddlers/]]"
+```

--- a/core/language/en-GB/Help/savewikifolder.tid
+++ b/core/language/en-GB/Help/savewikifolder.tid
@@ -14,10 +14,14 @@ description: Saves a wiki to a new wiki folder
 
 The following options are supported:
 
-* ''filter'': a filter expression that defines the tiddlers to include in the output.
-* ''explodePlugins'': defaults to "yes"
-** ''yes'' will "explode" plugins into separate tiddler files and save them to the plugin directory within the wiki folder
-** ''no'' will suppress exploding plugins into their constituent tiddler files. It will save the plugin as a single JSON tiddler in the tiddlers folder
+```
+  filter           filter expression defining tiddlers to include
+  explodePlugins   (default: "yes")
+                     yes - "explode" plugins into separate tiddler files
+                           and save to the plugin directory
+                     no  - save plugins as single JSON tiddlers in the
+                           tiddlers folder
+```
 
 Note that both ''explodePlugins'' options will produce wiki folders that build the exact same original wiki. The difference lies in how plugins are represented in the wiki folder.
 

--- a/core/language/en-GB/Help/server.tid
+++ b/core/language/en-GB/Help/server.tid
@@ -9,15 +9,22 @@ Legacy command to serve a wiki over HTTP.
 
 The parameters are:
 
-* ''port'' - port number on which to listen; non-numeric values are interpreted as a system environment variable from which the port number is extracted (defaults to "8080")
-* ''root-tiddler'' - the tiddler to serve at the root (defaults to "$:/core/save/all")
-* ''root-render-type'' - the content type to which the root tiddler should be rendered (defaults to "text/plain")
-* ''root-serve-type'' - the content type with which the root tiddler should be served (defaults to "text/html")
-* ''username'' - the default username for signing edits
-* ''password'' - optional password for basic authentication
-* ''host'' - optional hostname to serve from (defaults to "127.0.0.1" aka "localhost")
-* ''path-prefix'' - optional prefix for paths
-* ''debug-level'' - optional debug level; set to "debug" to view request details (defaults to "none")
+```
+  port              port number to listen on; non-numeric values are
+                    interpreted as an environment variable name
+                    (default: "8080")
+  root-tiddler      tiddler to serve at the root
+                    (default: "$:/core/save/all")
+  root-render-type  content type to render the root tiddler
+                    (default: "text/plain")
+  root-serve-type   content type to serve the root tiddler
+                    (default: "text/html")
+  username          default username for signing edits
+  password          password for basic authentication
+  host              hostname to serve from (default: "127.0.0.1")
+  path-prefix       prefix for paths
+  debug-level       set to "debug" for request details (default: "none")
+```
 
 If the password parameter is specified then the browser will prompt the user for the username and password. Note that the password is transmitted in plain text so this implementation should only be used on a trusted network or over HTTPS.
 

--- a/core/language/en-GB/Help/setfield.tid
+++ b/core/language/en-GB/Help/setfield.tid
@@ -11,7 +11,11 @@ Sets the specified field of a group of tiddlers to the result of wikifying a tem
 
 The parameters are:
 
-* ''filter'' - filter identifying the tiddlers to be affected
-* ''fieldname'' - the field to modify (defaults to "text")
-* ''templatetitle'' - the tiddler to wikify into the specified field. If blank or missing then the specified field is deleted
-* ''rendertype'' - the text type to render (defaults to "text/plain"; "text/html" can be used to include HTML tags)
+```
+  filter          filter identifying the tiddlers to be affected
+  fieldname       the field to modify (default: "text")
+  templatetitle   the tiddler to wikify into the specified field; if blank
+                  or missing then the specified field is deleted
+  rendertype      the text type to render (default: "text/plain";
+                  "text/html" can be used to include HTML tags)
+```

--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -319,7 +319,7 @@ Object.defineProperty(TW_Element.prototype, "formattedTextContent", {
 				b.push("\n");
 			}
 			if(this.tag === "li") {
-				b.push("\n* ");
+				b.push("\n  - ");
 			}
 			var self = this;
 			$tw.utils.each(this.children,function(node) {

--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -321,8 +321,10 @@ Object.defineProperty(TW_Element.prototype, "formattedTextContent", {
 			if(this.tag === "li") {
 				b.push("\n* ");
 			}
+			var self = this;
 			$tw.utils.each(this.children,function(node) {
-				b.push(node.formattedTextContent);
+				// Preserve literal newlines inside <pre> elements (code blocks)
+				b.push(self.tag === "pre" ? node.textContent : node.formattedTextContent);
 			});
 			if(isBlock && this.tag !== "li") {
 				b.push("\n");

--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -315,16 +315,16 @@ Object.defineProperty(TW_Element.prototype, "formattedTextContent", {
 		} else {
 			var b = [],
 				isBlock = $tw.config.htmlBlockElements.indexOf(this.tag) !== -1;
-			if(isBlock) {
+			if(isBlock && this.tag !== "li" && this.tag !== "ul" && this.tag !== "ol") {
 				b.push("\n");
 			}
 			if(this.tag === "li") {
-				b.push("* ");
+				b.push("\n* ");
 			}
 			$tw.utils.each(this.children,function(node) {
 				b.push(node.formattedTextContent);
 			});
-			if(isBlock) {
+			if(isBlock && this.tag !== "li") {
 				b.push("\n");
 			}
 			return b.join("");


### PR DESCRIPTION
This PR improves the TW CLI output format to be better readable by humans. The changes also work with the [Command description tiddlers](https://deploy-preview-9723--tiddlywiki-previews.netlify.app/#Commands:Commands%20ListenCommand%20RenderCommand) in the rendered wiki. 

The `formattedTextContent` function in the fakedom had to be changed. So the PR is not 100% backwards compatible. Since the `formattedtext` is only used by the wikify-widget and poorly documented, chances are high, that it isn't used much by 3rd parties.

### Summary

- **Fix spurious blank lines** between bullet list items and before lists by adjusting `<li>`/`<ul>`/`<ol>` handling in the plain-text serializer (`fakedom.js`)
- **Fix code block rendering** — multi-line `<pre>` blocks no longer collapse onto a single line
- **Add TiddlyWiki version** to the main `--help` output
- **Collapse excessive blank lines** and ensure output ends with a newline (`help.js`)
- **Improve parameter readability** — convert inline bullet lists to indented, column-aligned parameter tables for 6 commands (`listen`, `render`, `server`, `save`, `savewikifolder`, `setfield`)

### To test

- Run `tiddlywiki --help` and verify version is shown and list items are cleanly formatted
- Run `tiddlywiki --help listen` and verify parameters are displayed in aligned columns
- Run `tiddlywiki --help fetch` and verify multi-line code blocks render correctly
- Confirm no extra blank lines between list items or before lists
- Confirm output ends with a trailing newline

