### PR TITLE
GetOrphanTitles-performance-improvement

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -655,17 +655,20 @@ exports.getMissingTitles = function() {
 
 exports.getOrphanTitles = function() {
 	var self = this,
-		orphans = this.getTiddlers();
+		linkedTitles = Object.create(null);
 	this.forEachTiddler(function(title,tiddler) {
 		var links = self.getTiddlerLinks(title);
 		$tw.utils.each(links,function(link) {
-			var p = orphans.indexOf(link);
-			if(p !== -1) {
-				orphans.splice(p,1);
-			}
+			linkedTitles[link] = true;
 		});
 	});
-	return orphans; // Todo
+	var orphans = [];
+	this.forEachTiddler(function(title,tiddler) {
+		if(!linkedTitles[title]) {
+			orphans.push(title);
+		}
+	});
+	return orphans;
 };
 
 /*

--- a/editions/test/tiddlers/tests/benchmarks/concept-summary.md
+++ b/editions/test/tiddlers/tests/benchmarks/concept-summary.md
@@ -61,37 +61,141 @@ Located directly above `getOrphanTitles` in `core/modules/wiki.js` (line ~641). 
 
 ---
 
-## 2. How to Write TiddlyWiki Benchmarks
+## 2. Benchmark Architecture: Shared Core + Two Runners
 
-### File structure
+### The problem
 
-Benchmark files go in `editions/test/tiddlers/tests/` (or a subfolder like `benchmarks/`). They need the TiddlyWiki module header:
+Running benchmarks via the full TW Jasmine test suite (`node tiddlywiki.js editions/test --verbose --test`) is slow on Windows due to process startup overhead and full TW boot. But we also need benchmarks to run in the browser via the Jasmine test runner.
+
+### The solution: Three-file architecture
+
+Write the benchmark logic **once** in a shared core module, then use two thin runner wrappers:
+
+```
+editions/test/tiddlers/tests/benchmarks/
+├── orphans-benchmark-core.js   ← Shared benchmark logic (write tests here)
+├── test-orphans-benchmark.js   ← Thin Jasmine wrapper (browser + full TW)
+├── run-benchmark.js            ← Thin standalone wrapper (fast local testing)
+└── concept-summary.md          ← This file
+```
+
+### Shared core module (`orphans-benchmark-core.js`)
+
+This file has **both** a TW module header and standard `exports`, so it works in both contexts:
 
 ```javascript
 /*\
-title: test-my-benchmark.js
+title: orphans-benchmark-core.js
 type: application/javascript
-tags: [[$:/tags/test-spec]]
-
-Description here.
-
+module-type: library
 \*/
 "use strict";
+
+exports.run = function($tw) {
+    // Build wiki, run old vs new, return results
+    return {
+        correct: true/false,
+        orphanCount: N,
+        tiddlerCount: N,
+        oldMedian: N,
+        newMedian: N,
+        speedup: N
+    };
+};
 ```
 
-The `$:/tags/test-spec` tag is required for the Jasmine test runner to pick up the file.
+Key points:
+- `module-type: library` makes it requireable inside TW via `require("orphans-benchmark-core.js")`
+- Standard `exports.run` makes it requireable via Node's `require("./orphans-benchmark-core.js")`
+- Accepts `$tw` as a parameter — does NOT reference `$tw` as a global
+- All benchmark config (TIDDLER_COUNT, etc.), wiki building, old/new implementations, timing logic, and correctness checking live here
+
+### Jasmine wrapper (`test-orphans-benchmark.js`)
+
+Thin wrapper for in-browser and full TW test suite:
+
+```javascript
+/*\
+title: test-orphans-benchmark.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+\*/
+"use strict";
+
+if($tw.version.indexOf("5.4.0") === 0) {
+    var benchmark = require("orphans-benchmark-core.js");
+
+    describe("Orphan tiddler performance benchmarks", function() {
+        var results = benchmark.run($tw);
+
+        it("correctness: ...", function() {
+            expect(results.correct).toBe(true);
+        });
+
+        it("performance: ...", function() {
+            expect(results.newMedian).toBeLessThan(results.oldMedian);
+        });
+    });
+}
+```
+
+Key points:
+- Uses `require("orphans-benchmark-core.js")` (TW title, no `./` prefix)
+- Version guard with `$tw.version.indexOf(...)` to skip on incompatible versions
+- Wiki is built at `describe` scope (no `beforeAll` — not reliable in TW's browser Jasmine)
+- Jasmine `expect()` calls use the pre-computed results from the core module
+
+### Standalone runner (`run-benchmark.js`)
+
+Fast runner for local development — boots only TW core:
+
+```javascript
+#!/usr/bin/env node
+"use strict";
+
+var $tw = require("../../../../../boot/boot.js").TiddlyWiki();
+$tw.boot.argv = [];
+// Suppress boot help output
+var _write = process.stdout.write;
+process.stdout.write = function() { return true; };
+$tw.boot.boot(function() {
+    process.stdout.write = _write;
+    var benchmark = require("./orphans-benchmark-core.js");
+    var results = benchmark.run($tw);
+    process.exit(results.correct ? 0 : 1);
+});
+```
+
+Key points:
+- Uses `require("./orphans-benchmark-core.js")` (filesystem path, with `./` prefix)
+- Boots with empty `$tw.boot.argv = []` — no editions, no plugins, no Jasmine
+- Suppresses TW's boot help output by temporarily replacing `process.stdout.write`
+- Exits with code 0/1 for CI integration
 
 ### Running benchmarks
 
 ```bash
-# Run ALL tests
-node tiddlywiki.js editions/test --verbose --test
+# Fast standalone (Windows-friendly, ~2-3 seconds)
+node editions/test/tiddlers/tests/benchmarks/run-benchmark.js
 
-# Run only specific tests using Jasmine's specFilter (matches against full spec name)
+# Full Jasmine suite with spec filter (~45 seconds)
 node tiddlywiki.js editions/test --verbose --test spec="Orphan"
+
+# Full Jasmine suite (all tests)
+node tiddlywiki.js editions/test --verbose --test
 ```
 
-The `spec=` parameter is a regex matched against the full spec name (describe + it text).
+### Adding a new benchmark
+
+To add a new benchmark (e.g., for `getMissingTitles`):
+
+1. Add the old/new implementations and benchmark logic to the core module's `exports.run()` (or create a new core module like `missing-benchmark-core.js`)
+2. Add corresponding `expect()` checks in the Jasmine wrapper
+3. The standalone runner picks it up automatically since it calls the same `exports.run()`
+
+---
+
+## 3. How to Write TiddlyWiki Benchmarks
 
 ### Key TiddlyWiki APIs for tests
 
@@ -118,18 +222,35 @@ wiki.filterTiddlers(filterString)     // Run a TW filter
 
 Links are created with `[[TargetTitle]]` wikitext syntax. The parser extracts these via `extractLinks()` which walks the parse tree looking for `type === "link"` nodes.
 
+### Version-conditional tests
+
+Use `$tw.version` (a string like `"5.4.0-prerelease"`) to gate tests:
+
+```javascript
+// Run only on v5.5.0 and v5.5.0-prerelease
+if($tw.version.indexOf("5.5.0") === 0) {
+    describe("my tests", function() { ... });
+}
+
+// Or for "5.5.0 and above" use TW's version comparator:
+var isV550 = $tw.utils.compareVersions($tw.version, "5.5.0") >= 0;
+```
+
+### TW module `require()` differences
+
+- **Inside TW context** (Jasmine tests, browser): `require("my-module.js")` resolves by the `title` field in the TW module header
+- **Standalone Node.js**: `require("./my-module.js")` resolves by filesystem path
+- A module can work in both contexts by having both a TW header (`title`, `module-type: library`) and standard Node.js `exports`
+
 ### Critical gotchas learned
 
-1. **No `beforeAll` in browser Jasmine** — TW's in-browser Jasmine doesn't reliably support `beforeAll`. Initialize the wiki directly at `describe` scope (not inside `beforeAll` or `beforeEach`). This works in both Node and browser.
+1. **No `beforeAll` in browser Jasmine** — TW's in-browser Jasmine doesn't reliably support `beforeAll`. Initialize the wiki directly at `describe` scope. This works in both Node and browser.
 
 2. **Timer resolution in browsers** — Browser `performance.now()` may have only 1ms resolution (integer values). For fast functions (~5-10ms), individual timings round to the same value, making comparisons meaningless. **Solution:** Batch multiple iterations per timed sample:
    ```javascript
    var ITERATIONS_PER_SAMPLE = 10;
-   // ...
    var start = now();
-   for(i = 0; i < ITERATIONS_PER_SAMPLE; i++) {
-       result = fn();
-   }
+   for(i = 0; i < ITERATIONS_PER_SAMPLE; i++) { result = fn(); }
    var end = now();
    times.push((end - start) / ITERATIONS_PER_SAMPLE);
    ```
@@ -148,42 +269,11 @@ Links are created with `[[TargetTitle]]` wikitext syntax. The parser extracts th
 
 5. **Seeded PRNG for reproducibility** — Use a deterministic PRNG (mulberry32) instead of `Math.random()` so benchmark data is identical across runs.
 
-### Benchmark function template
-
-```javascript
-function benchmarkFn(fn, label) {
-    var r, i;
-    for(r = 0; r < WARMUP_RUNS; r++) { fn(); }
-    var times = [], result;
-    for(r = 0; r < BENCHMARK_RUNS; r++) {
-        var start = now();
-        for(i = 0; i < ITERATIONS_PER_SAMPLE; i++) { result = fn(); }
-        var end = now();
-        times.push((end - start) / ITERATIONS_PER_SAMPLE);
-    }
-    times.sort(function(a,b) { return a - b; });
-    var median = times[Math.floor(times.length / 2)];
-    console.log("  " + label + ": median=" + median.toFixed(2) + "ms");
-    return { result: result, median: median };
-}
-```
-
-### Correctness test pattern
-
-Always verify the new implementation returns the same results before benchmarking:
-```javascript
-it("correctness: new should match old", function() {
-    var oldSorted = oldFn().slice().sort();
-    var newSorted = newFn().slice().sort();
-    expect(newSorted).toEqual(oldSorted);
-});
-```
-
-Sort both results since order may differ between implementations.
+6. **Selectively checking out files** — If the benchmark files live on a different branch, you can selectively pull them: `git checkout <branch> -- editions/test/tiddlers/tests/benchmarks/`
 
 ---
 
-## 3. Synthetic Test Data Design
+## 4. Synthetic Test Data Design
 
 For 10,000 tiddlers:
 - **10% linking** (1,000 tiddlers) — contain `[[Target]]` wikitext links, 1-5 links each
@@ -197,21 +287,23 @@ Use Fisher-Yates shuffle with seeded PRNG to randomly assign which tiddlers get 
 
 ---
 
-## 4. Observed Results
+## 5. Observed Results
 
 | Function | Old (ms) | New (ms) | Speedup |
 |---|---|---|---|
-| `getOrphanTitles` | ~48-130 | ~11-13 | **4-10x faster** |
+| `getOrphanTitles` | ~48-209 | ~11-13 | **4-19x faster** |
 | `getMissingTitles` | ~7-8 | ~6-7 | ~1.2-1.4x faster |
 
-The `getOrphanTitles` speedup is dramatic because `indexOf`+`splice` on a 10,000-element array is expensive. The `getMissingTitles` speedup is modest because the missing array stays small (~259 elements).
+The `getOrphanTitles` speedup is dramatic because `indexOf`+`splice` on a 10,000-element array is expensive. The `getMissingTitles` speedup is modest because the missing array stays small (~259 elements). Speedup varies by environment (Node vs browser, Windows vs Linux).
 
 ---
 
-## 5. File Locations
+## 6. File Locations
 
 - **Optimized source:** `core/modules/wiki.js` — `getOrphanTitles` (~line 656), `getMissingTitles` (~line 641)
-- **Benchmark test:** `editions/test/tiddlers/tests/benchmarks/test-orphans-benchmark.js`
+- **Benchmark core:** `editions/test/tiddlers/tests/benchmarks/orphans-benchmark-core.js` — shared logic
+- **Jasmine wrapper:** `editions/test/tiddlers/tests/benchmarks/test-orphans-benchmark.js` — browser + full TW
+- **Standalone runner:** `editions/test/tiddlers/tests/benchmarks/run-benchmark.js` — fast local testing
 - **TW test runner:** `plugins/tiddlywiki/jasmine/jasmine-plugin.js` (filter on line 13)
 - **TW boot:** `boot/boot.js` — `$tw.Wiki` constructor, `addTiddler`, etc.
 - **Link extraction:** `core/modules/wiki.js` — `extractLinks` (~line 501), `getTiddlerLinks` (~line 525)

--- a/editions/test/tiddlers/tests/benchmarks/concept-summary.md
+++ b/editions/test/tiddlers/tests/benchmarks/concept-summary.md
@@ -1,0 +1,218 @@
+# TiddlyWiki Performance Optimization — Concept Summary
+
+This document captures the full context from a conversation optimizing `getOrphanTitles` in `core/modules/wiki.js`, including lessons learned for writing TiddlyWiki performance benchmarks. Feed this into a new conversation to replicate the approach for similar optimizations.
+
+---
+
+## 1. The Optimization Pattern
+
+### Problem: `indexOf` + `splice` on arrays is O(n²)
+
+Several functions in `core/modules/wiki.js` (around line 638+) use a pattern where they build up or filter an array using `Array.indexOf()` for deduplication/lookup and `Array.splice()` for removal. Both are O(n) per call, making the overall function O(n²) when called inside a loop over all tiddlers.
+
+### Solution: Use `Object.create(null)` as a hash map for O(1) lookups
+
+Replace `indexOf` checks with property lookups on a plain object (`Object.create(null)`), and `splice` removals with a two-pass collect-then-filter approach.
+
+### Example — `getOrphanTitles`
+
+**Before (O(n²)):**
+```javascript
+exports.getOrphanTitles = function() {
+    var self = this,
+        orphans = this.getTiddlers();
+    this.forEachTiddler(function(title, tiddler) {
+        var links = self.getTiddlerLinks(title);
+        $tw.utils.each(links, function(link) {
+            var p = orphans.indexOf(link);    // O(n) scan
+            if(p !== -1) {
+                orphans.splice(p, 1);         // O(n) shift
+            }
+        });
+    });
+    return orphans;
+};
+```
+
+**After (O(n)):**
+```javascript
+exports.getOrphanTitles = function() {
+    var self = this,
+        linkedTitles = Object.create(null);
+    this.forEachTiddler(function(title, tiddler) {
+        var links = self.getTiddlerLinks(title);
+        $tw.utils.each(links, function(link) {
+            linkedTitles[link] = true;        // O(1) insert
+        });
+    });
+    var orphans = [];
+    this.forEachTiddler(function(title, tiddler) {
+        if(!linkedTitles[title]) {            // O(1) lookup
+            orphans.push(title);
+        }
+    });
+    return orphans;
+};
+```
+
+### Candidate for same optimization: `getMissingTitles`
+
+Located directly above `getOrphanTitles` in `core/modules/wiki.js` (line ~641). Uses `missing.indexOf(link) === -1` for deduplication. Replace with `Object.create(null)` hash map, then `Object.keys()` at the end. Note: The speedup is smaller here (~1.2-1.4x) because the missing list is typically small (hundreds, not thousands), so `indexOf` cost is low.
+
+---
+
+## 2. How to Write TiddlyWiki Benchmarks
+
+### File structure
+
+Benchmark files go in `editions/test/tiddlers/tests/` (or a subfolder like `benchmarks/`). They need the TiddlyWiki module header:
+
+```javascript
+/*\
+title: test-my-benchmark.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Description here.
+
+\*/
+"use strict";
+```
+
+The `$:/tags/test-spec` tag is required for the Jasmine test runner to pick up the file.
+
+### Running benchmarks
+
+```bash
+# Run ALL tests
+node tiddlywiki.js editions/test --verbose --test
+
+# Run only specific tests using Jasmine's specFilter (matches against full spec name)
+node tiddlywiki.js editions/test --verbose --test spec="Orphan"
+```
+
+The `spec=` parameter is a regex matched against the full spec name (describe + it text).
+
+### Key TiddlyWiki APIs for tests
+
+```javascript
+// Create a wiki instance (use enableIndexers:[] to disable indexers for controlled testing)
+var wiki = new $tw.Wiki({enableIndexers: []});
+wiki.addIndexersToWiki();
+
+// Add tiddlers — accepts plain objects, auto-converts to $tw.Tiddler
+wiki.addTiddler({ title: "MyTiddler", text: "Content with [[Link]]" });
+
+// Core methods
+wiki.getTiddlers()                    // Returns sorted array of non-system tiddler titles
+wiki.forEachTiddler(function(title, tiddler) { ... })
+wiki.getTiddlerLinks(title)           // Returns array of link targets (parsed from wikitext)
+wiki.tiddlerExists(title)             // Boolean check
+wiki.isShadowTiddler(title)           // Boolean check
+wiki.parseTiddler(title)              // Returns parse tree (cached per tiddler)
+wiki.extractLinks(parseTree)          // Extracts link targets from parse tree
+wiki.filterTiddlers(filterString)     // Run a TW filter
+```
+
+### Link syntax in tiddler text
+
+Links are created with `[[TargetTitle]]` wikitext syntax. The parser extracts these via `extractLinks()` which walks the parse tree looking for `type === "link"` nodes.
+
+### Critical gotchas learned
+
+1. **No `beforeAll` in browser Jasmine** — TW's in-browser Jasmine doesn't reliably support `beforeAll`. Initialize the wiki directly at `describe` scope (not inside `beforeAll` or `beforeEach`). This works in both Node and browser.
+
+2. **Timer resolution in browsers** — Browser `performance.now()` may have only 1ms resolution (integer values). For fast functions (~5-10ms), individual timings round to the same value, making comparisons meaningless. **Solution:** Batch multiple iterations per timed sample:
+   ```javascript
+   var ITERATIONS_PER_SAMPLE = 10;
+   // ...
+   var start = now();
+   for(i = 0; i < ITERATIONS_PER_SAMPLE; i++) {
+       result = fn();
+   }
+   var end = now();
+   times.push((end - start) / ITERATIONS_PER_SAMPLE);
+   ```
+
+3. **Cross-platform timer** — Use `performance.now.bind(performance)` (not a wrapper that calls `performance.now()` — linters may rename it to `now()` creating infinite recursion). Fallback to `process.hrtime()` for older Node:
+   ```javascript
+   var now = (typeof performance !== "undefined" && typeof performance.now === "function")
+       ? performance.now.bind(performance)
+       : function() {
+           var hr = process.hrtime();
+           return hr[0] * 1000 + hr[1] / 1e6;
+       };
+   ```
+
+4. **Linter interference** — A project linter automatically renames things. Be aware that `performance.now()` inside a function called `now` will get rewritten to `now()` (infinite recursion). Using `.bind()` avoids this.
+
+5. **Seeded PRNG for reproducibility** — Use a deterministic PRNG (mulberry32) instead of `Math.random()` so benchmark data is identical across runs.
+
+### Benchmark function template
+
+```javascript
+function benchmarkFn(fn, label) {
+    var r, i;
+    for(r = 0; r < WARMUP_RUNS; r++) { fn(); }
+    var times = [], result;
+    for(r = 0; r < BENCHMARK_RUNS; r++) {
+        var start = now();
+        for(i = 0; i < ITERATIONS_PER_SAMPLE; i++) { result = fn(); }
+        var end = now();
+        times.push((end - start) / ITERATIONS_PER_SAMPLE);
+    }
+    times.sort(function(a,b) { return a - b; });
+    var median = times[Math.floor(times.length / 2)];
+    console.log("  " + label + ": median=" + median.toFixed(2) + "ms");
+    return { result: result, median: median };
+}
+```
+
+### Correctness test pattern
+
+Always verify the new implementation returns the same results before benchmarking:
+```javascript
+it("correctness: new should match old", function() {
+    var oldSorted = oldFn().slice().sort();
+    var newSorted = newFn().slice().sort();
+    expect(newSorted).toEqual(oldSorted);
+});
+```
+
+Sort both results since order may differ between implementations.
+
+---
+
+## 3. Synthetic Test Data Design
+
+For 10,000 tiddlers:
+- **10% linking** (1,000 tiddlers) — contain `[[Target]]` wikitext links, 1-5 links each
+- **20% no links** (2,000 tiddlers) — plain text, no links at all
+- **70% remaining** — plain text, no links (these plus the 20% form the bulk)
+- **10% missing targets** (1,000 titles) — link targets that have no corresponding tiddler (e.g., "MissingTiddler0" through "MissingTiddler999")
+
+This produces ~7,600 orphan tiddlers and ~259 missing tiddlers, which is a realistic distribution.
+
+Use Fisher-Yates shuffle with seeded PRNG to randomly assign which tiddlers get links vs no links.
+
+---
+
+## 4. Observed Results
+
+| Function | Old (ms) | New (ms) | Speedup |
+|---|---|---|---|
+| `getOrphanTitles` | ~48-130 | ~11-13 | **4-10x faster** |
+| `getMissingTitles` | ~7-8 | ~6-7 | ~1.2-1.4x faster |
+
+The `getOrphanTitles` speedup is dramatic because `indexOf`+`splice` on a 10,000-element array is expensive. The `getMissingTitles` speedup is modest because the missing array stays small (~259 elements).
+
+---
+
+## 5. File Locations
+
+- **Optimized source:** `core/modules/wiki.js` — `getOrphanTitles` (~line 656), `getMissingTitles` (~line 641)
+- **Benchmark test:** `editions/test/tiddlers/tests/benchmarks/test-orphans-benchmark.js`
+- **TW test runner:** `plugins/tiddlywiki/jasmine/jasmine-plugin.js` (filter on line 13)
+- **TW boot:** `boot/boot.js` — `$tw.Wiki` constructor, `addTiddler`, etc.
+- **Link extraction:** `core/modules/wiki.js` — `extractLinks` (~line 501), `getTiddlerLinks` (~line 525)
+- **Test command:** `plugins/tiddlywiki/jasmine/command.js` — supports `spec=` filter parameter

--- a/editions/test/tiddlers/tests/benchmarks/concept-summary.md
+++ b/editions/test/tiddlers/tests/benchmarks/concept-summary.md
@@ -61,19 +61,19 @@ Located directly above `getOrphanTitles` in `core/modules/wiki.js` (line ~641). 
 
 ---
 
-## 2. Benchmark Architecture: Shared Core + Two Runners
+## 2. Benchmark Architecture: Shared Core + Two Runners + Browser Console
 
 ### The problem
 
-Running benchmarks via the full TW Jasmine test suite (`node tiddlywiki.js editions/test --verbose --test`) is slow on Windows due to process startup overhead and full TW boot. But we also need benchmarks to run in the browser via the Jasmine test runner.
+Running benchmarks via the full TW Jasmine test suite (`node tiddlywiki.js editions/test --verbose --test`) is slow on Windows due to process startup overhead and full TW boot. But we also need benchmarks to run in the browser via the Jasmine test runner. And sometimes we want to add test tiddlers to a **live wiki** in the browser to test UI responses interactively.
 
-### The solution: Three-file architecture
+### The solution: Three-file architecture with UMD-style auto-run
 
-Write the benchmark logic **once** in a shared core module, then use two thin runner wrappers:
+Write the benchmark logic **once** in a shared core module, then use two thin runner wrappers. The core module also auto-runs when pasted into a browser console.
 
 ```
 editions/test/tiddlers/tests/benchmarks/
-├── orphans-benchmark-core.js   ← Shared benchmark logic (write tests here)
+├── orphans-benchmark-core.js   ← Shared benchmark logic (+ browser console auto-run)
 ├── test-orphans-benchmark.js   ← Thin Jasmine wrapper (browser + full TW)
 ├── run-benchmark.js            ← Thin standalone wrapper (fast local testing)
 └── concept-summary.md          ← This file
@@ -81,7 +81,7 @@ editions/test/tiddlers/tests/benchmarks/
 
 ### Shared core module (`orphans-benchmark-core.js`)
 
-This file has **both** a TW module header and standard `exports`, so it works in both contexts:
+This file has a TW module header, standard `exports`, and a UMD-style tail so it works in three contexts:
 
 ```javascript
 /*\
@@ -91,17 +91,19 @@ module-type: library
 \*/
 "use strict";
 
-exports.run = function($tw) {
+var run = function($tw, wiki) {
     // Build wiki, run old vs new, return results
-    return {
-        correct: true/false,
-        orphanCount: N,
-        tiddlerCount: N,
-        oldMedian: N,
-        newMedian: N,
-        speedup: N
-    };
+    // wiki param is optional — omit for isolated wiki, pass $tw.wiki for live wiki
 };
+
+// --- Module exports (Node / TW test suite) or auto-run (browser console) ---
+if(typeof module !== "undefined" && module.exports) {
+    exports.run = run;
+    exports.buildWiki = buildWiki;
+} else if(typeof $tw !== "undefined") {
+    // Browser console: add tiddlers to live wiki, then run benchmark
+    run($tw, $tw.wiki);
+}
 ```
 
 Key points:
@@ -109,6 +111,18 @@ Key points:
 - Standard `exports.run` makes it requireable via Node's `require("./orphans-benchmark-core.js")`
 - Accepts `$tw` as a parameter — does NOT reference `$tw` as a global
 - All benchmark config (TIDDLER_COUNT, etc.), wiki building, old/new implementations, timing logic, and correctness checking live here
+- The `typeof module !== "undefined" && module.exports` check (not `typeof exports`) avoids ReferenceError when pasted into a browser console under strict mode
+
+### `buildWiki($tw, wiki)` — dual-mode test data creation
+
+The `buildWiki` function accepts an optional `wiki` parameter:
+
+- **Omitted / falsy** → creates a fresh isolated `new $tw.Wiki({enableIndexers: []})`. Used by the Node test suite.
+- **Provided** (e.g., `$tw.wiki`) → adds tiddlers to the existing live wiki. Used when pasted into the browser console.
+
+Both modes produce **identical tiddlers** — same titles (e.g., `"Tiddler0"`), same content, same seeded PRNG, same percentages. No prefixes, no extra fields (tags, etc.). This ensures benchmark results are comparable across environments.
+
+In the browser, find the tiddlers via `[prefix[Tiddler]]` or `[prefix[MissingTiddler]]` in Advanced Search.
 
 ### Jasmine wrapper (`test-orphans-benchmark.js`)
 
@@ -143,6 +157,7 @@ Key points:
 - Uses `require("orphans-benchmark-core.js")` (TW title, no `./` prefix)
 - Version guard with `$tw.version.indexOf(...)` to skip on incompatible versions
 - Wiki is built at `describe` scope (no `beforeAll` — not reliable in TW's browser Jasmine)
+- Calls `benchmark.run($tw)` without a wiki parameter → isolated wiki, no prefix
 - Jasmine `expect()` calls use the pre-computed results from the core module
 
 ### Standalone runner (`run-benchmark.js`)
@@ -170,7 +185,18 @@ Key points:
 - Uses `require("./orphans-benchmark-core.js")` (filesystem path, with `./` prefix)
 - Boots with empty `$tw.boot.argv = []` — no editions, no plugins, no Jasmine
 - Suppresses TW's boot help output by temporarily replacing `process.stdout.write`
+- Calls `benchmark.run($tw)` without a wiki parameter → isolated wiki, no prefix
 - Exits with code 0/1 for CI integration
+
+### Browser console usage
+
+Paste the entire contents of `orphans-benchmark-core.js` into the browser console of a running TiddlyWiki. The UMD tail detects that `module` is undefined and `$tw` exists, and auto-runs `run($tw, $tw.wiki)`. This:
+
+1. Adds 10,000 tiddlers (`Tiddler0` through `Tiddler9999`) to the live wiki
+2. Runs the old vs new benchmark against the live wiki (which now includes both real and test tiddlers)
+3. Logs results to the console
+
+The tiddlers persist in the wiki — they are **not** cleaned up. You can browse them, test UI responses (e.g., the Orphans tab in $:/ControlPanel), and use filters like `[prefix[Tiddler]]`.
 
 ### Running benchmarks
 
@@ -183,15 +209,17 @@ node tiddlywiki.js editions/test --verbose --test spec="Orphan"
 
 # Full Jasmine suite (all tests)
 node tiddlywiki.js editions/test --verbose --test
+
+# Browser console (paste entire orphans-benchmark-core.js contents)
 ```
 
 ### Adding a new benchmark
 
 To add a new benchmark (e.g., for `getMissingTitles`):
 
-1. Add the old/new implementations and benchmark logic to the core module's `exports.run()` (or create a new core module like `missing-benchmark-core.js`)
+1. Add the old/new implementations and benchmark logic to the core module's `run()` function (or create a new core module like `missing-benchmark-core.js`)
 2. Add corresponding `expect()` checks in the Jasmine wrapper
-3. The standalone runner picks it up automatically since it calls the same `exports.run()`
+3. The standalone runner picks it up automatically since it calls the same `run()`
 
 ---
 
@@ -200,12 +228,17 @@ To add a new benchmark (e.g., for `getMissingTitles`):
 ### Key TiddlyWiki APIs for tests
 
 ```javascript
-// Create a wiki instance (use enableIndexers:[] to disable indexers for controlled testing)
+// Create an isolated wiki instance (used by Node test suite / buildWiki without wiki param)
 var wiki = new $tw.Wiki({enableIndexers: []});
 wiki.addIndexersToWiki();
 
-// Add tiddlers — accepts plain objects, auto-converts to $tw.Tiddler
+// Or use the live wiki (used by browser console / buildWiki with wiki param)
+var wiki = $tw.wiki;
+
+// Add tiddlers — plain objects work for isolated wikis
 wiki.addTiddler({ title: "MyTiddler", text: "Content with [[Link]]" });
+// For live wikis, wrap in new $tw.Tiddler() to trigger change events properly
+wiki.addTiddler(new $tw.Tiddler({ title: "MyTiddler", text: "Content with [[Link]]" }));
 
 // Core methods
 wiki.getTiddlers()                    // Returns sorted array of non-system tiddler titles
@@ -270,6 +303,10 @@ var isV550 = $tw.utils.compareVersions($tw.version, "5.5.0") >= 0;
 5. **Seeded PRNG for reproducibility** — Use a deterministic PRNG (mulberry32) instead of `Math.random()` so benchmark data is identical across runs.
 
 6. **Selectively checking out files** — If the benchmark files live on a different branch, you can selectively pull them: `git checkout <branch> -- editions/test/tiddlers/tests/benchmarks/`
+
+7. **Keep test tiddlers identical across environments** — When adding test tiddlers to a live wiki (browser console mode), do not add tags, prefixes, extra fields, or any data that the isolated wiki mode doesn't add. Any difference changes test conditions (e.g., tags affect link parsing, prefixes change titles), making results non-comparable. Both modes must produce the exact same tiddlers.
+
+8. **UMD detection: use `typeof module` not `typeof exports`** — In strict mode, referencing an undeclared variable like `exports` throws a ReferenceError in the browser console. Use `typeof module !== "undefined" && module.exports` instead, which is safe in all environments.
 
 ---
 

--- a/editions/test/tiddlers/tests/benchmarks/concept-summary.md.meta
+++ b/editions/test/tiddlers/tests/benchmarks/concept-summary.md.meta
@@ -1,0 +1,4 @@
+title: Orphan Titles Benchmark Concept
+created: 20260308203654000
+modified: 20260308203705000
+type: text/plain

--- a/editions/test/tiddlers/tests/benchmarks/orphans-benchmark-core.js
+++ b/editions/test/tiddlers/tests/benchmarks/orphans-benchmark-core.js
@@ -4,12 +4,12 @@ type: application/javascript
 module-type: library
 
 Shared benchmark code for getOrphanTitles optimization.
-Used by both the Jasmine test (test-orphans-benchmark.js) and
-the standalone runner (run-benchmark.js).
 
-Usage:
-  var benchmark = require("orphans-benchmark-core.js");
-  var results = benchmark.run($tw);
+Works in three environments:
+  1. Node / TW test suite:  var benchmark = require("orphans-benchmark-core.js");
+                            var results = benchmark.run($tw);
+  2. Browser console:       paste the whole file — auto-runs, adds tiddlers
+                            to the live $tw.wiki so you can inspect them in the UI.
 
 \*/
 "use strict";
@@ -77,10 +77,20 @@ function getOrphanTitlesNew(wiki, $tw) {
 	return orphans;
 }
 
-function buildWiki($tw) {
+/*
+Build test tiddlers and add them to a wiki.
+  $tw   - the TiddlyWiki instance (must be booted)
+  wiki  - (optional) wiki to add tiddlers to. If omitted a fresh
+          isolated wiki is created (used by the Node test suite).
+          Identical tiddlers are produced in both modes.
+*/
+function buildWiki($tw, wiki) {
 	var random = mulberry32(42);
-	var wiki = new $tw.Wiki({enableIndexers: []});
-	wiki.addIndexersToWiki();
+	var useLiveWiki = !!wiki;
+	if(!wiki) {
+		wiki = new $tw.Wiki({enableIndexers: []});
+		wiki.addIndexersToWiki();
+	}
 	var allTitles = [];
 	var missingTitles = [];
 	var t;
@@ -127,10 +137,15 @@ function buildWiki($tw) {
 		} else {
 			text = "Content of tiddler " + t + ".";
 		}
-		wiki.addTiddler({
+		var fields = {
 			title: allTitles[t],
 			text: text
-		});
+		};
+		if(useLiveWiki) {
+			wiki.addTiddler(new $tw.Tiddler(fields));
+		} else {
+			wiki.addTiddler(fields);
+		}
 	}
 	return { wiki: wiki, allTitles: allTitles, missingTitles: missingTitles };
 }
@@ -161,13 +176,14 @@ function benchmarkFn(fn, label) {
 
 /*
 Run all benchmarks. Returns an object with results for use by callers.
-  $tw - the TiddlyWiki instance (must be booted)
+  $tw  - the TiddlyWiki instance (must be booted)
+  wiki - (optional) existing wiki to use instead of creating a fresh one
 */
-exports.run = function($tw) {
+var run = function($tw, wiki) {
 	console.log("\nBuilding wiki with " + TIDDLER_COUNT + " tiddlers...");
 	var buildStart = now();
-	var data = buildWiki($tw);
-	var wiki = data.wiki;
+	var data = buildWiki($tw, wiki);
+	wiki = data.wiki;
 	var buildElapsed = now() - buildStart;
 	console.log("Wiki built in " + buildElapsed.toFixed(0) + "ms");
 	console.log("  " + TIDDLER_COUNT + " tiddlers, " +
@@ -198,3 +214,13 @@ exports.run = function($tw) {
 		speedup: speedup
 	};
 };
+
+// --- Module exports (Node / TW test suite) or auto-run (browser console) ---
+if(typeof module !== "undefined" && module.exports) {
+	exports.run = run;
+	exports.buildWiki = buildWiki;
+} else if(typeof $tw !== "undefined") {
+	// Browser console: add tiddlers to live wiki, then run benchmark
+	console.log("Adding " + TIDDLER_COUNT + " tiddlers to live wiki...");
+	run($tw, $tw.wiki);
+}

--- a/editions/test/tiddlers/tests/benchmarks/orphans-benchmark-core.js
+++ b/editions/test/tiddlers/tests/benchmarks/orphans-benchmark-core.js
@@ -1,0 +1,200 @@
+/*\
+title: orphans-benchmark-core.js
+type: application/javascript
+module-type: library
+
+Shared benchmark code for getOrphanTitles optimization.
+Used by both the Jasmine test (test-orphans-benchmark.js) and
+the standalone runner (run-benchmark.js).
+
+Usage:
+  var benchmark = require("orphans-benchmark-core.js");
+  var results = benchmark.run($tw);
+
+\*/
+"use strict";
+
+var now = (typeof performance !== "undefined" && typeof performance.now === "function")
+	? performance.now.bind(performance)
+	: function() {
+		var hr = process.hrtime();
+		return hr[0] * 1000 + hr[1] / 1e6;
+	};
+
+var TIDDLER_COUNT = 10000;
+var LINK_PERCENTAGE = 0.10;       // 10% of tiddlers link to other tiddlers
+var NO_LINK_PERCENTAGE = 0.20;    // 20% of tiddlers have no links at all
+var MISSING_LINK_PERCENTAGE = 0.10; // 10% of link targets are non-existent tiddlers
+var LINKS_PER_TIDDLER_MIN = 1;
+var LINKS_PER_TIDDLER_MAX = 5;
+var WARMUP_RUNS = 2;
+var BENCHMARK_RUNS = 5;
+// Run multiple iterations per timed sample to overcome low-resolution browser timers
+var ITERATIONS_PER_SAMPLE = 10;
+
+// Seeded PRNG for reproducible benchmarks
+function mulberry32(seed) {
+	return function() {
+		seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+		var t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+		t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+		return ((t ^ t >>> 14) >>> 0) / 4294967296;
+	};
+}
+
+// Old implementation for comparison
+function getOrphanTitlesOld(wiki, $tw) {
+	var self = wiki,
+		orphans = wiki.getTiddlers();
+	wiki.forEachTiddler(function(title, tiddler) {
+		var links = self.getTiddlerLinks(title);
+		$tw.utils.each(links, function(link) {
+			var p = orphans.indexOf(link);
+			if(p !== -1) {
+				orphans.splice(p, 1);
+			}
+		});
+	});
+	return orphans;
+}
+
+// New optimized implementation
+function getOrphanTitlesNew(wiki, $tw) {
+	var self = wiki,
+		linkedTitles = Object.create(null);
+	wiki.forEachTiddler(function(title, tiddler) {
+		var links = self.getTiddlerLinks(title);
+		$tw.utils.each(links, function(link) {
+			linkedTitles[link] = true;
+		});
+	});
+	var orphans = [];
+	wiki.forEachTiddler(function(title, tiddler) {
+		if(!linkedTitles[title]) {
+			orphans.push(title);
+		}
+	});
+	return orphans;
+}
+
+function buildWiki($tw) {
+	var random = mulberry32(42);
+	var wiki = new $tw.Wiki({enableIndexers: []});
+	wiki.addIndexersToWiki();
+	var allTitles = [];
+	var missingTitles = [];
+	var t;
+	for(t = 0; t < TIDDLER_COUNT; t++) {
+		allTitles.push("Tiddler" + t);
+	}
+	var missingCount = Math.floor(TIDDLER_COUNT * MISSING_LINK_PERCENTAGE);
+	for(t = 0; t < missingCount; t++) {
+		missingTitles.push("MissingTiddler" + t);
+	}
+	var allTargets = allTitles.concat(missingTitles);
+	var noLinkCount = Math.floor(TIDDLER_COUNT * NO_LINK_PERCENTAGE);
+	var linkingCount = Math.floor(TIDDLER_COUNT * LINK_PERCENTAGE);
+	var indices = [];
+	for(t = 0; t < TIDDLER_COUNT; t++) {
+		indices.push(t);
+	}
+	for(t = indices.length - 1; t > 0; t--) {
+		var j = Math.floor(random() * (t + 1));
+		var temp = indices[t];
+		indices[t] = indices[j];
+		indices[j] = temp;
+	}
+	var noLinkSet = Object.create(null);
+	for(t = 0; t < noLinkCount; t++) {
+		noLinkSet[indices[t]] = true;
+	}
+	var linkingSet = Object.create(null);
+	for(t = noLinkCount; t < noLinkCount + linkingCount; t++) {
+		linkingSet[indices[t]] = true;
+	}
+	for(t = 0; t < TIDDLER_COUNT; t++) {
+		var text;
+		if(noLinkSet[t]) {
+			text = "This is tiddler " + t + " with no links.";
+		} else if(linkingSet[t]) {
+			var numLinks = LINKS_PER_TIDDLER_MIN + Math.floor(random() * (LINKS_PER_TIDDLER_MAX - LINKS_PER_TIDDLER_MIN + 1));
+			var links = [];
+			for(var l = 0; l < numLinks; l++) {
+				var targetIdx = Math.floor(random() * allTargets.length);
+				links.push("[[" + allTargets[targetIdx] + "]]");
+			}
+			text = "Tiddler " + t + " links to " + links.join(" and ");
+		} else {
+			text = "Content of tiddler " + t + ".";
+		}
+		wiki.addTiddler({
+			title: allTitles[t],
+			text: text
+		});
+	}
+	return { wiki: wiki, allTitles: allTitles, missingTitles: missingTitles };
+}
+
+function benchmarkFn(fn, label) {
+	var r, i;
+	for(r = 0; r < WARMUP_RUNS; r++) {
+		fn();
+	}
+	var times = [];
+	var result;
+	for(r = 0; r < BENCHMARK_RUNS; r++) {
+		var start = now();
+		for(i = 0; i < ITERATIONS_PER_SAMPLE; i++) {
+			result = fn();
+		}
+		var end = now();
+		times.push((end - start) / ITERATIONS_PER_SAMPLE);
+	}
+	times.sort(function(a, b) { return a - b; });
+	var median = times[Math.floor(times.length / 2)];
+	var avg = times.reduce(function(s, v) { return s + v; }, 0) / times.length;
+	var min = times[0];
+	var max = times[times.length - 1];
+	console.log("  " + label + ": median=" + median.toFixed(2) + "ms, avg=" + avg.toFixed(2) + "ms, min=" + min.toFixed(2) + "ms, max=" + max.toFixed(2) + "ms");
+	return { result: result, median: median, avg: avg, min: min, max: max };
+}
+
+/*
+Run all benchmarks. Returns an object with results for use by callers.
+  $tw - the TiddlyWiki instance (must be booted)
+*/
+exports.run = function($tw) {
+	console.log("\nBuilding wiki with " + TIDDLER_COUNT + " tiddlers...");
+	var buildStart = now();
+	var data = buildWiki($tw);
+	var wiki = data.wiki;
+	var buildElapsed = now() - buildStart;
+	console.log("Wiki built in " + buildElapsed.toFixed(0) + "ms");
+	console.log("  " + TIDDLER_COUNT + " tiddlers, " +
+		Math.floor(TIDDLER_COUNT * LINK_PERCENTAGE) + " linking, " +
+		Math.floor(TIDDLER_COUNT * NO_LINK_PERCENTAGE) + " with no links, " +
+		data.missingTitles.length + " missing targets");
+
+	// Correctness
+	var oldResult = getOrphanTitlesOld(wiki, $tw);
+	var newResult = getOrphanTitlesNew(wiki, $tw);
+	var oldSorted = oldResult.slice().sort();
+	var newSorted = newResult.slice().sort();
+	var correct = JSON.stringify(oldSorted) === JSON.stringify(newSorted);
+
+	// Performance
+	console.log("\n  getOrphanTitles benchmark (" + BENCHMARK_RUNS + " runs, " + WARMUP_RUNS + " warmup, " + ITERATIONS_PER_SAMPLE + " iter/sample):");
+	var oldBench = benchmarkFn(function() { return getOrphanTitlesOld(wiki, $tw); }, "OLD (indexOf + splice)");
+	var newBench = benchmarkFn(function() { return getOrphanTitlesNew(wiki, $tw); }, "NEW (hash lookup)      ");
+	var speedup = oldBench.median / newBench.median;
+	console.log("  Speedup: " + speedup.toFixed(2) + "x faster");
+
+	return {
+		correct: correct,
+		orphanCount: oldResult.length,
+		tiddlerCount: TIDDLER_COUNT,
+		oldMedian: oldBench.median,
+		newMedian: newBench.median,
+		speedup: speedup
+	};
+};

--- a/editions/test/tiddlers/tests/benchmarks/run-benchmark.js
+++ b/editions/test/tiddlers/tests/benchmarks/run-benchmark.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+/*
+Standalone benchmark runner for TiddlyWiki performance tests.
+Boots TW core minimally and runs benchmarks directly — much faster
+than the full Jasmine test suite on Windows.
+
+Usage:
+  node editions/test/tiddlers/tests/benchmarks/run-benchmark.js
+*/
+
+"use strict";
+
+// Boot TiddlyWiki with just the core (no editions, no plugins, no Jasmine)
+var $tw = require("../../../../../boot/boot.js").TiddlyWiki();
+$tw.boot.argv = [];
+// Suppress boot help/info output, restore before running benchmarks
+var _write = process.stdout.write;
+process.stdout.write = function() { return true; };
+$tw.boot.boot(function() {
+	process.stdout.write = _write;
+
+	console.log("TiddlyWiki " + $tw.version + " — Standalone Benchmark Runner\n");
+
+	var benchmark = require("./orphans-benchmark-core.js");
+	var results = benchmark.run($tw);
+
+	console.log("\nCorrectness: " + (results.correct ? "PASS" : "FAIL"));
+	if(!results.correct) {
+		console.error("ERROR: Old and new implementations return different results!");
+		process.exit(1);
+	}
+	process.exit(0);
+});

--- a/editions/test/tiddlers/tests/benchmarks/run-benchmark.js
+++ b/editions/test/tiddlers/tests/benchmarks/run-benchmark.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
 Standalone benchmark runner for TiddlyWiki performance tests.
 Boots TW core minimally and runs benchmarks directly — much faster

--- a/editions/test/tiddlers/tests/benchmarks/run-benchmark.js.meta
+++ b/editions/test/tiddlers/tests/benchmarks/run-benchmark.js.meta
@@ -1,0 +1,5 @@
+title: Run Benchmark on Windows - small wrapper - much faster
+type: text/plain
+created: 20260308204959
+modified: 20260308205023000
+

--- a/editions/test/tiddlers/tests/benchmarks/test-orphans-benchmark.js
+++ b/editions/test/tiddlers/tests/benchmarks/test-orphans-benchmark.js
@@ -20,7 +20,7 @@ var now = (typeof performance !== "undefined" && typeof performance.now === "fun
 // TODO: Adjust the version check! Currently for the draft it is v5.4.0-pre.. 
 
 if($tw.version.indexOf("5.4.0") === 0) {
-	describe("Orphan and Missing tiddler performance benchmarks", function() {
+	describe("Orphan tiddler performance benchmarks", function() {
 
 		var TIDDLER_COUNT = 10000;
 		var LINK_PERCENTAGE = 0.10;       // 10% of tiddlers link to other tiddlers

--- a/editions/test/tiddlers/tests/benchmarks/test-orphans-benchmark.js
+++ b/editions/test/tiddlers/tests/benchmarks/test-orphans-benchmark.js
@@ -16,193 +16,198 @@ var now = (typeof performance !== "undefined" && typeof performance.now === "fun
 		return hr[0] * 1000 + hr[1] / 1e6;
 	};
 
-describe("Orphan and Missing tiddler performance benchmarks", function() {
+// only run for v5.5.0 and v5.5.0-prerelease
+// TODO: Adjust the version check! Currently for the draft it is v5.4.0-pre.. 
 
-	var TIDDLER_COUNT = 10000;
-	var LINK_PERCENTAGE = 0.10;       // 10% of tiddlers link to other tiddlers
-	var NO_LINK_PERCENTAGE = 0.20;    // 20% of tiddlers have no links at all
-	var MISSING_LINK_PERCENTAGE = 0.10; // 10% of link targets are non-existent tiddlers
-	var LINKS_PER_TIDDLER_MIN = 1;
-	var LINKS_PER_TIDDLER_MAX = 5;
-	var WARMUP_RUNS = 2;
-	var BENCHMARK_RUNS = 5;
-	// Run multiple iterations per timed sample to overcome low-resolution browser timers
-	var ITERATIONS_PER_SAMPLE = 10;
+if($tw.version.indexOf("5.4.0") === 0) {
+	describe("Orphan and Missing tiddler performance benchmarks", function() {
 
-	// Seeded PRNG for reproducible benchmarks
-	function mulberry32(seed) {
-		return function() {
-			seed |= 0; seed = seed + 0x6D2B79F5 | 0;
-			var t = Math.imul(seed ^ seed >>> 15, 1 | seed);
-			t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
-			return ((t ^ t >>> 14) >>> 0) / 4294967296;
-		};
-	}
+		var TIDDLER_COUNT = 10000;
+		var LINK_PERCENTAGE = 0.10;       // 10% of tiddlers link to other tiddlers
+		var NO_LINK_PERCENTAGE = 0.20;    // 20% of tiddlers have no links at all
+		var MISSING_LINK_PERCENTAGE = 0.10; // 10% of link targets are non-existent tiddlers
+		var LINKS_PER_TIDDLER_MIN = 1;
+		var LINKS_PER_TIDDLER_MAX = 5;
+		var WARMUP_RUNS = 2;
+		var BENCHMARK_RUNS = 5;
+		// Run multiple iterations per timed sample to overcome low-resolution browser timers
+		var ITERATIONS_PER_SAMPLE = 10;
 
-	var wiki, allTitles, missingTitles;
+		// Seeded PRNG for reproducible benchmarks
+		function mulberry32(seed) {
+			return function() {
+				seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+				var t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+				t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+				return ((t ^ t >>> 14) >>> 0) / 4294967296;
+			};
+		}
 
-	// Old implementations for comparison
-	function getOrphanTitlesOld() {
-		var self = wiki,
-			orphans = wiki.getTiddlers();
-		wiki.forEachTiddler(function(title,tiddler) {
-			var links = self.getTiddlerLinks(title);
-			$tw.utils.each(links,function(link) {
-				var p = orphans.indexOf(link);
-				if(p !== -1) {
-					orphans.splice(p,1);
+		var wiki, allTitles, missingTitles;
+
+		// Old implementations for comparison
+		function getOrphanTitlesOld() {
+			var self = wiki,
+				orphans = wiki.getTiddlers();
+			wiki.forEachTiddler(function(title,tiddler) {
+				var links = self.getTiddlerLinks(title);
+				$tw.utils.each(links,function(link) {
+					var p = orphans.indexOf(link);
+					if(p !== -1) {
+						orphans.splice(p,1);
+					}
+				});
+			});
+			return orphans;
+		}
+
+		// New optimized implementation
+		function getOrphanTitlesNew() {
+			var self = wiki,
+				linkedTitles = Object.create(null);
+			wiki.forEachTiddler(function(title,tiddler) {
+				var links = self.getTiddlerLinks(title);
+				$tw.utils.each(links,function(link) {
+					linkedTitles[link] = true;
+				});
+			});
+			var orphans = [];
+			wiki.forEachTiddler(function(title,tiddler) {
+				if(!linkedTitles[title]) {
+					orphans.push(title);
 				}
 			});
-		});
-		return orphans;
-	}
+			return orphans;
+		}
 
-	// New optimized implementation
-	function getOrphanTitlesNew() {
-		var self = wiki,
-			linkedTitles = Object.create(null);
-		wiki.forEachTiddler(function(title,tiddler) {
-			var links = self.getTiddlerLinks(title);
-			$tw.utils.each(links,function(link) {
-				linkedTitles[link] = true;
-			});
-		});
-		var orphans = [];
-		wiki.forEachTiddler(function(title,tiddler) {
-			if(!linkedTitles[title]) {
-				orphans.push(title);
+		function buildWiki() {
+			var random = mulberry32(42);
+			wiki = new $tw.Wiki({enableIndexers: []});
+			wiki.addIndexersToWiki();
+			allTitles = [];
+			missingTitles = [];
+			// Generate tiddler titles
+			var t;
+			for(t = 0; t < TIDDLER_COUNT; t++) {
+				allTitles.push("Tiddler" + t);
 			}
-		});
-		return orphans;
-	}
-
-	function buildWiki() {
-		var random = mulberry32(42);
-		wiki = new $tw.Wiki({enableIndexers: []});
-		wiki.addIndexersToWiki();
-		allTitles = [];
-		missingTitles = [];
-		// Generate tiddler titles
-		var t;
-		for(t = 0; t < TIDDLER_COUNT; t++) {
-			allTitles.push("Tiddler" + t);
-		}
-		// Generate missing tiddler titles (targets that won't have actual tiddlers)
-		var missingCount = Math.floor(TIDDLER_COUNT * MISSING_LINK_PERCENTAGE);
-		for(t = 0; t < missingCount; t++) {
-			missingTitles.push("MissingTiddler" + t);
-		}
-		// All possible link targets: real tiddlers + missing tiddlers
-		var allTargets = allTitles.concat(missingTitles);
-		// Determine which tiddlers get no links (20%)
-		var noLinkCount = Math.floor(TIDDLER_COUNT * NO_LINK_PERCENTAGE);
-		// Determine which tiddlers link to others (10% of the total)
-		var linkingCount = Math.floor(TIDDLER_COUNT * LINK_PERCENTAGE);
-		// Shuffle indices to randomly assign roles
-		var indices = [];
-		for(t = 0; t < TIDDLER_COUNT; t++) {
-			indices.push(t);
-		}
-		// Fisher-Yates shuffle with seeded PRNG
-		for(t = indices.length - 1; t > 0; t--) {
-			var j = Math.floor(random() * (t + 1));
-			var temp = indices[t];
-			indices[t] = indices[j];
-			indices[j] = temp;
-		}
-		var noLinkSet = Object.create(null);
-		for(t = 0; t < noLinkCount; t++) {
-			noLinkSet[indices[t]] = true;
-		}
-		var linkingSet = Object.create(null);
-		for(t = noLinkCount; t < noLinkCount + linkingCount; t++) {
-			linkingSet[indices[t]] = true;
-		}
-		// Create tiddlers
-		for(t = 0; t < TIDDLER_COUNT; t++) {
-			var text;
-			if(noLinkSet[t]) {
-				// No links - just plain text
-				text = "This is tiddler " + t + " with no links.";
-			} else if(linkingSet[t]) {
-				// This tiddler links to random targets
-				var numLinks = LINKS_PER_TIDDLER_MIN + Math.floor(random() * (LINKS_PER_TIDDLER_MAX - LINKS_PER_TIDDLER_MIN + 1));
-				var links = [];
-				for(var l = 0; l < numLinks; l++) {
-					var targetIdx = Math.floor(random() * allTargets.length);
-					links.push("[[" + allTargets[targetIdx] + "]]");
+			// Generate missing tiddler titles (targets that won't have actual tiddlers)
+			var missingCount = Math.floor(TIDDLER_COUNT * MISSING_LINK_PERCENTAGE);
+			for(t = 0; t < missingCount; t++) {
+				missingTitles.push("MissingTiddler" + t);
+			}
+			// All possible link targets: real tiddlers + missing tiddlers
+			var allTargets = allTitles.concat(missingTitles);
+			// Determine which tiddlers get no links (20%)
+			var noLinkCount = Math.floor(TIDDLER_COUNT * NO_LINK_PERCENTAGE);
+			// Determine which tiddlers link to others (10% of the total)
+			var linkingCount = Math.floor(TIDDLER_COUNT * LINK_PERCENTAGE);
+			// Shuffle indices to randomly assign roles
+			var indices = [];
+			for(t = 0; t < TIDDLER_COUNT; t++) {
+				indices.push(t);
+			}
+			// Fisher-Yates shuffle with seeded PRNG
+			for(t = indices.length - 1; t > 0; t--) {
+				var j = Math.floor(random() * (t + 1));
+				var temp = indices[t];
+				indices[t] = indices[j];
+				indices[j] = temp;
+			}
+			var noLinkSet = Object.create(null);
+			for(t = 0; t < noLinkCount; t++) {
+				noLinkSet[indices[t]] = true;
+			}
+			var linkingSet = Object.create(null);
+			for(t = noLinkCount; t < noLinkCount + linkingCount; t++) {
+				linkingSet[indices[t]] = true;
+			}
+			// Create tiddlers
+			for(t = 0; t < TIDDLER_COUNT; t++) {
+				var text;
+				if(noLinkSet[t]) {
+					// No links - just plain text
+					text = "This is tiddler " + t + " with no links.";
+				} else if(linkingSet[t]) {
+					// This tiddler links to random targets
+					var numLinks = LINKS_PER_TIDDLER_MIN + Math.floor(random() * (LINKS_PER_TIDDLER_MAX - LINKS_PER_TIDDLER_MIN + 1));
+					var links = [];
+					for(var l = 0; l < numLinks; l++) {
+						var targetIdx = Math.floor(random() * allTargets.length);
+						links.push("[[" + allTargets[targetIdx] + "]]");
+					}
+					text = "Tiddler " + t + " links to " + links.join(" and ");
+				} else {
+					// Remaining 70% - plain text, no links
+					text = "Content of tiddler " + t + ".";
 				}
-				text = "Tiddler " + t + " links to " + links.join(" and ");
-			} else {
-				// Remaining 70% - plain text, no links
-				text = "Content of tiddler " + t + ".";
+				wiki.addTiddler({
+					title: allTitles[t],
+					text: text
+				});
 			}
-			wiki.addTiddler({
-				title: allTitles[t],
-				text: text
+		}
+
+		function benchmarkFn(fn, label) {
+			// Warmup
+			var r, i;
+			for(r = 0; r < WARMUP_RUNS; r++) {
+				fn();
+			}
+			// Timed runs: batch ITERATIONS_PER_SAMPLE calls per sample
+			// to overcome low-resolution browser timers
+			var times = [];
+			var result;
+			for(r = 0; r < BENCHMARK_RUNS; r++) {
+				var start = now();
+				for(i = 0; i < ITERATIONS_PER_SAMPLE; i++) {
+					result = fn();
+				}
+				var end = now();
+				times.push((end - start) / ITERATIONS_PER_SAMPLE);
+			}
+			times.sort(function(a,b) { return a - b; });
+			var median = times[Math.floor(times.length / 2)];
+			var avg = times.reduce(function(s,v) { return s + v; }, 0) / times.length;
+			var min = times[0];
+			var max = times[times.length - 1];
+			console.log("  " + label + ": median=" + median.toFixed(2) + "ms, avg=" + avg.toFixed(2) + "ms, min=" + min.toFixed(2) + "ms, max=" + max.toFixed(2) + "ms");
+			return { result: result, median: median, avg: avg, min: min, max: max };
+		}
+
+		// Build wiki at describe scope (beforeAll is not available in TW's in-browser Jasmine)
+		console.log("\nBuilding wiki with " + TIDDLER_COUNT + " tiddlers...");
+		var buildStart = now();
+		buildWiki();
+		var buildElapsed = now() - buildStart;
+		console.log("Wiki built in " + buildElapsed.toFixed(0) + "ms");
+		console.log("  " + TIDDLER_COUNT + " tiddlers, " +
+			Math.floor(TIDDLER_COUNT * LINK_PERCENTAGE) + " linking, " +
+			Math.floor(TIDDLER_COUNT * NO_LINK_PERCENTAGE) + " with no links, " +
+			missingTitles.length + " missing targets");
+
+		describe("getOrphanTitles", function() {
+			var oldResult, newResult;
+
+			it("correctness: new implementation should return the same results as old", function() {
+				oldResult = getOrphanTitlesOld();
+				newResult = getOrphanTitlesNew();
+				// Sort both for comparison since order may differ
+				var oldSorted = oldResult.slice().sort();
+				var newSorted = newResult.slice().sort();
+				expect(newSorted).toEqual(oldSorted);
+				console.log("  getOrphanTitles: " + oldResult.length + " orphans found out of " + TIDDLER_COUNT + " tiddlers");
 			});
-		}
-	}
 
-	function benchmarkFn(fn, label) {
-		// Warmup
-		var r, i;
-		for(r = 0; r < WARMUP_RUNS; r++) {
-			fn();
-		}
-		// Timed runs: batch ITERATIONS_PER_SAMPLE calls per sample
-		// to overcome low-resolution browser timers
-		var times = [];
-		var result;
-		for(r = 0; r < BENCHMARK_RUNS; r++) {
-			var start = now();
-			for(i = 0; i < ITERATIONS_PER_SAMPLE; i++) {
-				result = fn();
-			}
-			var end = now();
-			times.push((end - start) / ITERATIONS_PER_SAMPLE);
-		}
-		times.sort(function(a,b) { return a - b; });
-		var median = times[Math.floor(times.length / 2)];
-		var avg = times.reduce(function(s,v) { return s + v; }, 0) / times.length;
-		var min = times[0];
-		var max = times[times.length - 1];
-		console.log("  " + label + ": median=" + median.toFixed(2) + "ms, avg=" + avg.toFixed(2) + "ms, min=" + min.toFixed(2) + "ms, max=" + max.toFixed(2) + "ms");
-		return { result: result, median: median, avg: avg, min: min, max: max };
-	}
-
-	// Build wiki at describe scope (beforeAll is not available in TW's in-browser Jasmine)
-	console.log("\nBuilding wiki with " + TIDDLER_COUNT + " tiddlers...");
-	var buildStart = now();
-	buildWiki();
-	var buildElapsed = now() - buildStart;
-	console.log("Wiki built in " + buildElapsed.toFixed(0) + "ms");
-	console.log("  " + TIDDLER_COUNT + " tiddlers, " +
-		Math.floor(TIDDLER_COUNT * LINK_PERCENTAGE) + " linking, " +
-		Math.floor(TIDDLER_COUNT * NO_LINK_PERCENTAGE) + " with no links, " +
-		missingTitles.length + " missing targets");
-
-	describe("getOrphanTitles", function() {
-		var oldResult, newResult;
-
-		it("correctness: new implementation should return the same results as old", function() {
-			oldResult = getOrphanTitlesOld();
-			newResult = getOrphanTitlesNew();
-			// Sort both for comparison since order may differ
-			var oldSorted = oldResult.slice().sort();
-			var newSorted = newResult.slice().sort();
-			expect(newSorted).toEqual(oldSorted);
-			console.log("  getOrphanTitles: " + oldResult.length + " orphans found out of " + TIDDLER_COUNT + " tiddlers");
+			it("performance: new implementation should be faster than old", function() {
+				console.log("\n  getOrphanTitles benchmark (" + BENCHMARK_RUNS + " runs, " + WARMUP_RUNS + " warmup):");
+				var oldBench = benchmarkFn(getOrphanTitlesOld, "OLD (indexOf + splice)");
+				var newBench = benchmarkFn(getOrphanTitlesNew, "NEW (hash lookup)      ");
+				var speedup = oldBench.median / newBench.median;
+				console.log("  Speedup: " + speedup.toFixed(2) + "x faster");
+				expect(newBench.median).toBeLessThan(oldBench.median);
+			});
 		});
 
-		it("performance: new implementation should be faster than old", function() {
-			console.log("\n  getOrphanTitles benchmark (" + BENCHMARK_RUNS + " runs, " + WARMUP_RUNS + " warmup):");
-			var oldBench = benchmarkFn(getOrphanTitlesOld, "OLD (indexOf + splice)");
-			var newBench = benchmarkFn(getOrphanTitlesNew, "NEW (hash lookup)      ");
-			var speedup = oldBench.median / newBench.median;
-			console.log("  Speedup: " + speedup.toFixed(2) + "x faster");
-			expect(newBench.median).toBeLessThan(oldBench.median);
-		});
 	});
-
-});
+}

--- a/editions/test/tiddlers/tests/benchmarks/test-orphans-benchmark.js
+++ b/editions/test/tiddlers/tests/benchmarks/test-orphans-benchmark.js
@@ -3,211 +3,31 @@ title: test-orphans-benchmark.js
 type: application/javascript
 tags: [[$:/tags/test-spec]]
 
-Performance benchmark comparing old vs new getOrphanTitles implementations.
-Generates 10,000 synthetic tiddlers with realistic link distributions.
+Performance benchmark for getOrphanTitles optimization.
+Delegates to orphans-benchmark-core.js for the actual benchmark logic.
 
 \*/
 "use strict";
 
-var now = (typeof performance !== "undefined" && typeof performance.now === "function")
-	? performance.now.bind(performance)
-	: function() {
-		var hr = process.hrtime();
-		return hr[0] * 1000 + hr[1] / 1e6;
-	};
-
 // only run for v5.5.0 and v5.5.0-prerelease
-// TODO: Adjust the version check! Currently for the draft it is v5.4.0-pre.. 
+// TODO: Adjust the version check! Currently for the draft it is v5.4.0-pre..
 
 if($tw.version.indexOf("5.4.0") === 0) {
+
+	var benchmark = require("orphans-benchmark-core.js");
+
 	describe("Orphan tiddler performance benchmarks", function() {
 
-		var TIDDLER_COUNT = 10000;
-		var LINK_PERCENTAGE = 0.10;       // 10% of tiddlers link to other tiddlers
-		var NO_LINK_PERCENTAGE = 0.20;    // 20% of tiddlers have no links at all
-		var MISSING_LINK_PERCENTAGE = 0.10; // 10% of link targets are non-existent tiddlers
-		var LINKS_PER_TIDDLER_MIN = 1;
-		var LINKS_PER_TIDDLER_MAX = 5;
-		var WARMUP_RUNS = 2;
-		var BENCHMARK_RUNS = 5;
-		// Run multiple iterations per timed sample to overcome low-resolution browser timers
-		var ITERATIONS_PER_SAMPLE = 10;
+		var results = benchmark.run($tw);
 
-		// Seeded PRNG for reproducible benchmarks
-		function mulberry32(seed) {
-			return function() {
-				seed |= 0; seed = seed + 0x6D2B79F5 | 0;
-				var t = Math.imul(seed ^ seed >>> 15, 1 | seed);
-				t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
-				return ((t ^ t >>> 14) >>> 0) / 4294967296;
-			};
-		}
-
-		var wiki, allTitles, missingTitles;
-
-		// Old implementations for comparison
-		function getOrphanTitlesOld() {
-			var self = wiki,
-				orphans = wiki.getTiddlers();
-			wiki.forEachTiddler(function(title,tiddler) {
-				var links = self.getTiddlerLinks(title);
-				$tw.utils.each(links,function(link) {
-					var p = orphans.indexOf(link);
-					if(p !== -1) {
-						orphans.splice(p,1);
-					}
-				});
-			});
-			return orphans;
-		}
-
-		// New optimized implementation
-		function getOrphanTitlesNew() {
-			var self = wiki,
-				linkedTitles = Object.create(null);
-			wiki.forEachTiddler(function(title,tiddler) {
-				var links = self.getTiddlerLinks(title);
-				$tw.utils.each(links,function(link) {
-					linkedTitles[link] = true;
-				});
-			});
-			var orphans = [];
-			wiki.forEachTiddler(function(title,tiddler) {
-				if(!linkedTitles[title]) {
-					orphans.push(title);
-				}
-			});
-			return orphans;
-		}
-
-		function buildWiki() {
-			var random = mulberry32(42);
-			wiki = new $tw.Wiki({enableIndexers: []});
-			wiki.addIndexersToWiki();
-			allTitles = [];
-			missingTitles = [];
-			// Generate tiddler titles
-			var t;
-			for(t = 0; t < TIDDLER_COUNT; t++) {
-				allTitles.push("Tiddler" + t);
-			}
-			// Generate missing tiddler titles (targets that won't have actual tiddlers)
-			var missingCount = Math.floor(TIDDLER_COUNT * MISSING_LINK_PERCENTAGE);
-			for(t = 0; t < missingCount; t++) {
-				missingTitles.push("MissingTiddler" + t);
-			}
-			// All possible link targets: real tiddlers + missing tiddlers
-			var allTargets = allTitles.concat(missingTitles);
-			// Determine which tiddlers get no links (20%)
-			var noLinkCount = Math.floor(TIDDLER_COUNT * NO_LINK_PERCENTAGE);
-			// Determine which tiddlers link to others (10% of the total)
-			var linkingCount = Math.floor(TIDDLER_COUNT * LINK_PERCENTAGE);
-			// Shuffle indices to randomly assign roles
-			var indices = [];
-			for(t = 0; t < TIDDLER_COUNT; t++) {
-				indices.push(t);
-			}
-			// Fisher-Yates shuffle with seeded PRNG
-			for(t = indices.length - 1; t > 0; t--) {
-				var j = Math.floor(random() * (t + 1));
-				var temp = indices[t];
-				indices[t] = indices[j];
-				indices[j] = temp;
-			}
-			var noLinkSet = Object.create(null);
-			for(t = 0; t < noLinkCount; t++) {
-				noLinkSet[indices[t]] = true;
-			}
-			var linkingSet = Object.create(null);
-			for(t = noLinkCount; t < noLinkCount + linkingCount; t++) {
-				linkingSet[indices[t]] = true;
-			}
-			// Create tiddlers
-			for(t = 0; t < TIDDLER_COUNT; t++) {
-				var text;
-				if(noLinkSet[t]) {
-					// No links - just plain text
-					text = "This is tiddler " + t + " with no links.";
-				} else if(linkingSet[t]) {
-					// This tiddler links to random targets
-					var numLinks = LINKS_PER_TIDDLER_MIN + Math.floor(random() * (LINKS_PER_TIDDLER_MAX - LINKS_PER_TIDDLER_MIN + 1));
-					var links = [];
-					for(var l = 0; l < numLinks; l++) {
-						var targetIdx = Math.floor(random() * allTargets.length);
-						links.push("[[" + allTargets[targetIdx] + "]]");
-					}
-					text = "Tiddler " + t + " links to " + links.join(" and ");
-				} else {
-					// Remaining 70% - plain text, no links
-					text = "Content of tiddler " + t + ".";
-				}
-				wiki.addTiddler({
-					title: allTitles[t],
-					text: text
-				});
-			}
-		}
-
-		function benchmarkFn(fn, label) {
-			// Warmup
-			var r, i;
-			for(r = 0; r < WARMUP_RUNS; r++) {
-				fn();
-			}
-			// Timed runs: batch ITERATIONS_PER_SAMPLE calls per sample
-			// to overcome low-resolution browser timers
-			var times = [];
-			var result;
-			for(r = 0; r < BENCHMARK_RUNS; r++) {
-				var start = now();
-				for(i = 0; i < ITERATIONS_PER_SAMPLE; i++) {
-					result = fn();
-				}
-				var end = now();
-				times.push((end - start) / ITERATIONS_PER_SAMPLE);
-			}
-			times.sort(function(a,b) { return a - b; });
-			var median = times[Math.floor(times.length / 2)];
-			var avg = times.reduce(function(s,v) { return s + v; }, 0) / times.length;
-			var min = times[0];
-			var max = times[times.length - 1];
-			console.log("  " + label + ": median=" + median.toFixed(2) + "ms, avg=" + avg.toFixed(2) + "ms, min=" + min.toFixed(2) + "ms, max=" + max.toFixed(2) + "ms");
-			return { result: result, median: median, avg: avg, min: min, max: max };
-		}
-
-		// Build wiki at describe scope (beforeAll is not available in TW's in-browser Jasmine)
-		console.log("\nBuilding wiki with " + TIDDLER_COUNT + " tiddlers...");
-		var buildStart = now();
-		buildWiki();
-		var buildElapsed = now() - buildStart;
-		console.log("Wiki built in " + buildElapsed.toFixed(0) + "ms");
-		console.log("  " + TIDDLER_COUNT + " tiddlers, " +
-			Math.floor(TIDDLER_COUNT * LINK_PERCENTAGE) + " linking, " +
-			Math.floor(TIDDLER_COUNT * NO_LINK_PERCENTAGE) + " with no links, " +
-			missingTitles.length + " missing targets");
-
-		describe("getOrphanTitles", function() {
-			var oldResult, newResult;
-
-			it("correctness: new implementation should return the same results as old", function() {
-				oldResult = getOrphanTitlesOld();
-				newResult = getOrphanTitlesNew();
-				// Sort both for comparison since order may differ
-				var oldSorted = oldResult.slice().sort();
-				var newSorted = newResult.slice().sort();
-				expect(newSorted).toEqual(oldSorted);
-				console.log("  getOrphanTitles: " + oldResult.length + " orphans found out of " + TIDDLER_COUNT + " tiddlers");
-			});
-
-			it("performance: new implementation should be faster than old", function() {
-				console.log("\n  getOrphanTitles benchmark (" + BENCHMARK_RUNS + " runs, " + WARMUP_RUNS + " warmup):");
-				var oldBench = benchmarkFn(getOrphanTitlesOld, "OLD (indexOf + splice)");
-				var newBench = benchmarkFn(getOrphanTitlesNew, "NEW (hash lookup)      ");
-				var speedup = oldBench.median / newBench.median;
-				console.log("  Speedup: " + speedup.toFixed(2) + "x faster");
-				expect(newBench.median).toBeLessThan(oldBench.median);
-			});
+		it("correctness: new implementation should return the same results as old", function() {
+			expect(results.correct).toBe(true);
+			console.log("  getOrphanTitles: " + results.orphanCount + " orphans found out of " + results.tiddlerCount + " tiddlers");
 		});
 
+		it("performance: new implementation should be faster than old", function() {
+			expect(results.newMedian).toBeLessThan(results.oldMedian);
+			console.log("  Speedup: " + results.speedup.toFixed(2) + "x faster");
+		});
 	});
 }

--- a/editions/test/tiddlers/tests/benchmarks/test-orphans-benchmark.js
+++ b/editions/test/tiddlers/tests/benchmarks/test-orphans-benchmark.js
@@ -1,0 +1,208 @@
+/*\
+title: test-orphans-benchmark.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Performance benchmark comparing old vs new getOrphanTitles implementations.
+Generates 10,000 synthetic tiddlers with realistic link distributions.
+
+\*/
+"use strict";
+
+var now = (typeof performance !== "undefined" && typeof performance.now === "function")
+	? performance.now.bind(performance)
+	: function() {
+		var hr = process.hrtime();
+		return hr[0] * 1000 + hr[1] / 1e6;
+	};
+
+describe("Orphan and Missing tiddler performance benchmarks", function() {
+
+	var TIDDLER_COUNT = 10000;
+	var LINK_PERCENTAGE = 0.10;       // 10% of tiddlers link to other tiddlers
+	var NO_LINK_PERCENTAGE = 0.20;    // 20% of tiddlers have no links at all
+	var MISSING_LINK_PERCENTAGE = 0.10; // 10% of link targets are non-existent tiddlers
+	var LINKS_PER_TIDDLER_MIN = 1;
+	var LINKS_PER_TIDDLER_MAX = 5;
+	var WARMUP_RUNS = 2;
+	var BENCHMARK_RUNS = 5;
+	// Run multiple iterations per timed sample to overcome low-resolution browser timers
+	var ITERATIONS_PER_SAMPLE = 10;
+
+	// Seeded PRNG for reproducible benchmarks
+	function mulberry32(seed) {
+		return function() {
+			seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+			var t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+			t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+			return ((t ^ t >>> 14) >>> 0) / 4294967296;
+		};
+	}
+
+	var wiki, allTitles, missingTitles;
+
+	// Old implementations for comparison
+	function getOrphanTitlesOld() {
+		var self = wiki,
+			orphans = wiki.getTiddlers();
+		wiki.forEachTiddler(function(title,tiddler) {
+			var links = self.getTiddlerLinks(title);
+			$tw.utils.each(links,function(link) {
+				var p = orphans.indexOf(link);
+				if(p !== -1) {
+					orphans.splice(p,1);
+				}
+			});
+		});
+		return orphans;
+	}
+
+	// New optimized implementation
+	function getOrphanTitlesNew() {
+		var self = wiki,
+			linkedTitles = Object.create(null);
+		wiki.forEachTiddler(function(title,tiddler) {
+			var links = self.getTiddlerLinks(title);
+			$tw.utils.each(links,function(link) {
+				linkedTitles[link] = true;
+			});
+		});
+		var orphans = [];
+		wiki.forEachTiddler(function(title,tiddler) {
+			if(!linkedTitles[title]) {
+				orphans.push(title);
+			}
+		});
+		return orphans;
+	}
+
+	function buildWiki() {
+		var random = mulberry32(42);
+		wiki = new $tw.Wiki({enableIndexers: []});
+		wiki.addIndexersToWiki();
+		allTitles = [];
+		missingTitles = [];
+		// Generate tiddler titles
+		var t;
+		for(t = 0; t < TIDDLER_COUNT; t++) {
+			allTitles.push("Tiddler" + t);
+		}
+		// Generate missing tiddler titles (targets that won't have actual tiddlers)
+		var missingCount = Math.floor(TIDDLER_COUNT * MISSING_LINK_PERCENTAGE);
+		for(t = 0; t < missingCount; t++) {
+			missingTitles.push("MissingTiddler" + t);
+		}
+		// All possible link targets: real tiddlers + missing tiddlers
+		var allTargets = allTitles.concat(missingTitles);
+		// Determine which tiddlers get no links (20%)
+		var noLinkCount = Math.floor(TIDDLER_COUNT * NO_LINK_PERCENTAGE);
+		// Determine which tiddlers link to others (10% of the total)
+		var linkingCount = Math.floor(TIDDLER_COUNT * LINK_PERCENTAGE);
+		// Shuffle indices to randomly assign roles
+		var indices = [];
+		for(t = 0; t < TIDDLER_COUNT; t++) {
+			indices.push(t);
+		}
+		// Fisher-Yates shuffle with seeded PRNG
+		for(t = indices.length - 1; t > 0; t--) {
+			var j = Math.floor(random() * (t + 1));
+			var temp = indices[t];
+			indices[t] = indices[j];
+			indices[j] = temp;
+		}
+		var noLinkSet = Object.create(null);
+		for(t = 0; t < noLinkCount; t++) {
+			noLinkSet[indices[t]] = true;
+		}
+		var linkingSet = Object.create(null);
+		for(t = noLinkCount; t < noLinkCount + linkingCount; t++) {
+			linkingSet[indices[t]] = true;
+		}
+		// Create tiddlers
+		for(t = 0; t < TIDDLER_COUNT; t++) {
+			var text;
+			if(noLinkSet[t]) {
+				// No links - just plain text
+				text = "This is tiddler " + t + " with no links.";
+			} else if(linkingSet[t]) {
+				// This tiddler links to random targets
+				var numLinks = LINKS_PER_TIDDLER_MIN + Math.floor(random() * (LINKS_PER_TIDDLER_MAX - LINKS_PER_TIDDLER_MIN + 1));
+				var links = [];
+				for(var l = 0; l < numLinks; l++) {
+					var targetIdx = Math.floor(random() * allTargets.length);
+					links.push("[[" + allTargets[targetIdx] + "]]");
+				}
+				text = "Tiddler " + t + " links to " + links.join(" and ");
+			} else {
+				// Remaining 70% - plain text, no links
+				text = "Content of tiddler " + t + ".";
+			}
+			wiki.addTiddler({
+				title: allTitles[t],
+				text: text
+			});
+		}
+	}
+
+	function benchmarkFn(fn, label) {
+		// Warmup
+		var r, i;
+		for(r = 0; r < WARMUP_RUNS; r++) {
+			fn();
+		}
+		// Timed runs: batch ITERATIONS_PER_SAMPLE calls per sample
+		// to overcome low-resolution browser timers
+		var times = [];
+		var result;
+		for(r = 0; r < BENCHMARK_RUNS; r++) {
+			var start = now();
+			for(i = 0; i < ITERATIONS_PER_SAMPLE; i++) {
+				result = fn();
+			}
+			var end = now();
+			times.push((end - start) / ITERATIONS_PER_SAMPLE);
+		}
+		times.sort(function(a,b) { return a - b; });
+		var median = times[Math.floor(times.length / 2)];
+		var avg = times.reduce(function(s,v) { return s + v; }, 0) / times.length;
+		var min = times[0];
+		var max = times[times.length - 1];
+		console.log("  " + label + ": median=" + median.toFixed(2) + "ms, avg=" + avg.toFixed(2) + "ms, min=" + min.toFixed(2) + "ms, max=" + max.toFixed(2) + "ms");
+		return { result: result, median: median, avg: avg, min: min, max: max };
+	}
+
+	// Build wiki at describe scope (beforeAll is not available in TW's in-browser Jasmine)
+	console.log("\nBuilding wiki with " + TIDDLER_COUNT + " tiddlers...");
+	var buildStart = now();
+	buildWiki();
+	var buildElapsed = now() - buildStart;
+	console.log("Wiki built in " + buildElapsed.toFixed(0) + "ms");
+	console.log("  " + TIDDLER_COUNT + " tiddlers, " +
+		Math.floor(TIDDLER_COUNT * LINK_PERCENTAGE) + " linking, " +
+		Math.floor(TIDDLER_COUNT * NO_LINK_PERCENTAGE) + " with no links, " +
+		missingTitles.length + " missing targets");
+
+	describe("getOrphanTitles", function() {
+		var oldResult, newResult;
+
+		it("correctness: new implementation should return the same results as old", function() {
+			oldResult = getOrphanTitlesOld();
+			newResult = getOrphanTitlesNew();
+			// Sort both for comparison since order may differ
+			var oldSorted = oldResult.slice().sort();
+			var newSorted = newResult.slice().sort();
+			expect(newSorted).toEqual(oldSorted);
+			console.log("  getOrphanTitles: " + oldResult.length + " orphans found out of " + TIDDLER_COUNT + " tiddlers");
+		});
+
+		it("performance: new implementation should be faster than old", function() {
+			console.log("\n  getOrphanTitles benchmark (" + BENCHMARK_RUNS + " runs, " + WARMUP_RUNS + " warmup):");
+			var oldBench = benchmarkFn(getOrphanTitlesOld, "OLD (indexOf + splice)");
+			var newBench = benchmarkFn(getOrphanTitlesNew, "NEW (hash lookup)      ");
+			var speedup = oldBench.median / newBench.median;
+			console.log("  Speedup: " + speedup.toFixed(2) + "x faster");
+			expect(newBench.median).toBeLessThan(oldBench.median);
+		});
+	});
+
+});

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9730-orphan-titles-performance.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9730-orphan-titles-performance.tid
@@ -1,0 +1,12 @@
+change-category: internal
+change-type: performance
+created: 20260711184143000
+description: getOrphanTitles() collects orphans several times faster
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9730
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9730
+type: text/vnd.tiddlywiki
+
+* `getOrphanTitles()` marks linked titles in a hashmap and collects the orphans in a second pass, instead of splicing an array for every link, making the `[is[orphan]]` filter several times faster on large wikis


### PR DESCRIPTION
This PR consists of several elements. 

- A suggested change in the core code. wiki.js
- A MD file with the concept of the code change
- A TW test-suite test test-***-benchmark.js
  - runs with `node tiddlywiki.js ./editions/test --test` ... and all other tests (slow)
- A node test runner, which only runs 1 test run-benchmark.js
  - This is needed, because running all tests on Windows needs about 2 minutes with my PC
  - from TiddlyWiki5 dir run: `node .\editions\test\tiddlers\tests\benchmarks\run-benchmark.js`
- ***-benchmark-core.js .. contains the test logic and the code to create a wiki with specific test tiddlers. 

The test output is

```
\TiddlyWiki5> node .\editions\test\tiddlers\tests\benchmarks\run-benchmark.js
TiddlyWiki 5.4.0-prerelease — Standalone Benchmark Runner


Building wiki with 10000 tiddlers...
Wiki built in 49ms
  10000 tiddlers, 1000 linking, 2000 with no links, 1000 missing targets

  getOrphanTitles benchmark (5 runs, 2 warmup, 10 iter/sample):
  OLD (indexOf + splice): median=160.85ms, avg=161.38ms, min=160.28ms, max=163.95ms
  NEW (hash lookup)      : median=10.06ms, avg=10.00ms, min=9.84ms, max=10.14ms
  Speedup: 16.00x faster

Correctness: PASS
```