### PR TITLE
Exclude Claude from npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@
 tmp/
 output/
 node_modules/
+.claude/


### PR DESCRIPTION
The npm package for v5.4.0 erroneously includes a `.claude` directory. Since there is no sensitive data included I think we can wait until v5.4.1 to fix this.