### PR TITLE
FindDraft-performcance-improvement

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1630,7 +1630,7 @@ Find any existing draft of a specified tiddler
 */
 exports.findDraft = function(targetTitle) {
 	var draftTitle = undefined;
-	this.forEachTiddler({includeSystem: true},function(title,tiddler) {
+	this.each(function(tiddler,title) {
 		if(tiddler.fields["draft.title"] && tiddler.fields["draft.of"] === targetTitle) {
 			draftTitle = title;
 		}

--- a/editions/test/tiddlers/tests/benchmarks/concept-summary-finddraft.md
+++ b/editions/test/tiddlers/tests/benchmarks/concept-summary-finddraft.md
@@ -1,0 +1,65 @@
+# findDraft Performance Optimization
+
+## Summary
+
+The `findDraft` function in `core/modules/wiki.js` searches all tiddlers to find an existing draft of a specified tiddler. It was using `forEachTiddler({includeSystem: true}, ...)` which sorts all tiddlers alphabetically (O(n log n)) before iterating — completely unnecessary for a simple search operation.
+
+## The Change
+
+### Before
+```javascript
+exports.findDraft = function(targetTitle) {
+    var draftTitle = undefined;
+    this.forEachTiddler({includeSystem: true},function(title,tiddler) {
+        if(tiddler.fields["draft.title"] && tiddler.fields["draft.of"] === targetTitle) {
+            draftTitle = title;
+        }
+    });
+    return draftTitle;
+};
+```
+
+### After
+```javascript
+exports.findDraft = function(targetTitle) {
+    var draftTitle = undefined;
+    this.each(function(tiddler,title) {
+        if(tiddler.fields["draft.title"] && tiddler.fields["draft.of"] === targetTitle) {
+            draftTitle = title;
+        }
+    });
+    return draftTitle;
+};
+```
+
+## Why `each()` over `forEachTiddler()`
+
+| Aspect | `forEachTiddler()` | `each()` |
+|--------|-------------------|----------|
+| **Sorting** | Sorts alphabetically O(n log n) | No sorting — direct hash iteration O(n) |
+| **System tiddlers** | Excluded by default; needs `{includeSystem: true}` | Includes all tiddlers by default |
+| **Callback signature** | `(title, tiddler)` | `(tiddler, title)` |
+| **Use case** | Display/ordered output | Internal lookups and searches |
+
+The `forEachTiddler` call with `{includeSystem: true}` was paying the full O(n log n) sort cost just to search through every tiddler — the sort order is irrelevant when looking for a specific draft.
+
+## Benchmark Results (10,000 tiddlers, 200 drafts)
+
+| Implementation | Median | Avg | Min | Max |
+|---------------|--------|-----|-----|-----|
+| OLD (`forEachTiddler`) | 4.99ms | 5.02ms | 4.92ms | 5.19ms |
+| NEW (`each()`) | 1.66ms | 1.67ms | 1.61ms | 1.80ms |
+| **Speedup** | **3.01x** | | | |
+
+The ~3x speedup comes entirely from eliminating the unnecessary alphabetical sort in `forEachTiddler`. The function logic itself is identical — just iterating and checking fields.
+
+## Note on Early Termination
+
+The wiki's `each()` method uses a simple `for` loop and does not support early termination (unlike `$tw.utils.each()` which uses `.every()` and supports `return false` to break). Both the old and new implementations continue iterating after finding the draft. An early-exit optimization could provide additional speedup but would require changes to the `each()` API or direct iteration over the tiddlers hash.
+
+## Files
+
+- **Optimization**: `core/modules/wiki.js` — `findDraft` function
+- **Benchmark core**: `editions/test/tiddlers/tests/benchmarks/finddraft-benchmark-core.js`
+- **Jasmine wrapper**: `editions/test/tiddlers/tests/benchmarks/test-finddraft-benchmark.js`
+- **Standalone runner**: `editions/test/tiddlers/tests/benchmarks/run-benchmark.js`

--- a/editions/test/tiddlers/tests/benchmarks/concept-summary-finddraft.md.meta
+++ b/editions/test/tiddlers/tests/benchmarks/concept-summary-finddraft.md.meta
@@ -1,0 +1,2 @@
+title: concept-summary-finddraft.md
+type: text/x-markdown

--- a/editions/test/tiddlers/tests/benchmarks/finddraft-benchmark-core.js
+++ b/editions/test/tiddlers/tests/benchmarks/finddraft-benchmark-core.js
@@ -1,0 +1,185 @@
+/*\
+title: finddraft-benchmark-core.js
+type: application/javascript
+module-type: library
+
+Shared benchmark code for findDraft optimization.
+Used by both the Jasmine test (test-finddraft-benchmark.js) and
+the standalone runner (run-benchmark.js).
+
+Usage:
+  var benchmark = require("finddraft-benchmark-core.js");
+  var results = benchmark.run($tw);
+
+\*/
+"use strict";
+
+var now = (typeof performance !== "undefined" && typeof performance.now === "function")
+	? performance.now.bind(performance)
+	: function() {
+		var hr = process.hrtime();
+		return hr[0] * 1000 + hr[1] / 1e6;
+	};
+
+var TIDDLER_COUNT = 10000;
+var DRAFT_PERCENTAGE = 0.02;      // 2% of tiddlers are drafts
+var WARMUP_RUNS = 2;
+var BENCHMARK_RUNS = 5;
+// Run multiple iterations per timed sample to overcome low-resolution browser timers
+var ITERATIONS_PER_SAMPLE = 10;
+
+// Seeded PRNG for reproducible benchmarks
+function mulberry32(seed) {
+	return function() {
+		seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+		var t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+		t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+		return ((t ^ t >>> 14) >>> 0) / 4294967296;
+	};
+}
+
+// Old implementation using forEachTiddler (sorts all tiddlers alphabetically)
+function findDraftOld(wiki, targetTitle) {
+	var draftTitle = undefined;
+	wiki.forEachTiddler({includeSystem: true},function(title,tiddler) {
+		if(tiddler.fields["draft.title"] && tiddler.fields["draft.of"] === targetTitle) {
+			draftTitle = title;
+		}
+	});
+	return draftTitle;
+}
+
+// New optimized implementation using each() (no sorting)
+function findDraftNew(wiki, targetTitle) {
+	var draftTitle = undefined;
+	wiki.each(function(tiddler,title) {
+		if(tiddler.fields["draft.title"] && tiddler.fields["draft.of"] === targetTitle) {
+			draftTitle = title;
+		}
+	});
+	return draftTitle;
+}
+
+function buildWiki($tw) {
+	var random = mulberry32(42);
+	var wiki = new $tw.Wiki({enableIndexers: []});
+	wiki.addIndexersToWiki();
+	var allTitles = [];
+	var draftTargets = [];
+	var draftTitles = [];
+	var t;
+	for(t = 0; t < TIDDLER_COUNT; t++) {
+		allTitles.push("Tiddler" + t);
+	}
+	// Create some drafts
+	var draftCount = Math.floor(TIDDLER_COUNT * DRAFT_PERCENTAGE);
+	// Pick random tiddlers to be draft targets
+	var indices = [];
+	for(t = 0; t < TIDDLER_COUNT; t++) {
+		indices.push(t);
+	}
+	// Shuffle to pick random draft targets
+	for(t = indices.length - 1; t > 0; t--) {
+		var j = Math.floor(random() * (t + 1));
+		var temp = indices[t];
+		indices[t] = indices[j];
+		indices[j] = temp;
+	}
+	for(t = 0; t < draftCount; t++) {
+		draftTargets.push(allTitles[indices[t]]);
+	}
+	// Add all regular tiddlers
+	for(t = 0; t < TIDDLER_COUNT; t++) {
+		wiki.addTiddler({
+			title: allTitles[t],
+			text: "Content of tiddler " + t + "."
+		});
+	}
+	// Add draft tiddlers (these are additional tiddlers with draft.of/draft.title fields)
+	for(t = 0; t < draftCount; t++) {
+		var draftTitle = "Draft of '" + draftTargets[t] + "'";
+		draftTitles.push(draftTitle);
+		wiki.addTiddler({
+			title: draftTitle,
+			text: "Draft content for " + draftTargets[t],
+			"draft.title": draftTargets[t],
+			"draft.of": draftTargets[t]
+		});
+	}
+	return { wiki: wiki, allTitles: allTitles, draftTargets: draftTargets, draftTitles: draftTitles };
+}
+
+function benchmarkFn(fn, label) {
+	var r, i;
+	for(r = 0; r < WARMUP_RUNS; r++) {
+		fn();
+	}
+	var times = [];
+	var result;
+	for(r = 0; r < BENCHMARK_RUNS; r++) {
+		var start = now();
+		for(i = 0; i < ITERATIONS_PER_SAMPLE; i++) {
+			result = fn();
+		}
+		var end = now();
+		times.push((end - start) / ITERATIONS_PER_SAMPLE);
+	}
+	times.sort(function(a, b) { return a - b; });
+	var median = times[Math.floor(times.length / 2)];
+	var avg = times.reduce(function(s, v) { return s + v; }, 0) / times.length;
+	var min = times[0];
+	var max = times[times.length - 1];
+	console.log("  " + label + ": median=" + median.toFixed(2) + "ms, avg=" + avg.toFixed(2) + "ms, min=" + min.toFixed(2) + "ms, max=" + max.toFixed(2) + "ms");
+	return { result: result, median: median, avg: avg, min: min, max: max };
+}
+
+/*
+Run all benchmarks. Returns an object with results for use by callers.
+  $tw - the TiddlyWiki instance (must be booted)
+*/
+exports.run = function($tw) {
+	console.log("\nBuilding wiki with " + TIDDLER_COUNT + " tiddlers...");
+	var buildStart = now();
+	var data = buildWiki($tw);
+	var wiki = data.wiki;
+	var buildElapsed = now() - buildStart;
+	console.log("Wiki built in " + buildElapsed.toFixed(0) + "ms");
+	console.log("  " + TIDDLER_COUNT + " regular tiddlers, " +
+		data.draftTargets.length + " drafts");
+
+	// Correctness: check all draft targets
+	var allCorrect = true;
+	for(var c = 0; c < data.draftTargets.length; c++) {
+		var target = data.draftTargets[c];
+		var oldResult = findDraftOld(wiki, target);
+		var newResult = findDraftNew(wiki, target);
+		if(oldResult !== newResult) {
+			allCorrect = false;
+			console.log("  MISMATCH for target '" + target + "': old='" + oldResult + "', new='" + newResult + "'");
+		}
+	}
+	// Also verify a non-draft tiddler returns undefined
+	var nonDraftOld = findDraftOld(wiki, "NonExistentTiddler");
+	var nonDraftNew = findDraftNew(wiki, "NonExistentTiddler");
+	if(nonDraftOld !== nonDraftNew) {
+		allCorrect = false;
+	}
+
+	// Performance: search for the first draft target repeatedly
+	var benchTarget = data.draftTargets[0];
+	console.log("\n  findDraft benchmark (" + BENCHMARK_RUNS + " runs, " + WARMUP_RUNS + " warmup, " + ITERATIONS_PER_SAMPLE + " iter/sample):");
+	console.log("  Searching for draft of: '" + benchTarget + "'");
+	var oldBench = benchmarkFn(function() { return findDraftOld(wiki, benchTarget); }, "OLD (forEachTiddler)");
+	var newBench = benchmarkFn(function() { return findDraftNew(wiki, benchTarget); }, "NEW (each)           ");
+	var speedup = oldBench.median / newBench.median;
+	console.log("  Speedup: " + speedup.toFixed(2) + "x faster");
+
+	return {
+		correct: allCorrect,
+		draftCount: data.draftTargets.length,
+		tiddlerCount: TIDDLER_COUNT,
+		oldMedian: oldBench.median,
+		newMedian: newBench.median,
+		speedup: speedup
+	};
+};

--- a/editions/test/tiddlers/tests/benchmarks/run-benchmark.js
+++ b/editions/test/tiddlers/tests/benchmarks/run-benchmark.js
@@ -1,0 +1,43 @@
+/*\
+title: Run Benchmark on Windows - small wrapper - much faster
+type: text/plain
+
+Standalone benchmark runner. Boots TiddlyWiki minimally and runs all
+*-benchmark-core.js files found in this directory.
+
+Usage:
+  node editions/test/tiddlers/tests/benchmarks/run-benchmark.js
+
+\*/
+"use strict";
+
+var path = require("path");
+var fs = require("fs");
+
+// Boot TiddlyWiki
+var twRoot = path.resolve(__dirname, "../../../../..");
+var $tw = require(path.join(twRoot, "boot/boot.js")).TiddlyWiki();
+$tw.boot.argv = [path.join(twRoot, "editions/test")];
+$tw.boot.boot();
+
+// Auto-detect all *-benchmark-core.js files
+var benchmarkDir = __dirname;
+var coreFiles = fs.readdirSync(benchmarkDir).filter(function(f) {
+	return f.match(/-benchmark-core\.js$/);
+});
+
+console.log("Found " + coreFiles.length + " benchmark(s): " + coreFiles.join(", "));
+
+var allPassed = true;
+coreFiles.forEach(function(coreFile) {
+	console.log("\n=== Running: " + coreFile + " ===");
+	var benchmark = require(path.join(benchmarkDir, coreFile));
+	var results = benchmark.run($tw);
+	if(!results.correct) {
+		console.log("FAIL: Correctness check failed for " + coreFile);
+		allPassed = false;
+	}
+});
+
+console.log("\n" + (allPassed ? "ALL BENCHMARKS PASSED" : "SOME BENCHMARKS FAILED"));
+process.exit(allPassed ? 0 : 1);

--- a/editions/test/tiddlers/tests/benchmarks/run-benchmark.js.meta
+++ b/editions/test/tiddlers/tests/benchmarks/run-benchmark.js.meta
@@ -1,0 +1,2 @@
+title: Run Benchmark on Windows - small wrapper - much faster
+type: text/plain

--- a/editions/test/tiddlers/tests/benchmarks/test-finddraft-benchmark.js
+++ b/editions/test/tiddlers/tests/benchmarks/test-finddraft-benchmark.js
@@ -1,0 +1,33 @@
+/*\
+title: test-finddraft-benchmark.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Performance benchmark for findDraft optimization.
+Delegates to finddraft-benchmark-core.js for the actual benchmark logic.
+
+\*/
+"use strict";
+
+// only run for v5.5.0 and v5.5.0-prerelease
+// TODO: Adjust the version check! Currently for the draft it is v5.4.0-pre..
+
+if($tw.version.indexOf("5.4.0") === 0) {
+
+	var benchmark = require("finddraft-benchmark-core.js");
+
+	describe("findDraft performance benchmarks", function() {
+
+		var results = benchmark.run($tw);
+
+		it("correctness: new implementation should return the same results as old", function() {
+			expect(results.correct).toBe(true);
+			console.log("  findDraft: " + results.draftCount + " drafts found out of " + results.tiddlerCount + " tiddlers");
+		});
+
+		it("performance: new implementation should be faster than old", function() {
+			expect(results.newMedian).toBeLessThan(results.oldMedian);
+			console.log("  Speedup: " + results.speedup.toFixed(2) + "x faster");
+		});
+	});
+}

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9729-finddraft-performance.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9729-finddraft-performance.tid
@@ -1,0 +1,12 @@
+change-category: internal
+change-type: performance
+created: 20260711184505000
+description: findDraft() scans the store several times faster
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9729
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9729
+type: text/vnd.tiddlywiki
+
+* `findDraft()` iterates the store directly instead of building and sorting a full tiddler list, speeding up every draft lookup, for example when opening a tiddler in the editor or generating unused titles


### PR DESCRIPTION
This PR consists of several elements. 

- A suggested change in the core code. wiki.js
- A MD file with the concept of the code change
- A TW test-suite test test-finddraft-benchmark.js
  - runs with `node tiddlywiki.js ./editions/test --test` ... and all other tests (slow)
- A node test runner, which only runs 1 test run-benchmark.js
  - This is needed, because running all tests on Windows needs about 2 minutes with my PC
  - from TiddlyWiki5 dir run: `node .\editions\test\tiddlers\tests\benchmarks\run-benchmark.js`
- finddraft-benchmark-core.js .. contains the test logic and the code to create a wiki with specific test tiddlers. 
