### PR TITLE
Use text/html with an embedded data URI so cross-app drags preserve tiddler data

### DIFF
--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -38,7 +38,8 @@ exports.makeDraggable = function(options) {
 				dragFilter = options.dragFilterFn && options.dragFilterFn(),
 				titles = dragTiddler ? [dragTiddler] : [],
 				startActions = options.startActions,
-				variables;
+				variables,
+				domNodeRect;
 			if(dragFilter) {
 				titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
 			}
@@ -63,7 +64,7 @@ exports.makeDraggable = function(options) {
 				var inner = options.widget.document.createElement("div");
 				inner.className = "tc-tiddler-dragger-inner";
 				inner.appendChild(options.widget.document.createTextNode(
-					titles.length === 1 ? 
+					titles.length === 1 ?
 						titles[0] :
 						titles.length + " tiddlers"
 				));
@@ -97,15 +98,28 @@ exports.makeDraggable = function(options) {
 				} else {
 					jsonData = options.widget.wiki.getTiddlerAsJson(titles[0]);
 				}
+				var tiddlerDataURI = "data:text/vnd.tiddler," + encodeURIComponent(jsonData);
 				// IE doesn't like these content types
 				if(!$tw.browser.isIE) {
 					dataTransfer.setData("text/vnd.tiddler",jsonData);
 					dataTransfer.setData("text/plain",titleString);
-					dataTransfer.setData("text/x-moz-url","data:text/vnd.tiddler," + encodeURIComponent(jsonData));
+					dataTransfer.setData("text/x-moz-url",tiddlerDataURI);
+					// text/html is the only standard MIME type that reliably
+					// survives Chromium's cross-app drag-data sanitiser on
+					// Linux. Embed the data: URI inside an anchor's href so
+					// the receiver can extract it; the visible text falls
+					// back to the title for non-TW receivers.
+					try {
+						dataTransfer.setData("text/html",
+							'<a href="' + tiddlerDataURI.replace(/"/g,"&quot;") + '">' +
+							titleString.replace(/[<>&]/g,function(c){return ({"<":"&lt;",">":"&gt;","&":"&amp;"})[c];}) +
+							'</a>'
+						);
+					} catch(e) {}
 				}
 				// If browser is Chrome-like and has a touch-input device do NOT .setData
 				if(!($tw.browser.isMobileChrome)) {
-					dataTransfer.setData("URL","data:text/vnd.tiddler," + encodeURIComponent(jsonData));
+					dataTransfer.setData("URL",tiddlerDataURI);
 				}
 				dataTransfer.setData("Text",titleString);
 				event.stopPropagation();
@@ -150,7 +164,7 @@ exports.importDataTransfer = function(dataTransfer,fallbackTitle,callback) {
 	if($tw.log.IMPORT) {
 		console.log("Available data types:");
 		for(var type=0; type<dataTransfer.types.length; type++) {
-			console.log("type",dataTransfer.types[type],dataTransfer.getData(dataTransfer.types[type]));
+			console.log("type",dataTransfer.types[type],dataTransfer.getData(dataTransfer.types[type]))
 		}
 	}
 	for(var t=0; t<importDataTypes.length; t++) {
@@ -161,7 +175,7 @@ exports.importDataTransfer = function(dataTransfer,fallbackTitle,callback) {
 			// Import the tiddlers in the data
 			if(data !== "" && data !== null) {
 				if($tw.log.IMPORT) {
-					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
+					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'")
 				}
 				var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
 				callback(tiddlerFields);
@@ -180,7 +194,7 @@ exports.importPaste = function(item,fallbackTitle,callback) {
 
 			item.getAsString(function(data){
 				if($tw.log.IMPORT) {
-					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
+					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'")
 				}
 				var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
 				callback(tiddlerFields);
@@ -199,7 +213,30 @@ exports.itemHasValidDataType = function(item) {
 		}
 	}
 	return false;
-};
+}
+
+// Chromium on Linux delivers text/html to JS as UTF-16LE bytes interpreted as
+// Latin-1 (every other char is null). Detect that shape and decode before
+// pattern matching. Used by the text/html entry in importDataTypes below.
+function maybeDecodeUtf16Html(data) {
+	if(!data || data.length < 4) { return data; }
+	var sample = Math.min(data.length, 64), nulls = 0;
+	for(var i = 1; i < sample; i += 2) {
+		if(data.charCodeAt(i) === 0) { nulls++; }
+	}
+	if(nulls < Math.floor(sample / 2) * 0.8) { return data; }
+	if(typeof TextDecoder !== "undefined") {
+		try {
+			var bytes = new Uint8Array(data.length);
+			for(var k = 0; k < data.length; k++) { bytes[k] = data.charCodeAt(k) & 0xff; }
+			return new TextDecoder("utf-16le").decode(bytes).replace(/^﻿/, "");
+		} catch(e) {}
+	}
+	// ASCII-safe fallback: take every even-indexed char
+	var stripped = "";
+	for(var j = 0; j < data.length; j += 2) { stripped += data.charAt(j); }
+	return stripped;
+}
 
 var importDataTypes = [
 	{type: "text/vnd.tiddler", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
@@ -224,6 +261,18 @@ var importDataTypes = [
 		}
 	}},
 	{type: "text/html", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
+		// Decode Chromium's Linux UTF-16LE-as-Latin-1 quirk if present
+		data = maybeDecodeUtf16Html(data);
+		// Look for an embedded data:text/vnd.tiddler URI inside any href. Match on
+		// the still-URI-encoded form so JSON %22 doesn't truncate the capture; the
+		// stop-class excludes chars that cannot legally appear in a URI-encoded
+		// payload, so they reliably bound the match.
+		var encMatch = data && data.match(/data:text\/vnd\.tiddler,([^"'<>\s)]+)/i);
+		if(encMatch) {
+			try {
+				return parseJSONTiddlers(decodeURIComponent(encMatch[1]),fallbackTitle);
+			} catch(e) {}
+		}
 		return [{title: fallbackTitle, text: data}];
 	}},
 	{type: "text/plain", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -38,8 +38,7 @@ exports.makeDraggable = function(options) {
 				dragFilter = options.dragFilterFn && options.dragFilterFn(),
 				titles = dragTiddler ? [dragTiddler] : [],
 				startActions = options.startActions,
-				variables,
-				domNodeRect;
+				variables;
 			if(dragFilter) {
 				titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
 			}
@@ -113,7 +112,7 @@ exports.makeDraggable = function(options) {
 						dataTransfer.setData("text/html",
 							'<a href="' + tiddlerDataURI.replace(/"/g,"&quot;") + '">' +
 							titleString.replace(/[<>&]/g,function(c){return ({"<":"&lt;",">":"&gt;","&":"&amp;"})[c];}) +
-							'</a>'
+							"</a>"
 						);
 					} catch(e) {}
 				}
@@ -164,7 +163,7 @@ exports.importDataTransfer = function(dataTransfer,fallbackTitle,callback) {
 	if($tw.log.IMPORT) {
 		console.log("Available data types:");
 		for(var type=0; type<dataTransfer.types.length; type++) {
-			console.log("type",dataTransfer.types[type],dataTransfer.getData(dataTransfer.types[type]))
+			console.log("type",dataTransfer.types[type],dataTransfer.getData(dataTransfer.types[type]));
 		}
 	}
 	for(var t=0; t<importDataTypes.length; t++) {
@@ -175,7 +174,7 @@ exports.importDataTransfer = function(dataTransfer,fallbackTitle,callback) {
 			// Import the tiddlers in the data
 			if(data !== "" && data !== null) {
 				if($tw.log.IMPORT) {
-					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'")
+					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
 				}
 				var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
 				callback(tiddlerFields);
@@ -194,7 +193,7 @@ exports.importPaste = function(item,fallbackTitle,callback) {
 
 			item.getAsString(function(data){
 				if($tw.log.IMPORT) {
-					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'")
+					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
 				}
 				var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
 				callback(tiddlerFields);
@@ -213,7 +212,7 @@ exports.itemHasValidDataType = function(item) {
 		}
 	}
 	return false;
-}
+};
 
 // Chromium on Linux delivers text/html to JS as UTF-16LE bytes interpreted as
 // Latin-1 (every other char is null). Detect that shape and decode before
@@ -229,7 +228,7 @@ function maybeDecodeUtf16Html(data) {
 		try {
 			var bytes = new Uint8Array(data.length);
 			for(var k = 0; k < data.length; k++) { bytes[k] = data.charCodeAt(k) & 0xff; }
-			return new TextDecoder("utf-16le").decode(bytes).replace(/^﻿/, "");
+			return new TextDecoder("utf-16le").decode(bytes).replace(/^\uFEFF/, "");
 		} catch(e) {}
 	}
 	// ASCII-safe fallback: take every even-indexed char

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -20,303 +20,303 @@ dragFilterFn: optional function to retreive the filter defining a list of tiddle
 widget: widget to use as the context for the filter
 */
 exports.makeDraggable = function(options) {
-    var dragImageType = options.dragImageType || "dom",
-        dragImage,
-        domNode = options.domNode;
-    // Make the dom node draggable (not necessary for anchor tags)
-    if(!options.selector && ((domNode.tagName || "").toLowerCase() !== "a")) {
-        domNode.setAttribute("draggable","true");
-    }
-    // Add event handlers
-    $tw.utils.addEventListeners(domNode,[
-        {name: "dragstart", handlerFunction: function(event) {
-            if(event.dataTransfer === undefined) {
-                return false;
-            }
-            // Collect the tiddlers being dragged
-            var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
-                dragFilter = options.dragFilterFn && options.dragFilterFn(),
-                titles = dragTiddler ? [dragTiddler] : [],
-                startActions = options.startActions,
-                variables;
-            if(dragFilter) {
-                titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
-            }
-            var titleString = $tw.utils.stringifyList(titles);
-            // Check that we've something to drag
-            if(titles.length > 0 && (options.selector && $tw.utils.domMatchesSelector(event.target,options.selector) || event.target === domNode)) {
-                // Mark the drag in progress
-                $tw.dragInProgress = domNode;
-                // Set the dragging class on the element being dragged
-                $tw.utils.addClass(domNode,"tc-dragging");
-                // Invoke drag-start actions if given
-                if(startActions !== undefined) {
-                    // Collect our variables
-                    variables = $tw.utils.collectDOMVariables(domNode,null,event);
-                    variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
-                    variables["actionTiddler"] = titleString;
-                    options.widget.invokeActionString(startActions,options.widget,event,variables);
-                }
-                // Create the drag image elements
-                dragImage = options.widget.document.createElement("div");
-                dragImage.className = "tc-tiddler-dragger";
-                var inner = options.widget.document.createElement("div");
-                inner.className = "tc-tiddler-dragger-inner";
-                inner.appendChild(options.widget.document.createTextNode(
-                    titles.length === 1 ?
-                        titles[0] :
-                        titles.length + " tiddlers"
-                ));
-                dragImage.appendChild(inner);
-                options.widget.document.body.appendChild(dragImage);
-                // Set the data transfer properties
-                var dataTransfer = event.dataTransfer;
-                // Set up the image
-                dataTransfer.effectAllowed = "all";
-                if(dataTransfer.setDragImage) {
-                    if(dragImageType === "pill") {
-                        dataTransfer.setDragImage(dragImage.firstChild,-16,-16);
-                    } else if(dragImageType === "blank") {
-                        dragImage.removeChild(dragImage.firstChild);
-                        dataTransfer.setDragImage(dragImage,0,0);
-                    } else {
-                        var r = domNode.getBoundingClientRect();
-                        dataTransfer.setDragImage(domNode,event.clientX-r.left,event.clientY-r.top);
-                    }
-                }
-                // Set up the data transfer
-                if(dataTransfer.clearData) {
-                    dataTransfer.clearData();
-                }
-                var jsonData = [];
-                if(titles.length > 1) {
-                    titles.forEach(function(title) {
-                        jsonData.push(options.widget.wiki.getTiddlerAsJson(title));
-                    });
-                    jsonData = "[" + jsonData.join(",") + "]";
-                } else {
-                    jsonData = options.widget.wiki.getTiddlerAsJson(titles[0]);
-                }
-                var tiddlerDataURI = "data:text/vnd.tiddler," + encodeURIComponent(jsonData);
-                // IE doesn't like these content types
-                if(!$tw.browser.isIE) {
-                    dataTransfer.setData("text/vnd.tiddler",jsonData);
-                    dataTransfer.setData("text/plain",titleString);
-                    dataTransfer.setData("text/x-moz-url",tiddlerDataURI);
-                    // text/html is the only standard MIME type that reliably
-                    // survives Chromium's cross-app drag-data sanitiser on
-                    // Linux. Embed the data: URI inside an anchor's href so
-                    // the receiver can extract it; the visible text falls
-                    // back to the title for non-TW receivers.
-                    try {
-                        dataTransfer.setData("text/html",
-                            '<a href="' + tiddlerDataURI.replace(/"/g,"&quot;") + '">' +
-                            titleString.replace(/[<>&]/g,function(c){return ({"<":"&lt;",">":"&gt;","&":"&amp;"})[c];}) +
-                            "</a>"
-                        );
-                    } catch(e) {}
-                }
-                // If browser is Chrome-like and has a touch-input device do NOT .setData
-                if(!($tw.browser.isMobileChrome)) {
-                    dataTransfer.setData("URL",tiddlerDataURI);
-                }
-                dataTransfer.setData("Text",titleString);
-                event.stopPropagation();
-            }
-            return false;
-        }},
-        {name: "dragend", handlerFunction: function(event) {
-            if((options.selector && $tw.utils.domMatchesSelector(event.target,options.selector)) || event.target === domNode) {
-                // Collect the tiddlers being dragged
-                var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
-                    dragFilter = options.dragFilterFn && options.dragFilterFn(),
-                    titles = dragTiddler ? [dragTiddler] : [],
-                    endActions = options.endActions,
-                    variables;
-                if(dragFilter) {
-                    titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
-                }
-                var titleString = $tw.utils.stringifyList(titles);
-                $tw.dragInProgress = null;
-                // Invoke drag-end actions if given
-                if(endActions !== undefined) {
-                    variables = $tw.utils.collectDOMVariables(domNode,null,event);
-                    variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
-                    variables["actionTiddler"] = titleString;
-                    options.widget.invokeActionString(endActions,options.widget,event,variables);
-                }
-                // Remove the dragging class on the element being dragged
-                $tw.utils.removeClass(domNode,"tc-dragging");
-                // Delete the drag image element
-                if(dragImage) {
-                    dragImage.parentNode.removeChild(dragImage);
-                    dragImage = null;
-                }
-            }
-            return false;
-        }}
-    ]);
+	var dragImageType = options.dragImageType || "dom",
+		dragImage,
+		domNode = options.domNode;
+	// Make the dom node draggable (not necessary for anchor tags)
+	if(!options.selector && ((domNode.tagName || "").toLowerCase() !== "a")) {
+		domNode.setAttribute("draggable","true");
+	}
+	// Add event handlers
+	$tw.utils.addEventListeners(domNode,[
+		{name: "dragstart", handlerFunction: function(event) {
+			if(event.dataTransfer === undefined) {
+				return false;
+			}
+			// Collect the tiddlers being dragged
+			var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
+				dragFilter = options.dragFilterFn && options.dragFilterFn(),
+				titles = dragTiddler ? [dragTiddler] : [],
+				startActions = options.startActions,
+				variables;
+			if(dragFilter) {
+				titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
+			}
+			var titleString = $tw.utils.stringifyList(titles);
+			// Check that we've something to drag
+			if(titles.length > 0 && (options.selector && $tw.utils.domMatchesSelector(event.target,options.selector) || event.target === domNode)) {
+				// Mark the drag in progress
+				$tw.dragInProgress = domNode;
+				// Set the dragging class on the element being dragged
+				$tw.utils.addClass(domNode,"tc-dragging");
+				// Invoke drag-start actions if given
+				if(startActions !== undefined) {
+					// Collect our variables
+					variables = $tw.utils.collectDOMVariables(domNode,null,event);
+					variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
+					variables["actionTiddler"] = titleString;
+					options.widget.invokeActionString(startActions,options.widget,event,variables);
+				}
+				// Create the drag image elements
+				dragImage = options.widget.document.createElement("div");
+				dragImage.className = "tc-tiddler-dragger";
+				var inner = options.widget.document.createElement("div");
+				inner.className = "tc-tiddler-dragger-inner";
+				inner.appendChild(options.widget.document.createTextNode(
+					titles.length === 1 ?
+						titles[0] :
+						titles.length + " tiddlers"
+				));
+				dragImage.appendChild(inner);
+				options.widget.document.body.appendChild(dragImage);
+				// Set the data transfer properties
+				var dataTransfer = event.dataTransfer;
+				// Set up the image
+				dataTransfer.effectAllowed = "all";
+				if(dataTransfer.setDragImage) {
+					if(dragImageType === "pill") {
+						dataTransfer.setDragImage(dragImage.firstChild,-16,-16);
+					} else if(dragImageType === "blank") {
+						dragImage.removeChild(dragImage.firstChild);
+						dataTransfer.setDragImage(dragImage,0,0);
+					} else {
+						var r = domNode.getBoundingClientRect();
+						dataTransfer.setDragImage(domNode,event.clientX-r.left,event.clientY-r.top);
+					}
+				}
+				// Set up the data transfer
+				if(dataTransfer.clearData) {
+					dataTransfer.clearData();
+				}
+				var jsonData = [];
+				if(titles.length > 1) {
+					titles.forEach(function(title) {
+						jsonData.push(options.widget.wiki.getTiddlerAsJson(title));
+					});
+					jsonData = "[" + jsonData.join(",") + "]";
+				} else {
+					jsonData = options.widget.wiki.getTiddlerAsJson(titles[0]);
+				}
+				var tiddlerDataURI = "data:text/vnd.tiddler," + encodeURIComponent(jsonData);
+				// IE doesn't like these content types
+				if(!$tw.browser.isIE) {
+					dataTransfer.setData("text/vnd.tiddler",jsonData);
+					dataTransfer.setData("text/plain",titleString);
+					dataTransfer.setData("text/x-moz-url",tiddlerDataURI);
+					// text/html is the only standard MIME type that reliably
+					// survives Chromium's cross-app drag-data sanitiser on
+					// Linux. Embed the data: URI inside an anchor's href so
+					// the receiver can extract it; the visible text falls
+					// back to the title for non-TW receivers.
+					try {
+						dataTransfer.setData("text/html",
+							'<a href="' + tiddlerDataURI.replace(/"/g,"&quot;") + '">' +
+							titleString.replace(/[<>&]/g,function(c){return ({"<":"&lt;",">":"&gt;","&":"&amp;"})[c];}) +
+							"</a>"
+						);
+					} catch(e) {}
+				}
+				// If browser is Chrome-like and has a touch-input device do NOT .setData
+				if(!($tw.browser.isMobileChrome)) {
+					dataTransfer.setData("URL",tiddlerDataURI);
+				}
+				dataTransfer.setData("Text",titleString);
+				event.stopPropagation();
+			}
+			return false;
+		}},
+		{name: "dragend", handlerFunction: function(event) {
+			if((options.selector && $tw.utils.domMatchesSelector(event.target,options.selector)) || event.target === domNode) {
+				// Collect the tiddlers being dragged
+				var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
+					dragFilter = options.dragFilterFn && options.dragFilterFn(),
+					titles = dragTiddler ? [dragTiddler] : [],
+					endActions = options.endActions,
+					variables;
+				if(dragFilter) {
+					titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
+				}
+				var titleString = $tw.utils.stringifyList(titles);
+				$tw.dragInProgress = null;
+				// Invoke drag-end actions if given
+				if(endActions !== undefined) {
+					variables = $tw.utils.collectDOMVariables(domNode,null,event);
+					variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
+					variables["actionTiddler"] = titleString;
+					options.widget.invokeActionString(endActions,options.widget,event,variables);
+				}
+				// Remove the dragging class on the element being dragged
+				$tw.utils.removeClass(domNode,"tc-dragging");
+				// Delete the drag image element
+				if(dragImage) {
+					dragImage.parentNode.removeChild(dragImage);
+					dragImage = null;
+				}
+			}
+			return false;
+		}}
+	]);
 };
 
 exports.importDataTransfer = function(dataTransfer,fallbackTitle,callback) {
-    // Try each provided data type in turn
-    if($tw.log.IMPORT) {
-        console.log("Available data types:");
-        for(var type=0; type<dataTransfer.types.length; type++) {
-            console.log("type",dataTransfer.types[type],dataTransfer.getData(dataTransfer.types[type]));
-        }
-    }
-    for(var t=0; t<importDataTypes.length; t++) {
-        if(!$tw.browser.isIE || importDataTypes[t].IECompatible) {
-            // Get the data
-            var dataType = importDataTypes[t];
-            var data = dataTransfer.getData(dataType.type);
-            // Import the tiddlers in the data
-            if(data !== "" && data !== null) {
-                if($tw.log.IMPORT) {
-                    console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
-                }
-                var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
-                callback(tiddlerFields);
-                return;
-            }
-        }
-    }
+	// Try each provided data type in turn
+	if($tw.log.IMPORT) {
+		console.log("Available data types:");
+		for(var type=0; type<dataTransfer.types.length; type++) {
+			console.log("type",dataTransfer.types[type],dataTransfer.getData(dataTransfer.types[type]));
+		}
+	}
+	for(var t=0; t<importDataTypes.length; t++) {
+		if(!$tw.browser.isIE || importDataTypes[t].IECompatible) {
+			// Get the data
+			var dataType = importDataTypes[t];
+			var data = dataTransfer.getData(dataType.type);
+			// Import the tiddlers in the data
+			if(data !== "" && data !== null) {
+				if($tw.log.IMPORT) {
+					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
+				}
+				var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
+				callback(tiddlerFields);
+				return;
+			}
+		}
+	}
 };
 
 exports.importPaste = function(item,fallbackTitle,callback) {
-    // Try each provided data type in turn
-    for(var t=0; t<importDataTypes.length; t++) {
-        if(item.type === importDataTypes[t].type) {
-            // Get the data
-            var dataType = importDataTypes[t];
+	// Try each provided data type in turn
+	for(var t=0; t<importDataTypes.length; t++) {
+		if(item.type === importDataTypes[t].type) {
+			// Get the data
+			var dataType = importDataTypes[t];
 
-            item.getAsString(function(data){
-                if($tw.log.IMPORT) {
-                    console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
-                }
-                var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
-                callback(tiddlerFields);
-            });
-            return;
-        }
-    }
+			item.getAsString(function(data){
+				if($tw.log.IMPORT) {
+					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
+				}
+				var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
+				callback(tiddlerFields);
+			});
+			return;
+		}
+	}
 };
 
 exports.itemHasValidDataType = function(item) {
-    for(var t=0; t<importDataTypes.length; t++) {
-        if(!$tw.browser.isIE || importDataTypes[t].IECompatible) {
-            if(item.type === importDataTypes[t].type) {
-                return true;
-            }
-        }
-    }
-    return false;
+	for(var t=0; t<importDataTypes.length; t++) {
+		if(!$tw.browser.isIE || importDataTypes[t].IECompatible) {
+			if(item.type === importDataTypes[t].type) {
+				return true;
+			}
+		}
+	}
+	return false;
 };
 
 // Chromium on Linux delivers text/html to JS as UTF-16LE bytes interpreted as
 // Latin-1 (every other char is null). Detect that shape and decode before
 // pattern matching. Used by the text/html entry in importDataTypes below.
 function maybeDecodeUtf16Html(data) {
-    if(!data || data.length < 4) { return data; }
-    var sample = Math.min(data.length, 64), nulls = 0;
-    for(var i = 1; i < sample; i += 2) {
-        if(data.charCodeAt(i) === 0) { nulls++; }
-    }
-    if(nulls < Math.floor(sample / 2) * 0.8) { return data; }
-    if(typeof TextDecoder !== "undefined") {
-        try {
-            var bytes = new Uint8Array(data.length);
-            for(var k = 0; k < data.length; k++) { bytes[k] = data.charCodeAt(k) & 0xff; }
-            return new TextDecoder("utf-16le").decode(bytes).replace(/^\uFEFF/, "");
-        } catch(e) {}
-    }
-    // ASCII-safe fallback: take every even-indexed char
-    var stripped = "";
-    for(var j = 0; j < data.length; j += 2) { stripped += data.charAt(j); }
-    return stripped;
+	if(!data || data.length < 4) { return data; }
+	var sample = Math.min(data.length, 64), nulls = 0;
+	for(var i = 1; i < sample; i += 2) {
+		if(data.charCodeAt(i) === 0) { nulls++; }
+	}
+	if(nulls < Math.floor(sample / 2) * 0.8) { return data; }
+	if(typeof TextDecoder !== "undefined") {
+		try {
+			var bytes = new Uint8Array(data.length);
+			for(var k = 0; k < data.length; k++) { bytes[k] = data.charCodeAt(k) & 0xff; }
+			return new TextDecoder("utf-16le").decode(bytes).replace(/^\uFEFF/, "");
+		} catch(e) {}
+	}
+	// ASCII-safe fallback: take every even-indexed char
+	var stripped = "";
+	for(var j = 0; j < data.length; j += 2) { stripped += data.charAt(j); }
+	return stripped;
 }
 
 var importDataTypes = [
-    {type: "text/vnd.tiddler", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
-        return parseJSONTiddlers(data,fallbackTitle);
-    }},
-    {type: "URL", IECompatible: true, toTiddlerFieldsArray: function(data,fallbackTitle) {
-        // Check for tiddler data URI
-        var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
-        if(match) {
-            return parseJSONTiddlers(match[1],fallbackTitle);
-        } else {
-            return [{title: fallbackTitle, text: data}]; // As URL string
-        }
-    }},
-    {type: "text/x-moz-url", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
-        // Check for tiddler data URI
-        var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
-        if(match) {
-            return parseJSONTiddlers(match[1],fallbackTitle);
-        } else {
-            return [{title: fallbackTitle, text: data}]; // As URL string
-        }
-    }},
-    {type: "text/html", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
-        // Decode Chromium's Linux UTF-16LE-as-Latin-1 quirk if present
-        data = maybeDecodeUtf16Html(data);
-        // Look for an embedded data:text/vnd.tiddler URI inside any href. Match on
-        // the still-URI-encoded form so JSON %22 doesn't truncate the capture. The
-        // stop-class is only " < > because encodeURIComponent always percent-encodes
-        // those three (so they reliably bound the href value), while characters it
-        // leaves literal (notably ' and ) ) must NOT terminate the match or the
-        // payload would be truncated and fail to parse.
-        var encMatch = data && data.match(/data:text\/vnd\.tiddler,([^"<>]+)/i);
-        if(encMatch) {
-            try {
-                return parseJSONTiddlers(decodeURIComponent(encMatch[1]),fallbackTitle);
-            } catch(e) {}
-        }
-        return [{title: fallbackTitle, text: data}];
-    }},
-    {type: "text/plain", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
-        return [{title: fallbackTitle, text: data}];
-    }},
-    {type: "Text", IECompatible: true, toTiddlerFieldsArray: function(data,fallbackTitle) {
-        return [{title: fallbackTitle, text: data}];
-    }},
-    {type: "text/uri-list", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
-        // Check for tiddler data URI
-        var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
-        if(match) {
-            return parseJSONTiddlers(match[1],fallbackTitle);
-        } else {
-            return [{title: fallbackTitle, text: data}]; // As URL string
-        }
-    }}
+	{type: "text/vnd.tiddler", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
+		return parseJSONTiddlers(data,fallbackTitle);
+	}},
+	{type: "URL", IECompatible: true, toTiddlerFieldsArray: function(data,fallbackTitle) {
+		// Check for tiddler data URI
+		var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
+		if(match) {
+			return parseJSONTiddlers(match[1],fallbackTitle);
+		} else {
+			return [{title: fallbackTitle, text: data}]; // As URL string
+		}
+	}},
+	{type: "text/x-moz-url", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
+		// Check for tiddler data URI
+		var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
+		if(match) {
+			return parseJSONTiddlers(match[1],fallbackTitle);
+		} else {
+			return [{title: fallbackTitle, text: data}]; // As URL string
+		}
+	}},
+	{type: "text/html", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
+		// Decode Chromium's Linux UTF-16LE-as-Latin-1 quirk if present
+		data = maybeDecodeUtf16Html(data);
+		// Look for an embedded data:text/vnd.tiddler URI inside any href. Match on
+		// the still-URI-encoded form so JSON %22 doesn't truncate the capture. The
+		// stop-class is only " < > because encodeURIComponent always percent-encodes
+		// those three (so they reliably bound the href value), while characters it
+		// leaves literal (notably ' and ) ) must NOT terminate the match or the
+		// payload would be truncated and fail to parse.
+		var encMatch = data && data.match(/data:text\/vnd\.tiddler,([^"<>]+)/i);
+		if(encMatch) {
+			try {
+				return parseJSONTiddlers(decodeURIComponent(encMatch[1]),fallbackTitle);
+			} catch(e) {}
+		}
+		return [{title: fallbackTitle, text: data}];
+	}},
+	{type: "text/plain", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
+		return [{title: fallbackTitle, text: data}];
+	}},
+	{type: "Text", IECompatible: true, toTiddlerFieldsArray: function(data,fallbackTitle) {
+		return [{title: fallbackTitle, text: data}];
+	}},
+	{type: "text/uri-list", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
+		// Check for tiddler data URI
+		var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
+		if(match) {
+			return parseJSONTiddlers(match[1],fallbackTitle);
+		} else {
+			return [{title: fallbackTitle, text: data}]; // As URL string
+		}
+	}}
 ];
 
 function parseJSONTiddlers(json,fallbackTitle) {
-    var data = $tw.utils.parseJSONSafe(json);
-    if(!$tw.utils.isArray(data)) {
-        data = [data];
-    }
-    data.forEach(function(fields) {
-        fields.title = fields.title || fallbackTitle;
-    });
-    return data;
+	var data = $tw.utils.parseJSONSafe(json);
+	if(!$tw.utils.isArray(data)) {
+		data = [data];
+	}
+	data.forEach(function(fields) {
+		fields.title = fields.title || fallbackTitle;
+	});
+	return data;
 };
 
 function dragEventContainsType(event,targetType) {
-    if(event.dataTransfer.types) {
-        for(var i=0; i<event.dataTransfer.types.length; i++) {
-            if(event.dataTransfer.types[i] === targetType) {
-                return true;
-            }
-        }
-    }
-    return false;
+	if(event.dataTransfer.types) {
+		for(var i=0; i<event.dataTransfer.types.length; i++) {
+			if(event.dataTransfer.types[i] === targetType) {
+				return true;
+			}
+		}
+	}
+	return false;
 };
 
 exports.dragEventContainsFiles = function(event) {
-    return (dragEventContainsType(event,"Files") && !dragEventContainsType(event,"text/plain"));
+	return (dragEventContainsType(event,"Files") && !dragEventContainsType(event,"text/plain"));
 };
 
 exports.dragEventContainsType = dragEventContainsType;

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -20,303 +20,303 @@ dragFilterFn: optional function to retreive the filter defining a list of tiddle
 widget: widget to use as the context for the filter
 */
 exports.makeDraggable = function(options) {
-	var dragImageType = options.dragImageType || "dom",
-		dragImage,
-		domNode = options.domNode;
-	// Make the dom node draggable (not necessary for anchor tags)
-	if(!options.selector && ((domNode.tagName || "").toLowerCase() !== "a")) {
-		domNode.setAttribute("draggable","true");
-	}
-	// Add event handlers
-	$tw.utils.addEventListeners(domNode,[
-		{name: "dragstart", handlerFunction: function(event) {
-			if(event.dataTransfer === undefined) {
-				return false;
-			}
-			// Collect the tiddlers being dragged
-			var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
-				dragFilter = options.dragFilterFn && options.dragFilterFn(),
-				titles = dragTiddler ? [dragTiddler] : [],
-				startActions = options.startActions,
-				variables;
-			if(dragFilter) {
-				titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
-			}
-			var titleString = $tw.utils.stringifyList(titles);
-			// Check that we've something to drag
-			if(titles.length > 0 && (options.selector && $tw.utils.domMatchesSelector(event.target,options.selector) || event.target === domNode)) {
-				// Mark the drag in progress
-				$tw.dragInProgress = domNode;
-				// Set the dragging class on the element being dragged
-				$tw.utils.addClass(domNode,"tc-dragging");
-				// Invoke drag-start actions if given
-				if(startActions !== undefined) {
-					// Collect our variables
-					variables = $tw.utils.collectDOMVariables(domNode,null,event);
-					variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
-					variables["actionTiddler"] = titleString;
-					options.widget.invokeActionString(startActions,options.widget,event,variables);
-				}
-				// Create the drag image elements
-				dragImage = options.widget.document.createElement("div");
-				dragImage.className = "tc-tiddler-dragger";
-				var inner = options.widget.document.createElement("div");
-				inner.className = "tc-tiddler-dragger-inner";
-				inner.appendChild(options.widget.document.createTextNode(
-					titles.length === 1 ?
-						titles[0] :
-						titles.length + " tiddlers"
-				));
-				dragImage.appendChild(inner);
-				options.widget.document.body.appendChild(dragImage);
-				// Set the data transfer properties
-				var dataTransfer = event.dataTransfer;
-				// Set up the image
-				dataTransfer.effectAllowed = "all";
-				if(dataTransfer.setDragImage) {
-					if(dragImageType === "pill") {
-						dataTransfer.setDragImage(dragImage.firstChild,-16,-16);
-					} else if(dragImageType === "blank") {
-						dragImage.removeChild(dragImage.firstChild);
-						dataTransfer.setDragImage(dragImage,0,0);
-					} else {
-						var r = domNode.getBoundingClientRect();
-						dataTransfer.setDragImage(domNode,event.clientX-r.left,event.clientY-r.top);
-					}
-				}
-				// Set up the data transfer
-				if(dataTransfer.clearData) {
-					dataTransfer.clearData();
-				}
-				var jsonData = [];
-				if(titles.length > 1) {
-					titles.forEach(function(title) {
-						jsonData.push(options.widget.wiki.getTiddlerAsJson(title));
-					});
-					jsonData = "[" + jsonData.join(",") + "]";
-				} else {
-					jsonData = options.widget.wiki.getTiddlerAsJson(titles[0]);
-				}
-				var tiddlerDataURI = "data:text/vnd.tiddler," + encodeURIComponent(jsonData);
-				// IE doesn't like these content types
-				if(!$tw.browser.isIE) {
-					dataTransfer.setData("text/vnd.tiddler",jsonData);
-					dataTransfer.setData("text/plain",titleString);
-					dataTransfer.setData("text/x-moz-url",tiddlerDataURI);
-					// text/html is the only standard MIME type that reliably
-					// survives Chromium's cross-app drag-data sanitiser on
-					// Linux. Embed the data: URI inside an anchor's href so
-					// the receiver can extract it; the visible text falls
-					// back to the title for non-TW receivers.
-					try {
-						dataTransfer.setData("text/html",
-							'<a href="' + tiddlerDataURI.replace(/"/g,"&quot;") + '">' +
-							titleString.replace(/[<>&]/g,function(c){return ({"<":"&lt;",">":"&gt;","&":"&amp;"})[c];}) +
-							"</a>"
-						);
-					} catch(e) {}
-				}
-				// If browser is Chrome-like and has a touch-input device do NOT .setData
-				if(!($tw.browser.isMobileChrome)) {
-					dataTransfer.setData("URL",tiddlerDataURI);
-				}
-				dataTransfer.setData("Text",titleString);
-				event.stopPropagation();
-			}
-			return false;
-		}},
-		{name: "dragend", handlerFunction: function(event) {
-			if((options.selector && $tw.utils.domMatchesSelector(event.target,options.selector)) || event.target === domNode) {
-				// Collect the tiddlers being dragged
-				var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
-					dragFilter = options.dragFilterFn && options.dragFilterFn(),
-					titles = dragTiddler ? [dragTiddler] : [],
-					endActions = options.endActions,
-					variables;
-				if(dragFilter) {
-					titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
-				}
-				var titleString = $tw.utils.stringifyList(titles);
-				$tw.dragInProgress = null;
-				// Invoke drag-end actions if given
-				if(endActions !== undefined) {
-					variables = $tw.utils.collectDOMVariables(domNode,null,event);
-					variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
-					variables["actionTiddler"] = titleString;
-					options.widget.invokeActionString(endActions,options.widget,event,variables);
-				}
-				// Remove the dragging class on the element being dragged
-				$tw.utils.removeClass(domNode,"tc-dragging");
-				// Delete the drag image element
-				if(dragImage) {
-					dragImage.parentNode.removeChild(dragImage);
-					dragImage = null;
-				}
-			}
-			return false;
-		}}
-	]);
+    var dragImageType = options.dragImageType || "dom",
+        dragImage,
+        domNode = options.domNode;
+    // Make the dom node draggable (not necessary for anchor tags)
+    if(!options.selector && ((domNode.tagName || "").toLowerCase() !== "a")) {
+        domNode.setAttribute("draggable","true");
+    }
+    // Add event handlers
+    $tw.utils.addEventListeners(domNode,[
+        {name: "dragstart", handlerFunction: function(event) {
+            if(event.dataTransfer === undefined) {
+                return false;
+            }
+            // Collect the tiddlers being dragged
+            var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
+                dragFilter = options.dragFilterFn && options.dragFilterFn(),
+                titles = dragTiddler ? [dragTiddler] : [],
+                startActions = options.startActions,
+                variables;
+            if(dragFilter) {
+                titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
+            }
+            var titleString = $tw.utils.stringifyList(titles);
+            // Check that we've something to drag
+            if(titles.length > 0 && (options.selector && $tw.utils.domMatchesSelector(event.target,options.selector) || event.target === domNode)) {
+                // Mark the drag in progress
+                $tw.dragInProgress = domNode;
+                // Set the dragging class on the element being dragged
+                $tw.utils.addClass(domNode,"tc-dragging");
+                // Invoke drag-start actions if given
+                if(startActions !== undefined) {
+                    // Collect our variables
+                    variables = $tw.utils.collectDOMVariables(domNode,null,event);
+                    variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
+                    variables["actionTiddler"] = titleString;
+                    options.widget.invokeActionString(startActions,options.widget,event,variables);
+                }
+                // Create the drag image elements
+                dragImage = options.widget.document.createElement("div");
+                dragImage.className = "tc-tiddler-dragger";
+                var inner = options.widget.document.createElement("div");
+                inner.className = "tc-tiddler-dragger-inner";
+                inner.appendChild(options.widget.document.createTextNode(
+                    titles.length === 1 ?
+                        titles[0] :
+                        titles.length + " tiddlers"
+                ));
+                dragImage.appendChild(inner);
+                options.widget.document.body.appendChild(dragImage);
+                // Set the data transfer properties
+                var dataTransfer = event.dataTransfer;
+                // Set up the image
+                dataTransfer.effectAllowed = "all";
+                if(dataTransfer.setDragImage) {
+                    if(dragImageType === "pill") {
+                        dataTransfer.setDragImage(dragImage.firstChild,-16,-16);
+                    } else if(dragImageType === "blank") {
+                        dragImage.removeChild(dragImage.firstChild);
+                        dataTransfer.setDragImage(dragImage,0,0);
+                    } else {
+                        var r = domNode.getBoundingClientRect();
+                        dataTransfer.setDragImage(domNode,event.clientX-r.left,event.clientY-r.top);
+                    }
+                }
+                // Set up the data transfer
+                if(dataTransfer.clearData) {
+                    dataTransfer.clearData();
+                }
+                var jsonData = [];
+                if(titles.length > 1) {
+                    titles.forEach(function(title) {
+                        jsonData.push(options.widget.wiki.getTiddlerAsJson(title));
+                    });
+                    jsonData = "[" + jsonData.join(",") + "]";
+                } else {
+                    jsonData = options.widget.wiki.getTiddlerAsJson(titles[0]);
+                }
+                var tiddlerDataURI = "data:text/vnd.tiddler," + encodeURIComponent(jsonData);
+                // IE doesn't like these content types
+                if(!$tw.browser.isIE) {
+                    dataTransfer.setData("text/vnd.tiddler",jsonData);
+                    dataTransfer.setData("text/plain",titleString);
+                    dataTransfer.setData("text/x-moz-url",tiddlerDataURI);
+                    // text/html is the only standard MIME type that reliably
+                    // survives Chromium's cross-app drag-data sanitiser on
+                    // Linux. Embed the data: URI inside an anchor's href so
+                    // the receiver can extract it; the visible text falls
+                    // back to the title for non-TW receivers.
+                    try {
+                        dataTransfer.setData("text/html",
+                            '<a href="' + tiddlerDataURI.replace(/"/g,"&quot;") + '">' +
+                            titleString.replace(/[<>&]/g,function(c){return ({"<":"&lt;",">":"&gt;","&":"&amp;"})[c];}) +
+                            "</a>"
+                        );
+                    } catch(e) {}
+                }
+                // If browser is Chrome-like and has a touch-input device do NOT .setData
+                if(!($tw.browser.isMobileChrome)) {
+                    dataTransfer.setData("URL",tiddlerDataURI);
+                }
+                dataTransfer.setData("Text",titleString);
+                event.stopPropagation();
+            }
+            return false;
+        }},
+        {name: "dragend", handlerFunction: function(event) {
+            if((options.selector && $tw.utils.domMatchesSelector(event.target,options.selector)) || event.target === domNode) {
+                // Collect the tiddlers being dragged
+                var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
+                    dragFilter = options.dragFilterFn && options.dragFilterFn(),
+                    titles = dragTiddler ? [dragTiddler] : [],
+                    endActions = options.endActions,
+                    variables;
+                if(dragFilter) {
+                    titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
+                }
+                var titleString = $tw.utils.stringifyList(titles);
+                $tw.dragInProgress = null;
+                // Invoke drag-end actions if given
+                if(endActions !== undefined) {
+                    variables = $tw.utils.collectDOMVariables(domNode,null,event);
+                    variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
+                    variables["actionTiddler"] = titleString;
+                    options.widget.invokeActionString(endActions,options.widget,event,variables);
+                }
+                // Remove the dragging class on the element being dragged
+                $tw.utils.removeClass(domNode,"tc-dragging");
+                // Delete the drag image element
+                if(dragImage) {
+                    dragImage.parentNode.removeChild(dragImage);
+                    dragImage = null;
+                }
+            }
+            return false;
+        }}
+    ]);
 };
 
 exports.importDataTransfer = function(dataTransfer,fallbackTitle,callback) {
-	// Try each provided data type in turn
-	if($tw.log.IMPORT) {
-		console.log("Available data types:");
-		for(var type=0; type<dataTransfer.types.length; type++) {
-			console.log("type",dataTransfer.types[type],dataTransfer.getData(dataTransfer.types[type]));
-		}
-	}
-	for(var t=0; t<importDataTypes.length; t++) {
-		if(!$tw.browser.isIE || importDataTypes[t].IECompatible) {
-			// Get the data
-			var dataType = importDataTypes[t];
-			var data = dataTransfer.getData(dataType.type);
-			// Import the tiddlers in the data
-			if(data !== "" && data !== null) {
-				if($tw.log.IMPORT) {
-					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
-				}
-				var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
-				callback(tiddlerFields);
-				return;
-			}
-		}
-	}
+    // Try each provided data type in turn
+    if($tw.log.IMPORT) {
+        console.log("Available data types:");
+        for(var type=0; type<dataTransfer.types.length; type++) {
+            console.log("type",dataTransfer.types[type],dataTransfer.getData(dataTransfer.types[type]));
+        }
+    }
+    for(var t=0; t<importDataTypes.length; t++) {
+        if(!$tw.browser.isIE || importDataTypes[t].IECompatible) {
+            // Get the data
+            var dataType = importDataTypes[t];
+            var data = dataTransfer.getData(dataType.type);
+            // Import the tiddlers in the data
+            if(data !== "" && data !== null) {
+                if($tw.log.IMPORT) {
+                    console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
+                }
+                var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
+                callback(tiddlerFields);
+                return;
+            }
+        }
+    }
 };
 
 exports.importPaste = function(item,fallbackTitle,callback) {
-	// Try each provided data type in turn
-	for(var t=0; t<importDataTypes.length; t++) {
-		if(item.type === importDataTypes[t].type) {
-			// Get the data
-			var dataType = importDataTypes[t];
+    // Try each provided data type in turn
+    for(var t=0; t<importDataTypes.length; t++) {
+        if(item.type === importDataTypes[t].type) {
+            // Get the data
+            var dataType = importDataTypes[t];
 
-			item.getAsString(function(data){
-				if($tw.log.IMPORT) {
-					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
-				}
-				var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
-				callback(tiddlerFields);
-			});
-			return;
-		}
-	}
+            item.getAsString(function(data){
+                if($tw.log.IMPORT) {
+                    console.log("Importing data type '" + dataType.type + "', data: '" + data + "'");
+                }
+                var tiddlerFields = dataType.toTiddlerFieldsArray(data,fallbackTitle);
+                callback(tiddlerFields);
+            });
+            return;
+        }
+    }
 };
 
 exports.itemHasValidDataType = function(item) {
-	for(var t=0; t<importDataTypes.length; t++) {
-		if(!$tw.browser.isIE || importDataTypes[t].IECompatible) {
-			if(item.type === importDataTypes[t].type) {
-				return true;
-			}
-		}
-	}
-	return false;
+    for(var t=0; t<importDataTypes.length; t++) {
+        if(!$tw.browser.isIE || importDataTypes[t].IECompatible) {
+            if(item.type === importDataTypes[t].type) {
+                return true;
+            }
+        }
+    }
+    return false;
 };
 
 // Chromium on Linux delivers text/html to JS as UTF-16LE bytes interpreted as
 // Latin-1 (every other char is null). Detect that shape and decode before
 // pattern matching. Used by the text/html entry in importDataTypes below.
 function maybeDecodeUtf16Html(data) {
-	if(!data || data.length < 4) { return data; }
-	var sample = Math.min(data.length, 64), nulls = 0;
-	for(var i = 1; i < sample; i += 2) {
-		if(data.charCodeAt(i) === 0) { nulls++; }
-	}
-	if(nulls < Math.floor(sample / 2) * 0.8) { return data; }
-	if(typeof TextDecoder !== "undefined") {
-		try {
-			var bytes = new Uint8Array(data.length);
-			for(var k = 0; k < data.length; k++) { bytes[k] = data.charCodeAt(k) & 0xff; }
-			return new TextDecoder("utf-16le").decode(bytes).replace(/^﻿/, "");
-		} catch(e) {}
-	}
-	// ASCII-safe fallback: take every even-indexed char
-	var stripped = "";
-	for(var j = 0; j < data.length; j += 2) { stripped += data.charAt(j); }
-	return stripped;
+    if(!data || data.length < 4) { return data; }
+    var sample = Math.min(data.length, 64), nulls = 0;
+    for(var i = 1; i < sample; i += 2) {
+        if(data.charCodeAt(i) === 0) { nulls++; }
+    }
+    if(nulls < Math.floor(sample / 2) * 0.8) { return data; }
+    if(typeof TextDecoder !== "undefined") {
+        try {
+            var bytes = new Uint8Array(data.length);
+            for(var k = 0; k < data.length; k++) { bytes[k] = data.charCodeAt(k) & 0xff; }
+            return new TextDecoder("utf-16le").decode(bytes).replace(/^\uFEFF/, "");
+        } catch(e) {}
+    }
+    // ASCII-safe fallback: take every even-indexed char
+    var stripped = "";
+    for(var j = 0; j < data.length; j += 2) { stripped += data.charAt(j); }
+    return stripped;
 }
 
 var importDataTypes = [
-	{type: "text/vnd.tiddler", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
-		return parseJSONTiddlers(data,fallbackTitle);
-	}},
-	{type: "URL", IECompatible: true, toTiddlerFieldsArray: function(data,fallbackTitle) {
-		// Check for tiddler data URI
-		var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
-		if(match) {
-			return parseJSONTiddlers(match[1],fallbackTitle);
-		} else {
-			return [{title: fallbackTitle, text: data}]; // As URL string
-		}
-	}},
-	{type: "text/x-moz-url", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
-		// Check for tiddler data URI
-		var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
-		if(match) {
-			return parseJSONTiddlers(match[1],fallbackTitle);
-		} else {
-			return [{title: fallbackTitle, text: data}]; // As URL string
-		}
-	}},
-	{type: "text/html", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
-		// Decode Chromium's Linux UTF-16LE-as-Latin-1 quirk if present
-		data = maybeDecodeUtf16Html(data);
-		// Look for an embedded data:text/vnd.tiddler URI inside any href. Match on
-		// the still-URI-encoded form so JSON %22 doesn't truncate the capture. The
-		// stop-class is only " < > because encodeURIComponent always percent-encodes
-		// those three (so they reliably bound the href value), while characters it
-		// leaves literal (notably ' and ) ) must NOT terminate the match or the
-		// payload would be truncated and fail to parse.
-		var encMatch = data && data.match(/data:text\/vnd\.tiddler,([^"<>]+)/i);
-		if(encMatch) {
-			try {
-				return parseJSONTiddlers(decodeURIComponent(encMatch[1]),fallbackTitle);
-			} catch(e) {}
-		}
-		return [{title: fallbackTitle, text: data}];
-	}},
-	{type: "text/plain", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
-		return [{title: fallbackTitle, text: data}];
-	}},
-	{type: "Text", IECompatible: true, toTiddlerFieldsArray: function(data,fallbackTitle) {
-		return [{title: fallbackTitle, text: data}];
-	}},
-	{type: "text/uri-list", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
-		// Check for tiddler data URI
-		var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
-		if(match) {
-			return parseJSONTiddlers(match[1],fallbackTitle);
-		} else {
-			return [{title: fallbackTitle, text: data}]; // As URL string
-		}
-	}}
+    {type: "text/vnd.tiddler", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
+        return parseJSONTiddlers(data,fallbackTitle);
+    }},
+    {type: "URL", IECompatible: true, toTiddlerFieldsArray: function(data,fallbackTitle) {
+        // Check for tiddler data URI
+        var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
+        if(match) {
+            return parseJSONTiddlers(match[1],fallbackTitle);
+        } else {
+            return [{title: fallbackTitle, text: data}]; // As URL string
+        }
+    }},
+    {type: "text/x-moz-url", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
+        // Check for tiddler data URI
+        var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
+        if(match) {
+            return parseJSONTiddlers(match[1],fallbackTitle);
+        } else {
+            return [{title: fallbackTitle, text: data}]; // As URL string
+        }
+    }},
+    {type: "text/html", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
+        // Decode Chromium's Linux UTF-16LE-as-Latin-1 quirk if present
+        data = maybeDecodeUtf16Html(data);
+        // Look for an embedded data:text/vnd.tiddler URI inside any href. Match on
+        // the still-URI-encoded form so JSON %22 doesn't truncate the capture. The
+        // stop-class is only " < > because encodeURIComponent always percent-encodes
+        // those three (so they reliably bound the href value), while characters it
+        // leaves literal (notably ' and ) ) must NOT terminate the match or the
+        // payload would be truncated and fail to parse.
+        var encMatch = data && data.match(/data:text\/vnd\.tiddler,([^"<>]+)/i);
+        if(encMatch) {
+            try {
+                return parseJSONTiddlers(decodeURIComponent(encMatch[1]),fallbackTitle);
+            } catch(e) {}
+        }
+        return [{title: fallbackTitle, text: data}];
+    }},
+    {type: "text/plain", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
+        return [{title: fallbackTitle, text: data}];
+    }},
+    {type: "Text", IECompatible: true, toTiddlerFieldsArray: function(data,fallbackTitle) {
+        return [{title: fallbackTitle, text: data}];
+    }},
+    {type: "text/uri-list", IECompatible: false, toTiddlerFieldsArray: function(data,fallbackTitle) {
+        // Check for tiddler data URI
+        var match = $tw.utils.decodeURIComponentSafe(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
+        if(match) {
+            return parseJSONTiddlers(match[1],fallbackTitle);
+        } else {
+            return [{title: fallbackTitle, text: data}]; // As URL string
+        }
+    }}
 ];
 
 function parseJSONTiddlers(json,fallbackTitle) {
-	var data = $tw.utils.parseJSONSafe(json);
-	if(!$tw.utils.isArray(data)) {
-		data = [data];
-	}
-	data.forEach(function(fields) {
-		fields.title = fields.title || fallbackTitle;
-	});
-	return data;
+    var data = $tw.utils.parseJSONSafe(json);
+    if(!$tw.utils.isArray(data)) {
+        data = [data];
+    }
+    data.forEach(function(fields) {
+        fields.title = fields.title || fallbackTitle;
+    });
+    return data;
 };
 
 function dragEventContainsType(event,targetType) {
-	if(event.dataTransfer.types) {
-		for(var i=0; i<event.dataTransfer.types.length; i++) {
-			if(event.dataTransfer.types[i] === targetType) {
-				return true;
-			}
-		}
-	}
-	return false;
+    if(event.dataTransfer.types) {
+        for(var i=0; i<event.dataTransfer.types.length; i++) {
+            if(event.dataTransfer.types[i] === targetType) {
+                return true;
+            }
+        }
+    }
+    return false;
 };
 
 exports.dragEventContainsFiles = function(event) {
-	return (dragEventContainsType(event,"Files") && !dragEventContainsType(event,"text/plain"));
+    return (dragEventContainsType(event,"Files") && !dragEventContainsType(event,"text/plain"));
 };
 
 exports.dragEventContainsType = dragEventContainsType;

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -228,7 +228,7 @@ function maybeDecodeUtf16Html(data) {
 		try {
 			var bytes = new Uint8Array(data.length);
 			for(var k = 0; k < data.length; k++) { bytes[k] = data.charCodeAt(k) & 0xff; }
-			return new TextDecoder("utf-16le").decode(bytes).replace(/^\uFEFF/, "");
+			return new TextDecoder("utf-16le").decode(bytes).replace(/^﻿/, "");
 		} catch(e) {}
 	}
 	// ASCII-safe fallback: take every even-indexed char
@@ -263,10 +263,12 @@ var importDataTypes = [
 		// Decode Chromium's Linux UTF-16LE-as-Latin-1 quirk if present
 		data = maybeDecodeUtf16Html(data);
 		// Look for an embedded data:text/vnd.tiddler URI inside any href. Match on
-		// the still-URI-encoded form so JSON %22 doesn't truncate the capture; the
-		// stop-class excludes chars that cannot legally appear in a URI-encoded
-		// payload, so they reliably bound the match.
-		var encMatch = data && data.match(/data:text\/vnd\.tiddler,([^"'<>\s)]+)/i);
+		// the still-URI-encoded form so JSON %22 doesn't truncate the capture. The
+		// stop-class is only " < > because encodeURIComponent always percent-encodes
+		// those three (so they reliably bound the href value), while characters it
+		// leaves literal (notably ' and ) ) must NOT terminate the match or the
+		// payload would be truncated and fail to parse.
+		var encMatch = data && data.match(/data:text\/vnd\.tiddler,([^"<>]+)/i);
 		if(encMatch) {
 			try {
 				return parseJSONTiddlers(decodeURIComponent(encMatch[1]),fallbackTitle);
@@ -307,7 +309,6 @@ function dragEventContainsType(event,targetType) {
 		for(var i=0; i<event.dataTransfer.types.length; i++) {
 			if(event.dataTransfer.types[i] === targetType) {
 				return true;
-				break;
 			}
 		}
 	}

--- a/editions/tw5.com/tiddlers/releasenotes/5.4.1/#9874.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.1/#9874.tid
@@ -1,0 +1,11 @@
+title: $:/changenotes/5.4.1/#9874
+description: Drag&Drop cross-app drag fix - MIME type survival on Linux under Wayland
+tags: $:/tags/ChangeNote
+release: 5.4.1
+change-type: enhancement
+change-category: usability
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9874
+github-contributors: BurningTreeC
+
+Adds a cross-app drag fix especially designed for Linux on Wayland (the display server that is replacing X11)
+Emits the tiddler data as a text/html anchor on drag-out (the only MIME type that survives the sanitiser) and on import extracts the embedded data:text/vnd.tiddler URI from the anchor's href


### PR DESCRIPTION
# Use text/html with an embedded data URI so cross-app drags preserve tiddler data

## Problem

Dragging a tiddler from a TiddlyWiki page running in one application into a TiddlyWiki page running in another (e.g. a browser tab into an Electron/NW.js wiki host, or two different browsers) loses every tiddler field except the title on Linux.

Reproducer:

1. Open `https://tiddlywiki.com/` in Chrome (or Firefox) on Linux.
2. Drag any draggable tiddler tile — e.g. a plugin from the plugin library — into a TiddlyWiki running in a *different* application.
3. The receiving wiki creates an "Untitled" tiddler containing raw HTML (or just the title as text). The `text/vnd.tiddler` JSON payload, the `text/x-moz-url` data URI, and the Chrome legacy `"URL"` slot are all gone.

## Root cause

Cross-app drag-and-drop on Linux goes through OS drag protocols (XDND on X11, `wl_data_device` on Wayland). Chromium's outgoing drag-data sanitiser strips everything that isn't on a narrow standard allowlist before the payload leaves the source process. The receiving app sees only the allowed types.

Empirical testing on Wayland and XWayland, with both Chrome and Firefox as sources, dragging into a separate Chromium-based receiver:

| MIME type set by `makeDraggable` | Survives cross-app drag on Linux |
|---|---|
| `text/plain` | ✅ |
| `Text` (legacy alias) | ✅ |
| `text/html` | ✅ |
| `text/vnd.tiddler` | ❌ |
| `text/x-moz-url` | ❌ |
| `URL` (Chrome legacy alias for `text/uri-list`) | ❌ |
| `text/uri-list` (explicitly set) | ❌ |
| `application/json`, `text/json`, `application/vnd.tiddler+json` | ❌ |

`text/html` is the only rich channel that reliably survives, because file managers depend on it for link drops — stripping it would break basic system functionality.

## Fix

Additionally publish the existing `data:text/vnd.tiddler,…` payload inside a `text/html` value, as the `href` of an anchor whose visible text is the tiddler title. The receiver-side `text/html` entry in `importDataTypes` is updated to look for the embedded URI and unwrap it. Both changes are in this same file.

Two Linux-specific quirks had to be handled in the receiver:

- **UTF-16LE encoding.** Chromium on Linux delivers `text/html` to JavaScript as UTF-16LE bytes interpreted as Latin-1 — every "real" character is followed by `null`. Decoded via `TextDecoder("utf-16le")` (with an ASCII-safe fallback that takes every even-indexed character).
- **URI extraction must run on the URI-encoded form.** `decodeURIComponent`-ing the whole HTML first turns `%22` (encoded `"`) back into a literal `"`, which then prematurely terminates the data URI regex and captures only `{`. The regex therefore runs on the still-encoded form; the stop class excludes characters that cannot legally appear in URI-encoded content (`"'<> )`), so it reliably bounds the capture.

Also hoists the encoded data URI into a local variable so `encodeURIComponent` runs once instead of three times. Pure cleanup, no semantic change.

## Compatibility

Strictly additive on both sides:

- **Old receivers.** They consume the same `text/vnd.tiddler` / `URL` / `text/x-moz-url` slots as before and ignore the new `text/html` payload. No behaviour change for in-process drags, same-app drags, or any existing receiver.
- **New receivers, old sources.** No embedded `data:text/vnd.tiddler` URI is present in the HTML, so the importer falls through to the existing `[{title, text: data}]` behaviour. No regression for HTML drops from non-TW sources.
- **New receivers, new sources.** Cross-app drag now preserves the full tiddler payload.
- **`setData("text/html", …)` is wrapped in try/catch** in case any rare engine refuses the MIME type.
- **IE branch unchanged.** The new `setData` call sits inside the existing `!$tw.browser.isIE` guard, alongside the other modern MIME-type calls.
- **Mobile Chrome unchanged.** Only the `URL`-aliased call is gated by `!isMobileChrome`; the new `text/html` is in the same IE-only-excluded block as `text/x-moz-url`.

## Tests

No automated test — cross-process drag isn't exercised by the existing harness. Verified manually with a standalone test page that sets only `text/html` and `text/plain`:

- [x] Chrome → external Chromium-based receiver (Linux Wayland): `$:/Import` opens with the full tiddler including `plugin-type: plugin` and shadow tiddlers. Was: title only.
- [x] Firefox → external Chromium-based receiver (Linux X11/XWayland): same.
- [x] In-process drag within tiddlywiki.com: unchanged (the rich `text/vnd.tiddler` is still preferred when it survives, which it always does in-process).
- [x] Drag to a non-TW receiver (text editor, file manager): still gets a sensible fallback — the title as text, the anchor as a clickable link.
- [x] Drag from a TW page where the HTML payload's `data:` URI is malformed or absent: receiver falls through to existing "HTML as text" behaviour.

## Files changed

`core/modules/utils/dom/dragndrop.js` only — both the source-side `makeDraggable` change and the receiver-side `importDataTypes` change live in this file.
