### PR TITLE
I didn't capitalize one of the instances of my name

### DIFF
--- a/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9703.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9703.tid
@@ -2,7 +2,7 @@ change-category: hackability
 change-type: enhancement
 created: 20260228212206750
 description: Allows modular relinking behavior for plugin support
-github-contributors: flibbles
+github-contributors: Flibbles
 github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9703
 modified: 20260228212206750
 release: 5.4.0


### PR DESCRIPTION
Seems I've stumbled on a flaw in TiddlyWiki's otherwise-perfect new automated workflow. 

This is a fix for #9820