### PR TITLE
Add a search field to the icon gallery

### DIFF
--- a/editions/tw5.com/tiddlers/images/Icon Gallery.tid
+++ b/editions/tw5.com/tiddlers/images/Icon Gallery.tid
@@ -14,6 +14,6 @@ type: text/vnd.tiddlywiki
 
 
 <div class="tc-image-chooser">
-<$macrocall $name="image-picker-list" filter="[all[shadows+tiddlers]tag[$:/tags/Image]]" actions=<<copyActions>> />
+<$macrocall $name="image-picker-list" filter="[all[shadows+tiddlers]tag[$:/tags/Image]search{!!search}]" actions=<<copyActions>> />
 </div>
 

--- a/editions/tw5.com/tiddlers/images/Icon Gallery.tid
+++ b/editions/tw5.com/tiddlers/images/Icon Gallery.tid
@@ -8,6 +8,7 @@ type: text/vnd.tiddlywiki
 
 <<.tip "Click an icon to copy the title to the clipboard">>
 
+<$tiddler tiddler=`$:/temp/$(thisTiddler)$/search`>
 @@display:flex;gap:1ch;
 <$edit type="search" field="search" class="tc-search"/><$button set="!!search" class="tc-btn-invisible">{{$:/core/images/close-button}}</$button>
 @@
@@ -17,3 +18,4 @@ type: text/vnd.tiddlywiki
 <$macrocall $name="image-picker-list" filter="[all[shadows+tiddlers]tag[$:/tags/Image]search{!!search}]" actions=<<copyActions>> />
 </div>
 
+</$tiddler>

--- a/editions/tw5.com/tiddlers/images/Icon Gallery.tid
+++ b/editions/tw5.com/tiddlers/images/Icon Gallery.tid
@@ -1,5 +1,5 @@
 created: 20211013132515594
-modified: 20211018102307833
+modified: 20260327102420168
 tags: Learning [[Core Icons]]
 title: Icon Gallery
 type: text/vnd.tiddlywiki
@@ -7,6 +7,11 @@ type: text/vnd.tiddlywiki
 \define copyActions() <$action-sendmessage $message="tm-copy-to-clipboard" $param=<<imageTitle>>/>
 
 <<.tip "Click an icon to copy the title to the clipboard">>
+
+@@display:flex;gap:1ch;
+<$edit type="search" field="search" class="tc-search"/><$button set="!!search" class="tc-btn-invisible">{{$:/core/images/close-button}}</$button>
+@@
+
 
 <div class="tc-image-chooser">
 <$macrocall $name="image-picker-list" filter="[all[shadows+tiddlers]tag[$:/tags/Image]]" actions=<<copyActions>> />

--- a/editions/tw5.com/tiddlers/images/Icon Gallery.tid
+++ b/editions/tw5.com/tiddlers/images/Icon Gallery.tid
@@ -5,17 +5,16 @@ title: Icon Gallery
 type: text/vnd.tiddlywiki
 
 \define copyActions() <$action-sendmessage $message="tm-copy-to-clipboard" $param=<<imageTitle>>/>
+\define temp.tiddler() $:/temp/$(thisTiddler)$/search
+\function search.query() [<temp.tiddler>get[search]]
 
 <<.tip "Click an icon to copy the title to the clipboard">>
 
-<$tiddler tiddler=`$:/temp/$(thisTiddler)$/search`>
 @@display:flex;gap:1ch;
-<$edit type="search" field="search" class="tc-search"/><$button set="!!search" class="tc-btn-invisible">{{$:/core/images/close-button}}</$button>
+<$edit tiddler=<<temp.tiddler>> type="search" field="search" class="tc-search"/><$button setTitle=<<temp.tiddler>> setField="search" class="tc-btn-invisible">{{$:/core/images/close-button}}</$button>
 @@
 
 
 <div class="tc-image-chooser">
-<$macrocall $name="image-picker-list" filter="[all[shadows+tiddlers]tag[$:/tags/Image]search{!!search}]" actions=<<copyActions>> />
+<$macrocall $name="image-picker-list" filter="[all[shadows+tiddlers]tag[$:/tags/Image]search<search.query>]" actions=<<copyActions>> />
 </div>
-
-</$tiddler>


### PR DESCRIPTION
This PR add a search field to the icon gallery demo tiddler to help users find an icon quickly 

<img width="1885" height="1040" alt="image" src="https://github.com/user-attachments/assets/05e5027f-7a47-4571-9734-9d1a48a40d75" />