### PR TITLE
Add a new test that fails, because a missing typeof test in fakedom.js

### DIFF
--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -82,6 +82,11 @@ var TW_Style = function(el) {
 	// Return a Proxy to handle direct access to individual style properties
 	return new Proxy(styleObject, {
 		get: function(target, property) {
+			// Real CSSStyleDeclaration returns undefined for non-string keys.
+			// Guards against crashes when consumers probe Symbol.toPrimitive etc.
+			if(typeof property !== "string") {
+				return undefined;
+			}
 			// If the property exists on styleObject, return it (get, set, setProperty methods)
 			if(property in target) {
 				return target[property];
@@ -90,6 +95,10 @@ var TW_Style = function(el) {
 			return el._style[$tw.utils.convertStyleNameToPropertyName(property)] || "";
 		},
 		set: function(target, property, value) {
+			// Mirror the get trap: ignore non-string keys instead of crashing.
+			if(typeof property !== "string") {
+				return true;
+			}
 			// Set the property in _style
 			el._style[$tw.utils.convertStyleNameToPropertyName(property)] = value;
 			return true;

--- a/editions/test/tiddlers/tests/test-fakedom.js
+++ b/editions/test/tiddlers/tests/test-fakedom.js
@@ -18,4 +18,15 @@ describe("fakedom tests", function() {
 		expect($tw.fakeDocument.createTextNode("text").nodeType).toBe(3);
 		expect($tw.fakeDocument.createTextNode("text").TEXT_NODE).toBe(3);
 	});
+
+	// Real CSSStyleDeclaration returns undefined for Symbol property keys.
+	// Without a guard, the TW_Style Proxy throws on Symbol access. This bites
+	// in practice when Jasmine pretty-prints fakedom elements on failure.
+	// See related TODO in test-select-widget.js
+	it("returns undefined for Symbol property access on element.style", function() {
+		var el = $tw.fakeDocument.createElement("div");
+		expect(function() { return el.style[Symbol.toPrimitive]; }).not.toThrow();
+		expect(el.style[Symbol.toPrimitive]).toBeUndefined();
+		expect(function() { el.style[Symbol.iterator] = "x"; }).not.toThrow();
+	});
 });


### PR DESCRIPTION
The first CI/CD run for this PR is intended to fail. 
It should throw, because fakedom.js is missing a typeof string check. 

Related spec: https://drafts.csswg.org/cssom/#the-cssstyledeclaration-interface