### PR TITLE
Fix 9865 filter field parentheses

### DIFF
--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -23,8 +23,9 @@ Returns the new start position, after the parsed operation
 */
 function parseFilterOperation(operators,filterString,p) {
 	var nextBracketPos, operator;
-	// The opening brackets that can begin a filter operand
+	// The brackets that can begin a filter operand, as a set for single chars and a regexp for scanning
 	var operandBrackets = "[{</(";
+	var operandBracketRegExp = new RegExp("[" + operandBrackets + "]","g");
 	var isOperandBracket = function(chr) {
 		return chr !== "" && operandBrackets.indexOf(chr) !== -1;
 	};
@@ -44,20 +45,22 @@ function parseFilterOperation(operators,filterString,p) {
 		// See test-filter-field-parens.js
 		nextBracketPos = -1;
 		var scanPos = p;
-		while(nextBracketPos === -1 && scanPos < filterString.length) {
-			var chr = filterString.charAt(scanPos);
-			if(!isOperandBracket(chr)) {
-				// Still inside the operator name and its suffix
-				scanPos++;
-				continue;
+		while(nextBracketPos === -1) {
+			operandBracketRegExp.lastIndex = scanPos;
+			var bracketMatch = operandBracketRegExp.exec(filterString);
+			if(!bracketMatch) {
+				break;
 			}
-			// Skip a "(...)" group that belongs to a suffix field name; otherwise this bracket starts the operand
-			var closeParenPos = chr === "(" ? filterString.indexOf(")",scanPos) : -1;
-			if(closeParenPos !== -1 && filterString.substring(p,scanPos).indexOf(":") !== -1 && isOperandBracket(filterString.charAt(closeParenPos + 1))) {
-				scanPos = closeParenPos + 1;
-			} else {
-				nextBracketPos = scanPos;
+			// A "(...)" group followed by another operand bracket belongs to a suffix field name; skip it
+			if(bracketMatch[0] === "(" && filterString.substring(p,bracketMatch.index).indexOf(":") !== -1) {
+				var closeParenPos = filterString.indexOf(")",bracketMatch.index);
+				if(closeParenPos !== -1 && isOperandBracket(filterString.charAt(closeParenPos + 1))) {
+					scanPos = closeParenPos + 1;
+					continue;
+				}
 			}
+			// Otherwise this bracket starts the operand
+			nextBracketPos = bracketMatch.index;
 		}
 		if(nextBracketPos === -1) {
 			throw "Missing [ in filter expression";

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -25,7 +25,7 @@ function parseFilterOperation(operators,filterString,p) {
 	var nextBracketPos, operator;
 	// The brackets that can begin a filter operand, as a set for single chars and a regexp for scanning
 	var operandBrackets = "[{</(";
-	var operandBracketRegExp = new RegExp("[" + operandBrackets + "]","g");
+	var operandBracketRegExp = new RegExp("[" + $tw.utils.escapeRegExp(operandBrackets) + "]","g");
 	var isOperandBracket = function(chr) {
 		return chr !== "" && operandBrackets.indexOf(chr) !== -1;
 	};

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -40,9 +40,8 @@ function parseFilterOperation(operators,filterString,p) {
 		if(filterString.charAt(p) === "!") {
 			operator.prefix = filterString.charAt(p++);
 		}
-		// Find the operator name, keeping a "(...)" group as part of a suffix field name
-		// e.g. "_cd-work(s)" when a ":" precedes it and the ")" is followed by another operand bracket.
-		// See test-filter-field-parens.js
+		// Find the operator name. In "[regexp:_cd-work(s)[...]]" the "(s)" is part of the suffix
+		// (a ":" precedes it, an operand bracket follows); otherwise it is an operand. See test-filter-field-parens.js
 		nextBracketPos = -1;
 		var scanPos = p;
 		while(nextBracketPos === -1) {
@@ -51,10 +50,11 @@ function parseFilterOperation(operators,filterString,p) {
 			if(!bracketMatch) {
 				break;
 			}
-			// A "(...)" group followed by another operand bracket belongs to a suffix field name; skip it
 			if(bracketMatch[0] === "(" && filterString.substring(p,bracketMatch.index).indexOf(":") !== -1) {
+				// This "(" follows a suffix, so look ahead: if another operand bracket comes after
+				// its ")", the operand is still to come and this "(...)" is suffix text to skip
 				var closeParenPos = filterString.indexOf(")",bracketMatch.index);
-				if(closeParenPos !== -1 && isOperandBracket(filterString.charAt(closeParenPos + 1))) {
+				if(closeParenPos !== -1 && filterString.substring(closeParenPos + 1).search(operandBracketRegExp) !== -1) {
 					scanPos = closeParenPos + 1;
 					continue;
 				}

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -23,6 +23,11 @@ Returns the new start position, after the parsed operation
 */
 function parseFilterOperation(operators,filterString,p) {
 	var nextBracketPos, operator;
+	// The opening brackets that can begin a filter operand
+	var operandBrackets = "[{</(";
+	var isOperandBracket = function(chr) {
+		return chr !== "" && operandBrackets.indexOf(chr) !== -1;
+	};
 	// Skip the starting square bracket
 	if(filterString.charAt(p++) !== "[") {
 		throw "Missing [ in filter expression";
@@ -34,12 +39,29 @@ function parseFilterOperation(operators,filterString,p) {
 		if(filterString.charAt(p) === "!") {
 			operator.prefix = filterString.charAt(p++);
 		}
-		// Get the operator name
-		nextBracketPos = filterString.substring(p).search(/[\[\{<\/\(]/);
+		// Find the operator name, keeping a "(...)" group as part of a suffix field name
+		// e.g. "_cd-work(s)" when a ":" precedes it and the ")" is followed by another operand bracket.
+		// See test-filter-field-parens.js
+		nextBracketPos = -1;
+		var scanPos = p;
+		while(nextBracketPos === -1 && scanPos < filterString.length) {
+			var chr = filterString.charAt(scanPos);
+			if(!isOperandBracket(chr)) {
+				// Still inside the operator name and its suffix
+				scanPos++;
+				continue;
+			}
+			// Skip a "(...)" group that belongs to a suffix field name; otherwise this bracket starts the operand
+			var closeParenPos = chr === "(" ? filterString.indexOf(")",scanPos) : -1;
+			if(closeParenPos !== -1 && filterString.substring(p,scanPos).indexOf(":") !== -1 && isOperandBracket(filterString.charAt(closeParenPos + 1))) {
+				scanPos = closeParenPos + 1;
+			} else {
+				nextBracketPos = scanPos;
+			}
+		}
 		if(nextBracketPos === -1) {
 			throw "Missing [ in filter expression";
 		}
-		nextBracketPos += p;
 		var bracket = filterString.charAt(nextBracketPos);
 		operator.operator = filterString.substring(p,nextBracketPos);
 		// Any suffix?
@@ -116,7 +138,7 @@ function parseFilterOperation(operators,filterString,p) {
 		// Check for multiple operands
 		while(filterString.charAt(p) === ",") {
 			p++;
-			if(/^[\[\{<\/\(]/.test(filterString.substring(p))) {
+			if(isOperandBracket(filterString.charAt(p))) {
 				nextBracketPos = p;
 				p++;
 				parseOperand(filterString.charAt(nextBracketPos));

--- a/editions/test/tiddlers/tests/test-filter-field-parens.js
+++ b/editions/test/tiddlers/tests/test-filter-field-parens.js
@@ -3,8 +3,17 @@ title: test-filter-field-parens.js
 type: application/javascript
 tags: [[$:/tags/test-spec]]
 
-Tests for field names containing parentheses used as filter operator suffixes,
-for example "[regexp:_cd-work(s)[(?i)suite]]". See issue #9865.
+Tests for field names that contain parentheses used as a filter operator suffix,
+e.g. [regexp:_cd-work(s)[(?i)suite]].
+
+Issue #9865: TiddlyWiki 5.4.0 added the round bracket operand syntax (varname)
+for multi value variables, so the parser began treating "(" as an operand start.
+Before 5.4.0 "(" was an ordinary character, so field names like _cd-work(s)
+worked as a suffix; the change broke them.
+
+Fix (parseFilterOperation in core/modules/filters.js): a "(...)" is part of a
+suffix field name when a ":" precedes it and another operand bracket follows;
+otherwise it is a round bracket operand.
 
 \*/
 
@@ -12,13 +21,16 @@ for example "[regexp:_cd-work(s)[(?i)suite]]". See issue #9865.
 
 describe("Filter operator suffixes containing parentheses (#9865)", function() {
 
+	// Parse trees below: each operator has operator (name), suffix (raw text after the
+	// first ":"), suffixes (that suffix split on ":" then ","), and operands ({text} for
+	// [x], {variable:true,text} for <x>, {multiValuedVariable:true,text} for (x)).
+
 	it("should keep a parenthesised field name as a single operator suffix", function() {
-		// A field name like "_cd-work(s)" must survive as the operator suffix, not be
-		// split apart by the round bracket operand syntax for multi value variables
+		// Core regression: "_cd-work(s)" must stay whole as the suffix. It must work with
+		// literal, MVV (x) and variable <x> operands.
 		expect($tw.wiki.parseFilter("[regexp:_cd-work(s)[(?i)suite]]")).toEqual(
 			[ { prefix : "", operators : [ { operator : "regexp", suffix : "_cd-work(s)", suffixes : [ [ "_cd-work(s)" ] ], operands: [ { text:"(?i)suite" } ] } ] } ]
 		);
-		// A parenthesised field name can still be followed by a variable or MVV operand
 		expect($tw.wiki.parseFilter("[regexp:_cd-work(s)(varname)]")).toEqual(
 			[ { prefix : "", operators : [ { operator : "regexp", suffix : "_cd-work(s)", suffixes : [ [ "_cd-work(s)" ] ], operands: [ { multiValuedVariable: true, text:"varname" } ] } ] } ]
 		);
@@ -28,8 +40,8 @@ describe("Filter operator suffixes containing parentheses (#9865)", function() {
 	});
 
 	it("should keep multiple parenthesised groups in a field name as one suffix", function() {
-		// A field name with consecutive groups like "_cd-work(s)(x)" stays whole, because
-		// each group is followed by another operand bracket
+		// Consecutive groups like "_cd-work(s)(x)" all stay in the suffix; each is followed
+		// by another operand bracket, so the operand is the final one.
 		expect($tw.wiki.parseFilter("[regexp:_cd-work(s)(x)[(?i)suite]]")).toEqual(
 			[ { prefix : "", operators : [ { operator : "regexp", suffix : "_cd-work(s)(x)", suffixes : [ [ "_cd-work(s)(x)" ] ], operands: [ { text:"(?i)suite" } ] } ] } ]
 		);
@@ -43,20 +55,16 @@ describe("Filter operator suffixes containing parentheses (#9865)", function() {
 	});
 
 	it("should still parse round bracket operands (multi value variables) as operands", function() {
+		// Must not break the feature: with no suffix, "(varname)" is a real MVV operand
+		// (here on the bare title operator), followed by sort.
 		expect($tw.wiki.parseFilter("[(varname)sort[]]")).toEqual(
 			[ { prefix : "", operators : [ { operator : "title", operands: [ { multiValuedVariable: true, text:"varname" } ] }, { operator : "sort", operands: [ { text:"" } ] } ] } ]
 		);
 	});
 
-	it("should match a parenthesised field name with a literal operand", function() {
-		var wiki = new $tw.Wiki();
-		wiki.addTiddler({title: "Alpha", "_cd-work(s)": "My Test Suite"});
-		wiki.addTiddler({title: "Beta", "_cd-work(s)": "nothing relevant"});
-		wiki.addTiddler({title: "Gamma", text: "suite"});
-		expect(wiki.filterTiddlers("[regexp:_cd-work(s)[(?i)suite]]")).toEqual(["Alpha"]);
-	});
-
 	it("should take the regexp pattern from a variable when the field name has parentheses", function() {
+		// Field name as suffix, pattern from a variable. A widget is needed to resolve the
+		// variable, so build a root widget and use its child as the anchor.
 		var wiki = new $tw.Wiki();
 		wiki.addTiddler({title: "Alpha", "_cd-work(s)": "My Test Suite"});
 		wiki.addTiddler({title: "Beta", "_cd-work(s)": "nothing relevant"});
@@ -66,9 +74,33 @@ describe("Filter operator suffixes containing parentheses (#9865)", function() {
 		rootWidget.makeChildWidgets();
 		var anchorWidget = rootWidget.children[0];
 		rootWidget.setVariable("varname", "(?i)suite");
-		// The field name "_cd-work(s)" is the suffix; the pattern comes from the variable
+		// (varname) gives its first value as the pattern; <varname> the single value.
 		expect(wiki.filterTiddlers("[regexp:_cd-work(s)(varname)]", anchorWidget)).toEqual(["Alpha"]);
 		expect(wiki.filterTiddlers("[regexp:_cd-work(s)<varname>]", anchorWidget)).toEqual(["Alpha"]);
+	});
+
+	it("should keep parentheses in multi segment suffixes such as search fields and flags", function() {
+		// search has a two segment suffix: comma separated fields in suffixes[0], flags in
+		// suffixes[1]. A paren field must survive before ":flags", before "," and mid name.
+		expect($tw.wiki.parseFilter("[search:_cd-work(s):casesensitive[term]]")).toEqual(
+			[ { prefix : "", operators : [ { operator : "search", suffix : "_cd-work(s):casesensitive", suffixes : [ [ "_cd-work(s)" ], [ "casesensitive" ] ], operands: [ { text:"term" } ] } ] } ]
+		);
+		expect($tw.wiki.parseFilter("[search:_cd-work(s),title[term]]")).toEqual(
+			[ { prefix : "", operators : [ { operator : "search", suffix : "_cd-work(s),title", suffixes : [ [ "_cd-work(s)", "title" ] ], operands: [ { text:"term" } ] } ] } ]
+		);
+		expect($tw.wiki.parseFilter("[search:work(s)done:flags[x]]")).toEqual(
+			[ { prefix : "", operators : [ { operator : "search", suffix : "work(s)done:flags", suffixes : [ [ "work(s)done" ], [ "flags" ] ], operands: [ { text:"x" } ] } ] } ]
+		);
+	});
+
+	it("should match a field with parentheses in the middle of its name, via regexp and search", function() {
+		// Hardest case end to end: parentheses mid name "work(s)done", via regexp and search.
+		var wiki = new $tw.Wiki();
+		wiki.addTiddler({title: "Alpha", "work(s)done": "My Test Suite"});
+		wiki.addTiddler({title: "Beta", "work(s)done": "nothing relevant"});
+		wiki.addTiddler({title: "Gamma", text: "Suite"});
+		expect(wiki.filterTiddlers("[regexp:work(s)done[(?i)suite]]")).toEqual(["Alpha"]);
+		expect(wiki.filterTiddlers("[search:work(s)done[suite]]")).toEqual(["Alpha"]);
 	});
 
 });

--- a/editions/test/tiddlers/tests/test-filter-field-parens.js
+++ b/editions/test/tiddlers/tests/test-filter-field-parens.js
@@ -1,0 +1,74 @@
+/*\
+title: test-filter-field-parens.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Tests for field names containing parentheses used as filter operator suffixes,
+for example "[regexp:_cd-work(s)[(?i)suite]]". See issue #9865.
+
+\*/
+
+"use strict";
+
+describe("Filter operator suffixes containing parentheses (#9865)", function() {
+
+	it("should keep a parenthesised field name as a single operator suffix", function() {
+		// A field name like "_cd-work(s)" must survive as the operator suffix, not be
+		// split apart by the round bracket operand syntax for multi value variables
+		expect($tw.wiki.parseFilter("[regexp:_cd-work(s)[(?i)suite]]")).toEqual(
+			[ { prefix : "", operators : [ { operator : "regexp", suffix : "_cd-work(s)", suffixes : [ [ "_cd-work(s)" ] ], operands: [ { text:"(?i)suite" } ] } ] } ]
+		);
+		// A parenthesised field name can still be followed by a variable or MVV operand
+		expect($tw.wiki.parseFilter("[regexp:_cd-work(s)(varname)]")).toEqual(
+			[ { prefix : "", operators : [ { operator : "regexp", suffix : "_cd-work(s)", suffixes : [ [ "_cd-work(s)" ] ], operands: [ { multiValuedVariable: true, text:"varname" } ] } ] } ]
+		);
+		expect($tw.wiki.parseFilter("[regexp:_cd-work(s)<varname>]")).toEqual(
+			[ { prefix : "", operators : [ { operator : "regexp", suffix : "_cd-work(s)", suffixes : [ [ "_cd-work(s)" ] ], operands: [ { variable: true, text:"varname" } ] } ] } ]
+		);
+	});
+
+	it("should keep multiple parenthesised groups in a field name as one suffix", function() {
+		// A field name with consecutive groups like "_cd-work(s)(x)" stays whole, because
+		// each group is followed by another operand bracket
+		expect($tw.wiki.parseFilter("[regexp:_cd-work(s)(x)[(?i)suite]]")).toEqual(
+			[ { prefix : "", operators : [ { operator : "regexp", suffix : "_cd-work(s)(x)", suffixes : [ [ "_cd-work(s)(x)" ] ], operands: [ { text:"(?i)suite" } ] } ] } ]
+		);
+		expect($tw.wiki.parseFilter("[regexp:_cd-work(s)(x)(varname)]")).toEqual(
+			[ { prefix : "", operators : [ { operator : "regexp", suffix : "_cd-work(s)(x)", suffixes : [ [ "_cd-work(s)(x)" ] ], operands: [ { multiValuedVariable: true, text:"varname" } ] } ] } ]
+		);
+		var wiki = new $tw.Wiki();
+		wiki.addTiddler({title: "Alpha", "_cd-work(s)(x)": "My Test Suite"});
+		wiki.addTiddler({title: "Beta", "_cd-work(s)(x)": "nothing relevant"});
+		expect(wiki.filterTiddlers("[regexp:_cd-work(s)(x)[(?i)suite]]")).toEqual(["Alpha"]);
+	});
+
+	it("should still parse round bracket operands (multi value variables) as operands", function() {
+		expect($tw.wiki.parseFilter("[(varname)sort[]]")).toEqual(
+			[ { prefix : "", operators : [ { operator : "title", operands: [ { multiValuedVariable: true, text:"varname" } ] }, { operator : "sort", operands: [ { text:"" } ] } ] } ]
+		);
+	});
+
+	it("should match a parenthesised field name with a literal operand", function() {
+		var wiki = new $tw.Wiki();
+		wiki.addTiddler({title: "Alpha", "_cd-work(s)": "My Test Suite"});
+		wiki.addTiddler({title: "Beta", "_cd-work(s)": "nothing relevant"});
+		wiki.addTiddler({title: "Gamma", text: "suite"});
+		expect(wiki.filterTiddlers("[regexp:_cd-work(s)[(?i)suite]]")).toEqual(["Alpha"]);
+	});
+
+	it("should take the regexp pattern from a variable when the field name has parentheses", function() {
+		var wiki = new $tw.Wiki();
+		wiki.addTiddler({title: "Alpha", "_cd-work(s)": "My Test Suite"});
+		wiki.addTiddler({title: "Beta", "_cd-work(s)": "nothing relevant"});
+		var widget = require("$:/core/modules/widgets/widget.js");
+		var rootWidget = new widget.widget({type: "widget", children: [{type: "widget", children: []}]},
+			{wiki: wiki, document: $tw.document});
+		rootWidget.makeChildWidgets();
+		var anchorWidget = rootWidget.children[0];
+		rootWidget.setVariable("varname", "(?i)suite");
+		// The field name "_cd-work(s)" is the suffix; the pattern comes from the variable
+		expect(wiki.filterTiddlers("[regexp:_cd-work(s)(varname)]", anchorWidget)).toEqual(["Alpha"]);
+		expect(wiki.filterTiddlers("[regexp:_cd-work(s)<varname>]", anchorWidget)).toEqual(["Alpha"]);
+	});
+
+});


### PR DESCRIPTION
- Fix #9865

Field names containing parentheses, such as _cd-work(s), could be used as
filter operator suffixes up to v5.3.8, for example:

    [regexp:_cd-work(s)[(?i)suite]]

In v5.4.0 the round bracket operand syntax for multi value variables
(https://github.com/TiddlyWiki/TiddlyWiki5/pull/8972) made "(" terminate the operator name, which split such field names apart and broke these filters.

See: test-filter-field-parens.js

