### PR TITLE
PageScroller: Refactor scrollTo for instant behavior in scrolling

### DIFF
--- a/core/modules/utils/dom/scroller.js
+++ b/core/modules/utils/dom/scroller.js
@@ -115,12 +115,7 @@ PageScroller.prototype.scrollIntoView = function(element,callback,options) {
 				bounds = getBounds(),
 				endX = getEndPos(bounds.left,bounds.width,scrollPosition.x,srcWindow.innerWidth),
 				endY = getEndPos(bounds.top,bounds.height,scrollPosition.y,srcWindow.innerHeight);
-			// Use behavior:"instant" so that this animation's per-frame position
-			// updates are applied immediately and are NOT re-animated by a CSS
-			// `scroll-behavior: smooth` on the scrolling element (which would make
-			// the page lag behind and stutter). The easing here (slowInSlowOut over
-			// `duration`) provides the smoothness; CSS smooth still applies to other
-			// scrolls such as in-document anchor jumps.
+			// Use 'instant' to prevent conflicts with CSS scroll-behavior: smooth
 			srcWindow.scrollTo({
 				left: scrollPosition.x + (endX - scrollPosition.x) * t,
 				top: scrollPosition.y + (endY - scrollPosition.y) * t,

--- a/core/modules/utils/dom/scroller.js
+++ b/core/modules/utils/dom/scroller.js
@@ -12,6 +12,41 @@ Module that creates a $tw.utils.Scroller object prototype that manages scrolling
 /*
 Event handler for when the `tm-scroll` event hits the document body
 */
+/*
+Feature-detect (once, cached) whether scrollTo() honours an options object.
+*/
+var scrollOptionsSupported;
+function supportsScrollOptions(srcWindow) {
+	if(scrollOptionsSupported === undefined) {
+		scrollOptionsSupported = false;
+		try {
+			var doc = (srcWindow && srcWindow.document) || document,
+				probe = doc.createElement("div");
+			probe.scrollTo({top: 0, left: 0, get behavior() { scrollOptionsSupported = true; return "instant"; }});
+		} catch(e) {
+			scrollOptionsSupported = false;
+		}
+	}
+	return scrollOptionsSupported;
+}
+
+/*
+Detect (once, cached) whether we're running on Firefox.
+*/
+var browserIsFirefox;
+function isFirefox(srcWindow) {
+	if(browserIsFirefox === undefined) {
+		browserIsFirefox = false;
+		try {
+			var nav = (srcWindow && srcWindow.navigator) || (typeof navigator !== "undefined" ? navigator : null);
+			browserIsFirefox = !!nav && /firefox/i.test(nav.userAgent);
+		} catch(e) {
+			browserIsFirefox = false;
+		}
+	}
+	return browserIsFirefox;
+}
+
 var PageScroller = function() {
 	this.idRequestFrame = null;
 	this.requestAnimationFrame = window.requestAnimationFrame ||
@@ -115,13 +150,14 @@ PageScroller.prototype.scrollIntoView = function(element,callback,options) {
 				bounds = getBounds(),
 				endX = getEndPos(bounds.left,bounds.width,scrollPosition.x,srcWindow.innerWidth),
 				endY = getEndPos(bounds.top,bounds.height,scrollPosition.y,srcWindow.innerHeight);
-			// Use 'instant' to prevent conflicts with CSS scroll-behavior: smooth
-			srcWindow.scrollTo({
-				left: scrollPosition.x + (endX - scrollPosition.x) * t,
-				top: scrollPosition.y + (endY - scrollPosition.y) * t,
-				behavior: "instant"
-				
-			});
+			// Apply each frame's position instantly, except on Firefox or engines without scrollTo() options.
+			var newX = scrollPosition.x + (endX - scrollPosition.x) * t,
+				newY = scrollPosition.y + (endY - scrollPosition.y) * t;
+			if(supportsScrollOptions(srcWindow) && !isFirefox(srcWindow)) {
+				srcWindow.scrollTo({left: newX, top: newY, behavior: "instant"});
+			} else {
+				srcWindow.scrollTo(newX,newY);
+			}
 			if(t < 1) {
 				self.idRequestFrame = self.requestAnimationFrame.call(srcWindow,drawFrame);
 			}

--- a/core/modules/utils/dom/scroller.js
+++ b/core/modules/utils/dom/scroller.js
@@ -115,7 +115,18 @@ PageScroller.prototype.scrollIntoView = function(element,callback,options) {
 				bounds = getBounds(),
 				endX = getEndPos(bounds.left,bounds.width,scrollPosition.x,srcWindow.innerWidth),
 				endY = getEndPos(bounds.top,bounds.height,scrollPosition.y,srcWindow.innerHeight);
-			srcWindow.scrollTo(scrollPosition.x + (endX - scrollPosition.x) * t,scrollPosition.y + (endY - scrollPosition.y) * t);
+			// Use behavior:"instant" so that this animation's per-frame position
+			// updates are applied immediately and are NOT re-animated by a CSS
+			// `scroll-behavior: smooth` on the scrolling element (which would make
+			// the page lag behind and stutter). The easing here (slowInSlowOut over
+			// `duration`) provides the smoothness; CSS smooth still applies to other
+			// scrolls such as in-document anchor jumps.
+			srcWindow.scrollTo({
+				left: scrollPosition.x + (endX - scrollPosition.x) * t,
+				top: scrollPosition.y + (endY - scrollPosition.y) * t,
+				behavior: "instant"
+				
+			});
 			if(t < 1) {
 				self.idRequestFrame = self.requestAnimationFrame.call(srcWindow,drawFrame);
 			}

--- a/editions/tw5.com/tiddlers/releasenotes/5.4.1/#9888.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.1/#9888.tid
@@ -1,0 +1,10 @@
+title: $:/changenotes/5.4.1/#9888
+description: Make PageScroller scroll instantly
+tags: $:/tags/ChangeNote
+release: 5.4.1
+change-type: enhancement
+change-category: usability
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9888
+github-contributors: BurningTreeC
+
+Fixes a scrolling issue where `scroll-behavior` is set to `smooth` on the `<html>` element in Chromium browsers (Chromium/Chrome/Edge...)


### PR DESCRIPTION
Updated scrollTo method to use an object with behavior set to 'instant' for smoother animations. This accomodates for CSS that sets `scroll-behavior: smooth` on the `<html>` element, which would fight the scrolling behavior of the pageScroller and cause visual irritation.

To reproduce the buggy behavior:

- Use Chrome/Chromium browser
- Go to tiddlywiki.com
- Open the developer console (F12) and click on "Inspektor"
- Select the `<html>` element
- Give it the inline style `scroll-behavior: smooth;`
- Now in the sidebar's "Open" tab, click on tiddler links to scroll around

Then do the same on the preview build of this PR