### PR TITLE
Move background action console.log inside platforms check

### DIFF
--- a/core/modules/background-actions.js
+++ b/core/modules/background-actions.js
@@ -78,7 +78,6 @@ class BackgroundActionTracker {
 			fnProcess: (changes) => {
 				if(this.hasChanged) {
 					this.hasChanged = false;
-					console.log("Processing background action", this.title);
 					const tiddler = this.wiki.getTiddler(this.title);
 					let doActions = true;
 					if(tiddler && tiddler.fields.platforms) {
@@ -89,6 +88,7 @@ class BackgroundActionTracker {
 						}
 					}
 					if(doActions) {
+						console.log("Processing background action", this.title);
 						this.wiki.invokeActionString(
 							this.actions,
 							null,

--- a/editions/tw5.com/tiddlers/releasenotes/5.4.1/#9891.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.1/#9891.tid
@@ -1,0 +1,10 @@
+title: $:/changenotes/5.4.1/#9891
+description: Move background action log inside platforms check to avoid spurious server-side logs
+release: 5.4.1
+tags: $:/tags/ChangeNote
+change-type: bugfix
+change-category: core
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9891
+github-contributors: linonetwo
+
+Background actions with `platforms: browser` were logging "Processing background action" on the Node.js server even though the action itself was correctly skipped. The `console.log` is now moved inside the `if(doActions)` block so it only prints when the action actually executes on the matching platform.

--- a/editions/tw5.com/tiddlers/releasenotes/5.4.1/#9891.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.1/#9891.tid
@@ -7,4 +7,4 @@ change-category: core
 github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9891
 github-contributors: linonetwo
 
-Background actions with `platforms: browser` were logging "Processing background action" on the Node.js server even though the action itself was correctly skipped. The `console.log` is now moved inside the `if(doActions)` block so it only prints when the action actually executes on the matching platform.
+Background actions with `platforms: browser` were logging on the server even though execution was correctly skipped. The log now only prints when the action actually runs.

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9891.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9891.tid
@@ -1,6 +1,6 @@
-title: $:/changenotes/5.4.1/#9891
+title: $:/changenotes/5.5.0/#9891
 description: Move background action log inside platforms check to avoid spurious server-side logs
-release: 5.4.1
+release: 5.5.0
 tags: $:/tags/ChangeNote
 change-type: bugfix
 change-category: core

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9891.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9891.tid
@@ -3,7 +3,7 @@ description: Move background action log inside platforms check to avoid spurious
 release: 5.5.0
 tags: $:/tags/ChangeNote
 change-type: bugfix
-change-category: core
+change-category: internal
 github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9891
 github-contributors: linonetwo
 


### PR DESCRIPTION
I found this cosole log very annoying, because I already set it to only run on the browser, but it   still create a lot of log in the server side.

Now, I make it only log when it's going to really execute it.

