### PR TITLE
Refactor class attributes for edit field wrapper

### DIFF
--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -108,10 +108,10 @@ tags: $:/tags/EditTemplate
 			storeTitle=<<newFieldNameInputTiddler>>
 			searchListState=<<newFieldNameSelectionTiddler>>
 		>
-			<div class="tc-edit-field-add-name-wrapper">
+			<div class=`tc-edit-field-add-name-wrapper ${ [<newFieldNameTiddler>get[text]] :intersection[<storyTiddler>fields[]] :then[[tc-edit-field-exists]] }$`>
 				<$transclude $variable="keyboard-driven-input"
 					cancelPopups="yes"
-					class=`tc-edit-texteditor tc-popup-handle ${ [<newFieldNameTiddler>get[text]] :intersection[<storyTiddler>fields[]] :then[[tc-edit-field-exists]] }$`
+					class="tc-edit-texteditor tc-popup-handle"
 					configTiddlerFilter="[[$:/config/EditMode/fieldname-filter]]"
 					default=""
 					focus={{{ [{!!draft.of}is[tiddler]then{$:/config/AutoFocusEdit}match[fields]then[true]] :else[{$:/config/AutoFocus}match[fields]then[true]] :else[[false]] }}}

--- a/editions/tw5.com/tiddlers/releasenotes/5.4.1/#9879.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.1/#9879.tid
@@ -1,0 +1,10 @@
+title: $:/changenotes/5.4.1/#9879
+description: Fix field-name inputs re-render
+tags: $:/tags/ChangeNote
+release: 5.4.1
+change-type: bugfix
+change-category: usability
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9879
+github-contributors: BurningTreeC
+
+Fixes the field-name input re-rendering and therefor loosing focus when inserting a field-name that already exists


### PR DESCRIPTION
The problem here is, that if we have an existing field with name - say - "field1" and we want to add a field with name "field12345", at the moment we insert "field1" for the new field-name, the edit-text widget re-renders because its classes change. The `tc-edit-field-exists` class must go outside to the container div.