### PR TITLE
[DOCS] Fix survey image link

### DIFF
--- a/editions/tw5.com/tiddlers/community/Community Survey 2025.tid
+++ b/editions/tw5.com/tiddlers/community/Community Survey 2025.tid
@@ -1,9 +1,9 @@
-title: Community Survey 2025
 created: 20250708130030654
 modified: 20250826162904085
+title: Community Survey 2025
 
 <div style.float="right" style.padding-left="1em">
-<$image source="Community Survey 2025" alt="Shaping the future of TiddlyWiki with the Community Survey 2025" width="280"/>
+<$image source="Community Survey 2025 Image" alt="Shaping the future of TiddlyWiki with the Community Survey 2025" width="280"/>
 </div>
 
 The core developers work hard year by year to continuously improve ~TiddlyWiki. Part of the satisfaction is that we are not just building software for ourselves, we’re serving the needs of a wider community of users.


### PR DESCRIPTION
Survey image was not appearing due to incorrect link. Now fixed. 

---
<small>Submitted using https://edit.tiddlywiki.com/.</small>