### PR TITLE
Blank line paragraph preservation

### DIFF
--- a/core/modules/parsers/wikiparser/wikiparser.js
+++ b/core/modules/parsers/wikiparser/wikiparser.js
@@ -47,6 +47,9 @@ var WikiParser = function(type,text,options) {
 	this.configTrimWhiteSpace = options.configTrimWhiteSpace !== undefined ? options.configTrimWhiteSpace : false;
 	// Parser mode
 	this.parseAsInline = options.parseAsInline;
+	// Preserve extra blank lines as empty paragraph blocks when explicitly requested or configured
+	this.preserveBlankLines = options.preserveBlankLines === true ||
+		(options.preserveBlankLines !== false && this.wiki && this.wiki.getTiddlerText("$:/config/Parser/PreserveBlankLines","no") === "yes");
 	// Set current parse position
 	this.pos = 0;
 	// Start with empty output
@@ -260,6 +263,70 @@ WikiParser.prototype.parseBlock = function(terminatorRegExpString) {
 };
 
 /*
+Return parse tree nodes for extra blank lines in a whitespace run.
+The first blank line separates blocks; each additional blank line represents an
+empty paragraph block. At the start of a block list, two leading newlines are
+needed to represent the first empty paragraph.
+*/
+WikiParser.prototype.makeBlankLineBlocks = function(start,whitespace,options) {
+	options = options || {};
+	var newlineMatches = whitespace.match(/\r?\n/g),
+		newlineCount = newlineMatches ? newlineMatches.length : 0,
+		blankLineCount = options.leading ? Math.max(0,newlineCount - 1) : Math.max(0,newlineCount - 2),
+		blankLineBlocks = [];
+	for(var index = 0; index < blankLineCount; index++) {
+		blankLineBlocks.push({
+			type: "element",
+			tag: "p",
+			attributes: {
+				class: {name: "class", type: "string", value: "tc-blankline"}
+			},
+			orderedAttributes: [
+				{name: "class", type: "string", value: "tc-blankline"}
+			],
+			children: [],
+			start: start,
+			end: start,
+			rule: "blankline",
+			isLeadingBlankLine: !!options.leading && index === 0
+		});
+	}
+	return blankLineBlocks;
+};
+
+/*
+Consume whitespace between blocks and return parse tree nodes for extra blank lines.
+*/
+WikiParser.prototype.parseBlankLineBlocks = function(options) {
+	var whitespaceRegExp = /(\s+)/mg;
+	whitespaceRegExp.lastIndex = this.pos;
+	var whitespaceMatch = whitespaceRegExp.exec(this.source);
+	if(whitespaceMatch && whitespaceMatch.index === this.pos) {
+		var start = this.pos,
+			whitespace = whitespaceMatch[0];
+		this.pos = whitespaceRegExp.lastIndex;
+		return this.makeBlankLineBlocks(start,whitespace,options);
+	}
+	return [];
+};
+
+/*
+Some block rules consume trailing whitespace internally. Recover extra blank lines
+from the gap between the parse tree node end and the parser position.
+*/
+WikiParser.prototype.getTrailingBlankLineBlocks = function(blocks) {
+	if(blocks.length === 0) {
+		return [];
+	}
+	var lastBlock = blocks[blocks.length - 1];
+	if(lastBlock.end === undefined || lastBlock.end >= this.pos) {
+		return [];
+	}
+	var whitespace = this.source.substring(lastBlock.end,this.pos);
+	return /^\s+$/.test(whitespace) ? this.makeBlankLineBlocks(lastBlock.end,whitespace) : [];
+};
+
+/*
 Parse a series of blocks of text until a terminating regexp is encountered or the end of the text
 	terminatorRegExpString: terminating regular expression
 */
@@ -275,9 +342,25 @@ WikiParser.prototype.parseBlocks = function(terminatorRegExpString) {
 Parse a block from the current position to the end of the text
 */
 WikiParser.prototype.parseBlocksUnterminated = function() {
-	var tree = [];
+	if(!this.preserveBlankLines) {
+		var defaultTree = [];
+		while(this.pos < this.sourceLength) {
+			defaultTree.push.apply(defaultTree,this.parseBlock());
+		}
+		return defaultTree;
+	}
+	var tree = [],
+		isLeading = true;
 	while(this.pos < this.sourceLength) {
-		tree.push.apply(tree,this.parseBlock());
+		tree.push.apply(tree,this.parseBlankLineBlocks({leading: isLeading}));
+		if(this.pos >= this.sourceLength) {
+			break;
+		}
+		var blocks = this.parseBlock();
+		tree.push.apply(tree,blocks);
+		tree.push.apply(tree,this.getTrailingBlankLineBlocks(blocks));
+		tree.push.apply(tree,this.parseBlankLineBlocks());
+		isLeading = false;
 	}
 	return tree;
 };
@@ -299,7 +382,11 @@ WikiParser.prototype.parseBlocksTerminatedExtended = function(terminatorRegExpSt
 			tree: []
 		};
 	// Skip any whitespace
-	this.skipWhitespace();
+	if(this.preserveBlankLines) {
+		result.tree.push.apply(result.tree,this.parseBlankLineBlocks({leading: true}));
+	} else {
+		this.skipWhitespace();
+	}
 	//  Check if we've got the end marker
 	terminatorRegExp.lastIndex = this.pos;
 	var match = terminatorRegExp.exec(this.source);
@@ -307,8 +394,13 @@ WikiParser.prototype.parseBlocksTerminatedExtended = function(terminatorRegExpSt
 	while(this.pos < this.sourceLength && !(match && match.index === this.pos)) {
 		var blocks = this.parseBlock(terminatorRegExpString);
 		result.tree.push.apply(result.tree,blocks);
+		result.tree.push.apply(result.tree,this.getTrailingBlankLineBlocks(blocks));
 		// Skip any whitespace
-		this.skipWhitespace();
+		if(this.preserveBlankLines) {
+			result.tree.push.apply(result.tree,this.parseBlankLineBlocks());
+		} else {
+			this.skipWhitespace();
+		}
 		//  Check if we've got the end marker
 		terminatorRegExp.lastIndex = this.pos;
 		match = terminatorRegExp.exec(this.source);

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1062,7 +1062,8 @@ exports.parseText = function(type,text,options) {
 		parseAsInline: options.parseAsInline,
 		wiki: this,
 		_canonical_uri: options._canonical_uri,
-		configTrimWhiteSpace: options.configTrimWhiteSpace
+		configTrimWhiteSpace: options.configTrimWhiteSpace,
+		preserveBlankLines: options.preserveBlankLines
 	});
 };
 

--- a/editions/test/tiddlers/tests/test-wikitext-blanklines.js
+++ b/editions/test/tiddlers/tests/test-wikitext-blanklines.js
@@ -1,0 +1,90 @@
+/*\
+title: test-wikitext-blanklines.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Tests for preserving extra blank lines as empty paragraph blocks.
+
+\*/
+
+"use strict";
+
+describe("Wikitext blank line preservation", function() {
+	var PRESERVE_BLANK_LINES_CONFIG = "$:/config/Parser/PreserveBlankLines";
+
+	function parse(text, options) {
+		options = options || { preserveBlankLines: true };
+		return $tw.wiki.parseText("text/vnd.tiddlywiki", text, options).tree;
+	}
+
+	function serialize(text) {
+		return $tw.utils.serializeWikitextParseTree(parse(text));
+	}
+
+	function paragraphCount(text) {
+		return parse(text).filter(function(node) {
+			return node.type === "element" && node.tag === "p";
+		}).length;
+	}
+
+	it("should keep a single blank line as a paragraph separator", function() {
+		expect(paragraphCount("A\n\nB")).toBe(2);
+		expect(serialize("A\n\nB")).toBe("A\n\nB\n\n");
+	});
+
+	it("should leave extra blank lines ignored when disabled", function() {
+		var tree = parse("A\n\n\nB", { preserveBlankLines: false });
+		expect(tree.length).toBe(2);
+		expect(tree.map(function(node) { return node.rule; })).toEqual(["parseblock", "parseblock"]);
+	});
+
+	it("should use the parser config when no explicit option is provided", function() {
+		var previousTiddler = $tw.wiki.getTiddler(PRESERVE_BLANK_LINES_CONFIG);
+		try {
+			$tw.wiki.addTiddler({title: PRESERVE_BLANK_LINES_CONFIG, text: "no"});
+			expect(parse("A\n\n\nB", {}).map(function(node) { return node.rule; })).toEqual(["parseblock", "parseblock"]);
+			$tw.wiki.addTiddler({title: PRESERVE_BLANK_LINES_CONFIG, text: "yes"});
+			expect(parse("A\n\n\nB", {}).map(function(node) { return node.rule; })).toEqual(["parseblock", "blankline", "parseblock"]);
+		} finally{
+			if(previousTiddler) {
+				$tw.wiki.addTiddler(previousTiddler);
+			} else {
+				$tw.wiki.deleteTiddler(PRESERVE_BLANK_LINES_CONFIG);
+			}
+		}
+	});
+
+	it("should preserve extra blank lines as empty paragraphs", function() {
+		expect(paragraphCount("A\n\n\nB")).toBe(3);
+		expect(parse("A\n\n\nB")[1].attributes.class.value).toBe("tc-blankline");
+		expect(serialize("A\n\n\nB")).toBe("A\n\n\nB\n\n");
+		expect(paragraphCount("A\n\n\n\nB")).toBe(4);
+		expect(serialize("A\n\n\n\nB")).toBe("A\n\n\n\nB\n\n");
+	});
+
+	it("should preserve extra blank lines after non-paragraph blocks", function() {
+		var listThenParagraph = parse("* one\n* two\n\n\n\nB");
+		expect(listThenParagraph.map(function(node) { return node.rule; })).toEqual(["list", "blankline", "blankline", "parseblock"]);
+		expect(serialize("* one\n* two\n\n\n\nB")).toBe("* one\n* two\n\n\n\nB\n\n");
+
+		var listThenMacro = parse("* one\n* two\n\n\n\n<<now YYYY>>");
+		expect(listThenMacro.map(function(node) { return node.rule; })).toEqual(["list", "blankline", "blankline", "macrocallblock"]);
+	});
+
+	it("should preserve trailing empty paragraphs", function() {
+		expect(paragraphCount("A\n\n\n")).toBe(2);
+		expect(serialize("A\n\n\n")).toBe("A\n\n\n");
+	});
+
+	it("should not turn a single leading newline into an empty paragraph", function() {
+		expect(paragraphCount("\nA")).toBe(1);
+		expect(serialize("\nA")).toBe("A\n\n");
+	});
+
+	it("should preserve leading empty paragraphs when there are two or more leading newlines", function() {
+		expect(paragraphCount("\n\nA")).toBe(2);
+		expect(serialize("\n\nA")).toBe("\n\nA\n\n");
+		expect(paragraphCount("\n\n\nA")).toBe(3);
+		expect(serialize("\n\n\nA")).toBe("\n\n\nA\n\n");
+	});
+});

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9872.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9872.tid
@@ -1,0 +1,10 @@
+title: $:/changenotes/5.5.0/#9872
+description: Preserve additional blank lines as paragraph nodes
+release: 5.5.0
+tags: $:/tags/ChangeNote
+change-type: feature
+change-category: widget
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9872
+github-contributors: linonetwo
+
+WikiText can optionally preserve additional blank lines as empty paragraph nodes, including blank lines following block elements, and serialize them back to WikiText.

--- a/plugins/tiddlywiki/wikitext-serialize/utils/parsetree.js
+++ b/plugins/tiddlywiki/wikitext-serialize/utils/parsetree.js
@@ -41,6 +41,8 @@ exports.serializeWikitextParseTree = function serializeWikitextParseTree(tree,op
 			var serializeOneRule = Parser.prototype.serializers[tree.rule];
 			if(serializeOneRule) {
 				output.push(serializeOneRule(tree,serializeWikitextParseTree));
+			} else if(tree.rule === "blankline") {
+				output.push(tree.isLeadingBlankLine ? "\n\n" : "\n");
 			} else if(tree.rule === "parseblock") {
 				output.push(serializeWikitextParseTree(tree.children,options),"\n\n");
 			} else {

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1136,6 +1136,10 @@ button.tc-btn-invisible.tc-remove-tag-button {
 	margin-bottom: 3px;
 }
 
+.tc-tiddler-body p.tc-blankline {
+	min-height: 1.2em;
+}
+
 .tc-tiddler-info .tc-tab-buttons button.tc-tab-selected {
 	background-color: <<colour tiddler-info-tab-background>>;
 	border-bottom: 1px solid <<colour tiddler-info-tab-background>>;


### PR DESCRIPTION
## Summary

closes #9871

This PR introduces a `blankline` parse tree rule when preservation is enabled:

- `A\n\nB` remains two paragraphs separated by the normal paragraph separator
- `A\n\n\nB` becomes `parseblock, blankline, parseblock`
- `A\n\n\n\nB` becomes `parseblock, blankline, blankline, parseblock`

It also handles extra blank lines after non-paragraph block rules. This matters for content such as lists followed by macros or paragraphs, where the block rule may consume trailing whitespace before the outer block parser sees it.

## What changed

- Adds `preserveBlankLines` parser option support and `$:/config/Parser/PreserveBlankLines` config support
- Passes `preserveBlankLines` through `wiki.parseText()` to the parser
- Adds `blankline` parse tree nodes with `class="tc-blankline"`
- Serializes `blankline` nodes back to the extra newline they represent
- Adds a small view-mode style so rendered blankline paragraphs have visible height

## Compatibility

The behavior is opt-in for now:

- pass `{ preserveBlankLines: true }` to `wiki.parseText()`; or
- set `$:/config/Parser/PreserveBlankLines` to `yes`

With the option disabled, existing behavior is preserved: extra blank lines are ignored as before.

## Future path to remove the option

I don't really want the `preserveBlankLines` option, but directly enable blank line support breaks many test, so I have to add it now, until we decide to enable it globally.

If the project decides that preserving extra blank lines should become the default wikitext behavior, the feature option can be removed by:

- making the blankline-preserving paths in `core/modules/parsers/wikiparser/wikiparser.js` unconditional
- removing the `$:/config/Parser/PreserveBlankLines` check and the `preserveBlankLines` parser option
- removing `preserveBlankLines` pass-through from `core/modules/wiki.js`
- keeping the `blankline` serializer support, because parse trees may still contain `blankline` nodes

Tests to update if the option is removed:

- `editions/test/tiddlers/tests/test-wikitext-blanklines.js`
  - remove or invert the disabled/default-ignored expectation
  - remove the config toggle test once there is no option
  - keep coverage for paragraph, leading, trailing, list-to-paragraph, and list-to-macro blank lines
- any parser or serializer fixture that intentionally expected `A\n\n\nB` to collapse should be updated to expect a `blankline` empty paragraph instead
- WYSIWYG/ProseMirror integration tests can drop explicit `{ preserveBlankLines: true }` parser calls once the parser behavior is default
