### PR TITLE
Fix Typo in Link in Multi-Valued Variables

### DIFF
--- a/editions/tw5.com/tiddlers/variables/Multi-Valued Variables.tid
+++ b/editions/tw5.com/tiddlers/variables/Multi-Valued Variables.tid
@@ -1,13 +1,13 @@
-title: Multi-Valued Variables
 created: 20250307212252946
 modified: 20250307212252946
 tags: Concepts Variables
+title: Multi-Valued Variables
 
 <<.from-version "5.4.0">> In ordinary usage, [[variables|Variables]] contain a single snippet of text. With the introduction of multi-valued variables. it is now possible to store a list of multiple values in a single variable. When accessed in the usual way, only the first value is returned, but using round brackets instead of angle brackets around the variable name allows access to the complete list of the values. This makes multi-valued variables largely invisible unless you specifically need to use them.
 
 ! Setting Multi-Valued Variables
 
-Generally, all the methods for setting variables implicitly set multi-valued variables, with the exception of the [[Set Widget|Set Widget]].
+Generally, all the methods for setting variables implicitly set multi-valued variables, with the exception of the [[Set Widget|SetWidget]].
 
 !! LetWidget
 


### PR DESCRIPTION
Fix Typo in Link in Multi-Valued Variables. See: https://talk.tiddlywiki.org/t/your-help-is-needed-to-test-v5-4-0/14945/78 

---
<small>Submitted using https://edit.tiddlywiki.com/.</small>