### PR TITLE
Fix serializing inline code containing backticks

### DIFF
--- a/editions/test/tiddlers/tests/data/serialize/CodeInline.tid
+++ b/editions/test/tiddlers/tests/data/serialize/CodeInline.tid
@@ -1,0 +1,5 @@
+tags: $:/tags/wikitext-serialize-test-spec
+title: Serialize/CodeInline
+type: text/vnd.tiddlywiki
+
+Simple `code` and ``a`b`` and ``a `quoted` b`` and ```leading`` and empty ```` end

--- a/plugins/tiddlywiki/wikitext-serialize/rules/codeinline.js
+++ b/plugins/tiddlywiki/wikitext-serialize/rules/codeinline.js
@@ -11,6 +11,6 @@ exports.name = "codeinline";
 exports.serialize = function(tree,serialize) {
 	var text = serialize(tree.children),
 		// Backticks inside and empty text need double delimiters, eg: ``a`b``
-		delimiter = (text === "" || text.indexOf("`") !== -1) ? "``" : "`";
+		delimiter = (text === "" || text.includes("`")) ? "``" : "`";
 	return delimiter + text + delimiter;
 };

--- a/plugins/tiddlywiki/wikitext-serialize/rules/codeinline.js
+++ b/plugins/tiddlywiki/wikitext-serialize/rules/codeinline.js
@@ -9,5 +9,8 @@ module-type: wikiruleserializer
 exports.name = "codeinline";
 
 exports.serialize = function(tree,serialize) {
-	return "`" + serialize(tree.children) + "`";
+	var text = serialize(tree.children),
+		// Backticks inside and empty text need double delimiters, eg: ``a`b``
+		delimiter = (text === "" || text.indexOf("`") !== -1) ? "``" : "`";
+	return delimiter + text + delimiter;
 };


### PR DESCRIPTION
This PR fixes #9898 and contains a new test 

- see: #9898

This PR: 

* Usees double backtick delimiters when the code text contains a backtick. Previously ``a`b`` came back as `a`b`, which reparses as two code runs with changed content.
* Serialize an empty code run with double delimiters too, because a bare `` reparses as an opening delimiter and swallows the following siblings.
* Add the round trip fixture Serialize/CodeInline covering the issue case, content with a leading backtick, and an empty code run.