### PR TITLE
Add performance test harness

### DIFF
--- a/editions/perftest-realcontent/tiddlers/tests/real-content-corpus.js
+++ b/editions/perftest-realcontent/tiddlers/tests/real-content-corpus.js
@@ -1,0 +1,94 @@
+/*\
+title: $:/perf/tests/real-content-corpus.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Parses and renders the real included wiki corpus, measuring aggregate cost and counting recovery diagnostics so the resilience work reads against real content.
+
+\*/
+
+"use strict";
+
+exports.name = "real-content-corpus";
+exports.platform = "node";
+exports.warmup = 1;
+exports.iterations = 3;
+
+exports.run = function(context) {
+	var wiki = context.wiki,
+		titles = collectWikitextTitles(wiki),
+		measurements = [];
+	measurements.push(measureParse(context,titles));
+	measurements.push(measureRender(context,titles));
+	return measurements;
+};
+
+function collectWikitextTitles(wiki) {
+	var titles = [];
+	wiki.each(function(tiddler,title) {
+		var type = tiddler.fields.type;
+		if(type && type !== "text/vnd.tiddlywiki") {
+			return;
+		}
+		if(typeof tiddler.fields.text !== "string" || tiddler.fields.text === "") {
+			return;
+		}
+		titles.push(title);
+	});
+	return titles;
+}
+
+function measureParse(context,titles) {
+	return context.measure("corpus-parse",function() {
+		var topLevelNodes = 0,
+			diagnosticCount = 0,
+			tiddlersWithDiagnostics = 0;
+		for(var i = 0; i < titles.length; i++) {
+			var parser = context.wiki.parseText("text/vnd.tiddlywiki",context.wiki.getTiddlerText(titles[i]));
+			topLevelNodes += parser.tree.length;
+			if(parser.diagnostics && parser.diagnostics.length > 0) {
+				diagnosticCount += parser.diagnostics.length;
+				tiddlersWithDiagnostics++;
+			}
+		}
+		return {
+			mode: "main",
+			phase: "parse",
+			taxonomy: "real-content",
+			scenarioId: "real-content-parse",
+			scenarioDescription: "Parse every wikitext tiddler in the real corpus and count recovery diagnostics.",
+			fixtureName: "real-content-corpus",
+			corpusSize: titles.length,
+			topLevelNodes: topLevelNodes,
+			diagnosticCount: diagnosticCount,
+			tiddlersWithDiagnostics: tiddlersWithDiagnostics
+		};
+	});
+}
+
+function measureRender(context,titles) {
+	return context.measure("corpus-render",function() {
+		var domNodeCount = 0,
+			renderFailures = 0;
+		for(var i = 0; i < titles.length; i++) {
+			try {
+				var rendered = context.renderText(context.wiki.getTiddlerText(titles[i]));
+				domNodeCount += context.countDomNodes(rendered.wrapper);
+				rendered.widgetNode.destroy();
+			} catch(error) {
+				renderFailures++;
+			}
+		}
+		return {
+			mode: "main",
+			phase: "render",
+			taxonomy: "real-content",
+			scenarioId: "real-content-render",
+			scenarioDescription: "Render every wikitext tiddler in the real corpus, counting any that throw.",
+			fixtureName: "real-content-corpus",
+			corpusSize: titles.length,
+			domNodeCount: domNodeCount,
+			renderFailures: renderFailures
+		};
+	});
+}

--- a/editions/perftest-realcontent/tiddlywiki.info
+++ b/editions/perftest-realcontent/tiddlywiki.info
@@ -1,0 +1,11 @@
+{
+	"description": "TiddlyWiki performance tests over the real tw5.com content corpus",
+	"includeWikis": ["../tw5.com"],
+	"plugins": [
+		"tiddlywiki/perftest"
+	],
+	"themes": [
+		"tiddlywiki/vanilla",
+		"tiddlywiki/snowwhite"
+	]
+}

--- a/editions/perftest/playwright.config.js
+++ b/editions/perftest/playwright.config.js
@@ -1,0 +1,25 @@
+const { defineConfig, devices } = require("@playwright/test");
+
+module.exports = defineConfig({
+	testDir: __dirname,
+	testMatch: "playwright.spec.js",
+	timeout: 60000,
+	retries: 0,
+	reporter: "html",
+	use: {
+		screenshot: {
+			mode: "only-on-failure",
+			fullPage: true
+		},
+		actionTimeout: 15000
+	},
+	expect: {
+		timeout: 20000
+	},
+	projects: [
+		{
+			name: "chromium",
+			use: Object.assign({},devices["Desktop Chrome"])
+		}
+	]
+});

--- a/editions/perftest/playwright.spec.js
+++ b/editions/perftest/playwright.spec.js
@@ -1,0 +1,49 @@
+const { test, expect } = require("@playwright/test");
+const {resolve} = require("path");
+
+const indexPath = resolve(__dirname, "output", "perftest.html");
+const crossPlatformIndexPath = indexPath.replace(/^\/+/, "");
+
+test("performance tests complete", async ({ page }, testInfo) => {
+	const timeout = 1000 * 60;
+	test.setTimeout(timeout);
+
+	await page.goto(`file:///${crossPlatformIndexPath}`);
+
+	await expect(page.locator(".tc-site-title")).toHaveText("TiddlyWiki5 Performance Tests");
+	await expect(page.locator(".tw-perf-overall-result")).toBeVisible({timeout});
+	await expect(page.locator(".tw-perf-overall-result.tw-perf-failed")).not.toBeVisible();
+	await expect(page.locator(".tw-perf-overall-result.tw-perf-passed")).toBeVisible();
+
+	const resultsText = await page.locator("#tw-perf-results").textContent();
+	const results = JSON.parse(resultsText);
+	const measurementRows = results.benchmarks.filter((benchmark) => benchmark.rowType === "measurement");
+	const phaseRows = results.benchmarks.filter((benchmark) => benchmark.rowType === "phase");
+	const labels = measurementRows.map((benchmark) => benchmark.label);
+	const phases = phaseRows.map((benchmark) => benchmark.phase);
+	const draftGradient = measurementRows.find((benchmark) => benchmark.scenarioId === "draft-gradient-preview");
+	expect(labels).toContain("initial-render");
+	expect(labels).toContain("refresh-unrelated-change");
+	expect(labels).toContain("refresh-relevant-change");
+	expect(phases).toContain("render");
+	expect(phases).toContain("refresh");
+	// sampleCount must be positive; exact value depends on harness defaultIterations
+	expect(measurementRows[0].sampleCount).toBeGreaterThan(0);
+	expect(measurementRows[0].p75).not.toBeNull();
+	expect(measurementRows[0].p90).not.toBeNull();
+	expect(measurementRows[0].p95).not.toBeNull();
+	expect(measurementRows[0].p99).not.toBeNull();
+	expect(measurementRows[0].standardDeviation).not.toBeNull();
+	expect(draftGradient).toBeDefined();
+	expect(draftGradient.phase).toBe("live-preview");
+	expect(draftGradient.fixtureName).toBe("draft-gradient");
+	expect(draftGradient.gradientCaseCount).toBe(4);
+	expect(draftGradient.verifiedPreview).toBe(true);
+	await testInfo.attach("perftest-browser-results.json",{
+		body: JSON.stringify({
+			runName: "browser-" + testInfo.project.name + "-" + Date.now(),
+			results
+		},null,2),
+		contentType: "application/json"
+	});
+});

--- a/editions/perftest/tiddlers/DefaultTiddlers.tid
+++ b/editions/perftest/tiddlers/DefaultTiddlers.tid
@@ -1,0 +1,3 @@
+title: $:/DefaultTiddlers
+
+Performance Test Results

--- a/editions/perftest/tiddlers/Performance Findings.tid
+++ b/editions/perftest/tiddlers/Performance Findings.tid
@@ -1,0 +1,56 @@
+title: Performance Findings
+type: text/vnd.tiddlywiki
+
+! TiddlyWiki performance findings
+
+A snapshot from the performance test harness. These numbers state their own reliability plainly: each row reports a trust flag, and a row marked ''noisy'' cannot support a claim smaller than its own spread. Absolute numbers differ per machine; the shape of the findings travels.
+
+!! Environment
+
+|!Field |!Value |
+|TiddlyWiki |5.5.0-prerelease |
+|Runtime |Node.js v24.15.0, linux/x64 |
+|Iterations |40 measured, after warmup |
+|Captured |2026-07-11 |
+
+Reproduce, including TiddlyWiki's own `$tw.perf` instrumentation:
+
+```
+tiddlywiki ./editions/perftest --output ./output --perf output=results.json iterations=40 instrument=yes
+```
+
+!! The filter carries the cost, not the widgets
+
+A filter-heavy list of 2000 tiddlers renders in ''66 ms''. TiddlyWiki's own `$tw.perf` instrument shows the filter alone takes ''61 ms'' per evaluation, about ''92%'' of that render. A slow filtered list owes its cost to the filter, not the rendering. Keep the filter cheap and put indexed operators first.
+
+!! An indexed lookup beats a scan by an order of magnitude
+
+For the same 500 results, an indexed tag lookup and a full text search scan differ by roughly 15 times. Reach for `[tag[...]]` or the field indexer before `[search[...]]` on a large wiki.
+
+|!Query |!Median |!Results |!Note |
+|`[tag[...]]` indexed lookup |0.46 ms |500 |O(1) index hit |
+|`[search[...]]` scan, same set |6.75 ms |500 |O(n) scan of every tiddler |
+|`[all[tiddlers]search[word]]` |8.84 ms |3753 |typical keystroke search over 5000 |
+
+Search skips the index: every query scans every tiddler's title, tags and text, so it resists caching. This marks the per-keystroke cost users hit on large wikis.
+
+!! Render costs more than parse
+
+Parsing structured wikitext into a parse tree takes ''0.32 ms''; rendering that tree into a widget tree and DOM takes ''1.48 ms'', about ''4.6 times'' as much. The engine spends most in the render path, so widget and refresh work matters more than parse speed.
+
+|!Path |!Median |!Trust |
+|filter-heavy list render (2000 tiddlers) |66 ms |stable |
+|medium child walk render |20 ms |stable |
+|deep transclusion render (depth 16) |15 ms |noisy |
+|structured render (parse tree to widgets and DOM) |1.48 ms |noisy |
+|structured parse (text to parse tree) |0.32 ms |stable |
+
+!! Reading a row honestly
+
+Every measurement carries its spread and a resolvable-effect floor, the smallest change it could detect. The harness marks ''noisy'' any row whose floor swamps small effects. In this run 25 of 33 rows read noisy, mostly sub-millisecond operations where a few microseconds of jitter dominate. Quote the stable rows; treat the noisy ones as order-of-magnitude only.
+
+!! Comparing two versions
+
+Never read one whole run against another: between-session drift (machine load, thermal state) routinely exceeds the effect being hunted. Acquire runs interleaved in one session and use `scripts/perf/compare-runs.js <before-dir> <after-dir>`, which pairs them and reads ''inconclusive'' when the 95% confidence interval straddles zero, rather than reporting a number the data cannot support.
+
+To confirm a function genuinely runs hot before optimising it, count its calls with `scripts/perf/call-census.js`. A CPU sampling profiler mis-attributes time; an exact count catches the ghost.

--- a/editions/perftest/tiddlers/Performance Test Filter.tid
+++ b/editions/perftest/tiddlers/Performance Test Filter.tid
@@ -1,0 +1,3 @@
+title: $:/config/Performance/TestFilter
+
+[all[tiddlers+shadows]type[application/javascript]tag[$:/tags/performance-test]]

--- a/editions/perftest/tiddlers/Performance Test Results.tid
+++ b/editions/perftest/tiddlers/Performance Test Results.tid
@@ -1,0 +1,3 @@
+title: Performance Test Results
+
+The performance test runner appends results to this generated HTML page.

--- a/editions/perftest/tiddlers/SiteTitle.tid
+++ b/editions/perftest/tiddlers/SiteTitle.tid
@@ -1,0 +1,3 @@
+title: $:/SiteTitle
+
+TiddlyWiki5 Performance Tests

--- a/editions/perftest/tiddlers/tests/bulk-sync-burst.js
+++ b/editions/perftest/tiddlers/tests/bulk-sync-burst.js
@@ -1,0 +1,147 @@
+/*\
+title: $:/perf/tests/bulk-sync-burst.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Measures render and refresh behavior during bursty sync-like updates.
+
+\*/
+"use strict";
+
+exports.name = "bulk-sync-burst";
+exports.platform = "both";
+
+exports.run = function(context) {
+	return runScenario(context);
+};
+
+function runScenario(context) {
+	var wiki = context.wiki,
+		basePrefix = "$:/temp/perftest/bulk-sync/",
+		itemPrefix = basePrefix + "item-",
+		backgroundPrefix = basePrefix + "background-",
+		renderTitle = basePrefix + "source",
+		itemCount = 1000,
+		visibleCount = 150,
+		burstSize = 120,
+		renderMeasurement,
+		unrelatedMeasurement,
+		relatedMeasurement,
+		rendered,
+		unrelatedCounter = 0,
+		relatedCounter = 0;
+
+	seedItems(wiki,itemPrefix,backgroundPrefix,itemCount,burstSize);
+	wiki.addTiddler({title: renderTitle, text: makeSourceText(itemPrefix,visibleCount)});
+
+	renderMeasurement = context.measure("initial-render",function() {
+		rendered = context.renderText("{{" + renderTitle + "}}\n");
+		return {
+			phase: "render",
+			taxonomy: "render",
+			scenarioId: "bulk-sync-burst-initial-render",
+			scenarioTags: ["sync","burst","first-paint"],
+			scenarioChangeRelation: "none",
+			scenarioDescription: "Open a large list before a sync-like burst of updates.",
+			fixtureName: "bulk-sync-burst",
+			fixtureItemCount: itemCount,
+			burstSize: burstSize,
+			petName: "bulk sync burst",
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	unrelatedMeasurement = context.measure("refresh-unrelated-change",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		for(var i = 0; i < burstSize; i++) {
+			wiki.addTiddler({title: backgroundPrefix + pad(i,4), text: "bg-" + unrelatedCounter + "-" + i});
+		}
+		unrelatedCounter++;
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "refresh",
+			scenarioId: "bulk-sync-burst-refresh-unrelated-change",
+			scenarioTags: ["sync","burst","non-visible-change"],
+			scenarioChangeRelation: "unrelated",
+			scenarioDescription: "Apply a burst of background updates that do not touch visible rows.",
+			fixtureName: "bulk-sync-burst",
+			fixtureItemCount: itemCount,
+			burstSize: burstSize,
+			petName: "bulk sync burst",
+			changedTiddlerCount: burstSize,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	relatedMeasurement = context.measure("refresh-relevant-change",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		for(var i = 0; i < burstSize; i++) {
+			wiki.addTiddler({title: itemPrefix + pad(i,4), text: "visible-" + relatedCounter + "-" + i, tags: ["project-a","status-open"]});
+		}
+		relatedCounter++;
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "refresh",
+			scenarioId: "bulk-sync-burst-refresh-relevant-change",
+			scenarioTags: ["sync","burst","visible-content-change"],
+			scenarioChangeRelation: "relevant",
+			scenarioDescription: "Apply a burst of updates that directly touch visible rows.",
+			fixtureName: "bulk-sync-burst",
+			fixtureItemCount: itemCount,
+			burstSize: burstSize,
+			petName: "bulk sync burst",
+			changedTiddlerCount: burstSize,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	rendered.widgetNode.destroy();
+	cleanupItems(wiki,itemPrefix,backgroundPrefix,itemCount,burstSize,renderTitle);
+	wiki.clearTiddlerEventQueue();
+	return [renderMeasurement,unrelatedMeasurement,relatedMeasurement];
+}
+
+function seedItems(wiki,itemPrefix,backgroundPrefix,itemCount,burstSize) {
+	for(var i = 0; i < itemCount; i++) {
+		wiki.addTiddler({
+			title: itemPrefix + pad(i,4),
+			text: "Item " + i + " baseline content for sync burst workloads.",
+			tags: ["project-a","status-open"]
+		});
+	}
+	for(var j = 0; j < burstSize; j++) {
+		wiki.addTiddler({title: backgroundPrefix + pad(j,4), text: "background baseline " + j});
+	}
+}
+
+function cleanupItems(wiki,itemPrefix,backgroundPrefix,itemCount,burstSize,renderTitle) {
+	wiki.deleteTiddler(renderTitle);
+	for(var i = 0; i < itemCount; i++) {
+		wiki.deleteTiddler(itemPrefix + pad(i,4));
+	}
+	for(var j = 0; j < burstSize; j++) {
+		wiki.deleteTiddler(backgroundPrefix + pad(j,4));
+	}
+}
+
+function makeSourceText(itemPrefix,visibleCount) {
+	return [
+		"<$list filter=\"[prefix[" + itemPrefix + "]] +[sort[]] +[limit[" + visibleCount + "]]\">",
+		"<div class=\"perf-sync-row\"><$view field=\"title\"/> : <$view field=\"text\"/></div>",
+		"</$list>"
+	].join("\n");
+}
+
+function pad(value,width) {
+	var text = String(value);
+	while(text.length < width) {
+		text = "0" + text;
+	}
+	return text;
+}

--- a/editions/perftest/tiddlers/tests/deep-transclusion-stack.js
+++ b/editions/perftest/tiddlers/tests/deep-transclusion-stack.js
@@ -1,0 +1,138 @@
+/*\
+title: $:/perf/tests/deep-transclusion-stack.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Measures render and refresh paths for deep transclusion stacks.
+
+\*/
+"use strict";
+
+exports.name = "deep-transclusion-stack";
+exports.platform = "both";
+
+exports.run = function(context) {
+	return runScenario(context);
+};
+
+function runScenario(context) {
+	var wiki = context.wiki,
+		basePrefix = "$:/temp/perftest/deep-transclusion/",
+		renderTitle = basePrefix + "source",
+		unrelatedTitle = basePrefix + "unrelated",
+		nodePrefix = basePrefix + "node-",
+		itemPrefix = basePrefix + "item-",
+		depth = 16,
+		itemCount = 40,
+		renderMeasurement,
+		unrelatedMeasurement,
+		relatedMeasurement,
+		rendered,
+		unrelatedCounter = 0,
+		relatedCounter = 0;
+
+	seedFixture(wiki,nodePrefix,itemPrefix,depth,itemCount);
+	wiki.addTiddler({title: renderTitle, text: makeSourceText(itemPrefix,itemCount)});
+
+	renderMeasurement = context.measure("initial-render",function() {
+		rendered = context.renderText("{{" + renderTitle + "}}\n");
+		return {
+			phase: "render",
+			taxonomy: "render",
+			scenarioId: "deep-transclusion-initial-render",
+			scenarioTags: ["first-paint","deep-transclusion","widget-tree-build"],
+			scenarioChangeRelation: "none",
+			scenarioDescription: "Open a view that renders repeated deep transclusion stacks.",
+			fixtureName: "deep-transclusion-stack",
+			fixtureDepth: depth,
+			fixtureItemCount: itemCount,
+			petName: "deep transclusion stack",
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	unrelatedMeasurement = context.measure("refresh-unrelated-change",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		wiki.addTiddler({title: unrelatedTitle, text: "unrelated-" + unrelatedCounter++});
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "refresh",
+			scenarioId: "deep-transclusion-refresh-unrelated-change",
+			scenarioTags: ["background-edit","deep-transclusion","non-visible-change"],
+			scenarioChangeRelation: "unrelated",
+			scenarioDescription: "Edit a non-visible tiddler while deep transclusions stay on screen.",
+			fixtureName: "deep-transclusion-stack",
+			fixtureDepth: depth,
+			fixtureItemCount: itemCount,
+			petName: "deep transclusion stack",
+			changedTiddlerCount: 1,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	relatedMeasurement = context.measure("refresh-relevant-change",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		wiki.addTiddler({title: nodePrefix + (depth - 1), text: "leaf-" + relatedCounter++});
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "refresh",
+			scenarioId: "deep-transclusion-refresh-relevant-change",
+			scenarioTags: ["in-view-edit","deep-transclusion","transclusion-refresh"],
+			scenarioChangeRelation: "relevant",
+			scenarioDescription: "Edit the deepest transcluded node that is visible in the active view.",
+			fixtureName: "deep-transclusion-stack",
+			fixtureDepth: depth,
+			fixtureItemCount: itemCount,
+			petName: "deep transclusion stack",
+			changedTiddlerCount: 1,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	rendered.widgetNode.destroy();
+	cleanupFixture(wiki,basePrefix,nodePrefix,itemPrefix,renderTitle,depth,itemCount);
+	wiki.clearTiddlerEventQueue();
+	return [renderMeasurement,unrelatedMeasurement,relatedMeasurement];
+}
+
+function seedFixture(wiki,nodePrefix,itemPrefix,depth,itemCount) {
+	for(var i = depth - 1; i >= 0; i--) {
+		var text = i === depth - 1 ? "leaf-stable" : "{{" + nodePrefix + (i + 1) + "}}";
+		wiki.addTiddler({title: nodePrefix + i, text: text});
+	}
+	for(var j = 0; j < itemCount; j++) {
+		wiki.addTiddler({title: itemPrefix + j, text: "Item " + j + ": {{" + nodePrefix + "0}}"});
+	}
+}
+
+function cleanupFixture(wiki,basePrefix,nodePrefix,itemPrefix,renderTitle,depth,itemCount) {
+	wiki.deleteTiddler(renderTitle);
+	wiki.deleteTiddler(basePrefix + "unrelated");
+	for(var i = 0; i < depth; i++) {
+		wiki.deleteTiddler(nodePrefix + i);
+	}
+	for(var j = 0; j < itemCount; j++) {
+		wiki.deleteTiddler(itemPrefix + j);
+	}
+}
+
+function makeSourceText(itemPrefix,itemCount) {
+	if(itemCount === 0) {
+		return "";
+	}
+	// $transclude (not $view) is required so that {{node-0}} inside each item's
+	// text field is wiki-parsed and the full transclusion chain (node-0 -> ... ->
+	// node-{depth-1}) is actually traversed. $view field="text" renders raw stored
+	// text and never activates the chain.
+	return [
+		"<$list filter=\"[prefix[" + itemPrefix + "]] +[sort[]]\">",
+		"<div class=\"perf-deep-stack-row\"><$transclude tiddler=<<currentTiddler>>/></div>",
+		"</$list>"
+	].join("\n");
+}

--- a/editions/perftest/tiddlers/tests/draft-gradient.js
+++ b/editions/perftest/tiddlers/tests/draft-gradient.js
@@ -1,0 +1,106 @@
+/*\
+title: $:/perf/tests/draft-gradient.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Measures an ordinary editor input flowing through the wiki change queue into a local preview.
+
+\*/
+
+"use strict";
+
+exports.name = "draft-gradient-live-preview";
+exports.platform = "browser";
+exports.warmup = 2;
+exports.iterations = 20;
+
+var nextCase = 0;
+
+exports.run = function(context) {
+	var wiki = context.wiki,
+		draftTitle = "$:/temp/perftest/draft-gradient/draft",
+		originalTitle = "$:/temp/perftest/draft-gradient/original",
+		cases = [
+			{text: "before <<unfinished", rendered: "before <<unfinished"},
+			{text: "before [[unfinished", rendered: "before [[unfinished"},
+			{text: "before <$text text=\"unfinished", rendered: "before <$text text=\"unfinished"},
+			{text: "before <$list filter={{{ [tag[unfinished]] }}", rendered: "before <$list filter={"}
+		],
+		rendered,
+		measurement;
+	wiki.addTiddler({title: originalTitle, type: "text/vnd.tiddlywiki", text: "ordinary source"});
+	wiki.addTiddler({
+		title: draftTitle,
+		type: "text/vnd.tiddlywiki",
+		text: cases[0].text,
+		"draft.of": originalTitle,
+		"draft.title": originalTitle
+	});
+	rendered = context.renderText(makeSource(draftTitle));
+	rendered.wrapper.className = "tc-perf-draft-gradient";
+	context.document.body.appendChild(rendered.wrapper);
+	measurement = context.measureAsync("draft-preview-refresh",function() {
+		var item = cases[nextCase++ % cases.length],
+			input = rendered.wrapper.querySelector("textarea"),
+			preview = rendered.wrapper.querySelector(".tc-perf-draft-gradient-preview");
+		return new Promise(function(resolve,reject) {
+			var changeListener = function(changes) {
+				if(!changes[draftTitle]) {
+					return;
+				}
+				wiki.removeEventListener("change",changeListener);
+				try {
+					context.refresh(rendered.widgetNode,changes,rendered.wrapper);
+					if(preview.textContent !== item.rendered) {
+						throw new Error("Draft preview did not retain the expected base-wikitext recovery text");
+					}
+					resolve({
+						mode: "main",
+						phase: "live-preview",
+						taxonomy: "editor-preview",
+						scenarioId: "draft-gradient-preview",
+						scenarioTags: ["browser","edit-text","draft","base-wikitext","gradient"],
+						scenarioChangeRelation: "relevant",
+						scenarioDescription: "Type incomplete base wikitext into a draft and refresh its local rendered preview.",
+						fixtureName: "draft-gradient",
+						fixtureItemCount: cases.length,
+						petName: "draft gradient live preview",
+						gradientCaseCount: cases.length,
+						verifiedPreview: true
+					});
+				} catch(error) {
+					reject(error);
+				}
+			};
+			wiki.addEventListener("change",changeListener);
+			input.value = item.text;
+			input.dispatchEvent(new Event("input",{bubbles: true}));
+		});
+	}).then(function(result) {
+		cleanup(wiki,rendered,draftTitle,originalTitle);
+		return result;
+	},function(error) {
+		cleanup(wiki,rendered,draftTitle,originalTitle);
+		throw error;
+	});
+	return measurement;
+};
+
+function makeSource(draftTitle) {
+	return [
+		"<$edit-text tiddler=\"" + draftTitle + "\" class=\"tc-perf-draft-gradient-input\" autoHeight=\"no\"/>",
+		"<div class=\"tc-perf-draft-gradient-preview\"><$transclude tiddler=\"" + draftTitle + "\"/></div>"
+	].join("\n");
+}
+
+function cleanup(wiki,rendered,draftTitle,originalTitle) {
+	if(rendered) {
+		rendered.widgetNode.destroy();
+		if(rendered.wrapper.parentNode) {
+			rendered.wrapper.parentNode.removeChild(rendered.wrapper);
+		}
+	}
+	wiki.deleteTiddler(draftTitle);
+	wiki.deleteTiddler(originalTitle);
+	wiki.clearTiddlerEventQueue();
+}

--- a/editions/perftest/tiddlers/tests/filter-engine-scan.js
+++ b/editions/perftest/tiddlers/tests/filter-engine-scan.js
@@ -1,0 +1,83 @@
+/*\
+title: $:/perf/tests/filter-engine-scan.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Measures the filter engine directly (via wiki.filterTiddlers, no widgets or DOM) over a large tiddler set, across a graded battery from an indexed tag hit to an un-indexed search scan to a per-title sub-filter.
+
+\*/
+
+"use strict";
+
+exports.name = "filter-engine-scan";
+exports.platform = "both";
+exports.warmup = 2;
+exports.iterations = 12;
+
+var WORDS = ["alpha","beta","details","gamma","task","delta","report","epsilon","project","status"];
+
+exports.run = function(context) {
+	var wiki = context.wiki,
+		count = 2000,
+		prefix = "$:/temp/perftest/filter/item-",
+		measurements = [];
+	seed(wiki,prefix,count);
+	// Warm the tag index so the indexed-hit row measures a lookup, not a first build
+	wiki.filterTiddlers("[tag[perfitem-project-a]]");
+	try {
+		var battery = [
+			{id: "filter-tag-indexed", filter: "[tag[perfitem-project-a]]", note: "indexed tag lookup, first in run (the fast path)"},
+			{id: "filter-search-scan", filter: "[all[tiddlers]search[details]]", note: "un-indexed regexp scan over every tiddler (cache-proof; the honest headline)"},
+			{id: "filter-heavy-chain", filter: "[tag[perfitem-project-a]!tag[perfitem-archived]search[task]sort[priority]limit[200]]", note: "index hit, then scan, then scan, then sort"},
+			{id: "filter-sortsub-worst", filter: "[tag[perfitem-project-a]sortsub:number{[get[priority]]}]", note: "per-title sub-filter recompute (worst common operator)"}
+		];
+		for(var i = 0; i < battery.length; i++) {
+			measurements.push(measureFilter(context,count,battery[i]));
+		}
+	} finally{
+		cleanup(wiki,prefix,count);
+	}
+	return measurements;
+};
+
+function measureFilter(context,count,spec) {
+	var wiki = context.wiki,
+		results = [];
+	return context.measure(spec.id,function() {
+		results = wiki.filterTiddlers(spec.filter);
+		return {
+			mode: "main",
+			phase: "filter",
+			taxonomy: "filter-engine",
+			scenarioId: spec.id,
+			scenarioDescription: spec.note,
+			fixtureName: "filter-engine-scan",
+			fixtureItemCount: count,
+			resultCount: results.length,
+			filterString: spec.filter
+		};
+	});
+}
+
+function seed(wiki,prefix,count) {
+	for(var i = 0; i < count; i++) {
+		var tags = [i % 2 ? "perfitem-project-a" : "perfitem-project-b",i % 3 ? "perfitem-status-open" : "perfitem-status-closed"];
+		if(i % 11 === 0) {
+			tags.push("perfitem-archived");
+		}
+		wiki.addTiddler(new $tw.Tiddler({
+			title: prefix + i,
+			tags: tags,
+			priority: "" + (i % 100),
+			text: "Item " + i + " " + WORDS[i % WORDS.length] + " " + WORDS[(i * 3) % WORDS.length] + " content for the " + (i % 2 ? "task" : "details") + " list."
+		}));
+	}
+	wiki.clearTiddlerEventQueue();
+}
+
+function cleanup(wiki,prefix,count) {
+	for(var i = 0; i < count; i++) {
+		wiki.deleteTiddler(prefix + i);
+	}
+	wiki.clearTiddlerEventQueue();
+}

--- a/editions/perftest/tiddlers/tests/filter-heavy-lists.js
+++ b/editions/perftest/tiddlers/tests/filter-heavy-lists.js
@@ -1,0 +1,145 @@
+/*\
+title: $:/perf/tests/filter-heavy-lists.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Measures render and refresh paths for filter-heavy large-wiki style lists.
+
+\*/
+"use strict";
+
+exports.name = "filter-heavy-lists";
+exports.platform = "both";
+
+exports.run = function(context) {
+	return runScenario(context);
+};
+
+function runScenario(context) {
+	var wiki = context.wiki,
+		basePrefix = "$:/temp/perftest/filter-heavy/",
+		itemPrefix = basePrefix + "task-",
+		renderTitle = basePrefix + "source",
+		unrelatedTitle = basePrefix + "unrelated",
+		itemCount = 2000,
+		relevantTitle = itemPrefix + "0006",
+		renderMeasurement,
+		unrelatedMeasurement,
+		relatedMeasurement,
+		rendered,
+		unrelatedCounter = 0,
+		relatedCounter = 0;
+
+	seedItems(wiki,itemPrefix,itemCount);
+	wiki.addTiddler({title: renderTitle, text: makeSourceText(itemPrefix)});
+
+	renderMeasurement = context.measure("initial-render",function() {
+		rendered = context.renderText("{{" + renderTitle + "}}\n");
+		return {
+			phase: "render",
+			taxonomy: "render",
+			scenarioId: "filter-heavy-initial-render",
+			scenarioTags: ["first-paint","large-wiki","filter-heavy"],
+			scenarioChangeRelation: "none",
+			scenarioDescription: "Open a large filtered list with heavy filter clauses and sorted results.",
+			fixtureName: "filter-heavy-lists",
+			fixtureItemCount: itemCount,
+			petName: "filter heavy lists",
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	unrelatedMeasurement = context.measure("refresh-unrelated-change",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		wiki.addTiddler({title: unrelatedTitle, text: "background-" + unrelatedCounter++});
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "refresh",
+			scenarioId: "filter-heavy-refresh-unrelated-change",
+			scenarioTags: ["background-edit","large-wiki","non-visible-change"],
+			scenarioChangeRelation: "unrelated",
+			scenarioDescription: "Edit an unrelated tiddler while a heavy filtered list remains visible.",
+			fixtureName: "filter-heavy-lists",
+			fixtureItemCount: itemCount,
+			petName: "filter heavy lists",
+			changedTiddlerCount: 1,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	relatedMeasurement = context.measure("refresh-relevant-change",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		wiki.addTiddler({
+			title: relevantTitle,
+			text: "Task content update " + relatedCounter++,
+			tags: ["project-a","status-open"]
+		});
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "refresh",
+			scenarioId: "filter-heavy-refresh-relevant-change",
+			scenarioTags: ["in-view-edit","large-wiki","filter-recompute"],
+			scenarioChangeRelation: "relevant",
+			scenarioDescription: "Edit a tiddler that participates in the current heavy filter results.",
+			fixtureName: "filter-heavy-lists",
+			fixtureItemCount: itemCount,
+			petName: "filter heavy lists",
+			changedTiddlerCount: 1,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	rendered.widgetNode.destroy();
+	cleanupItems(wiki,basePrefix,itemPrefix,itemCount,renderTitle);
+	wiki.clearTiddlerEventQueue();
+	return [renderMeasurement,unrelatedMeasurement,relatedMeasurement];
+}
+
+function seedItems(wiki,itemPrefix,itemCount) {
+	for(var i = 0; i < itemCount; i++) {
+		var title = itemPrefix + pad(i,4),
+			tags = [i % 2 === 0 ? "project-a" : "project-b", i % 3 === 0 ? "status-open" : "status-closed"],
+			text = "Task " + i + " summary with details for list rendering and filtering.";
+		if(i % 11 === 0) {
+			tags.push("archived");
+		}
+		wiki.addTiddler({
+			title: title,
+			text: text,
+			tags: tags,
+			status: i % 3 === 0 ? "open" : "closed",
+			priority: String(i % 5)
+		});
+	}
+}
+
+function cleanupItems(wiki,basePrefix,itemPrefix,itemCount,renderTitle) {
+	wiki.deleteTiddler(renderTitle);
+	wiki.deleteTiddler(basePrefix + "unrelated");
+	for(var i = 0; i < itemCount; i++) {
+		wiki.deleteTiddler(itemPrefix + pad(i,4));
+	}
+}
+
+function makeSourceText(itemPrefix) {
+	var filter = "[prefix[" + itemPrefix + "]] +[tag[project-a]] +[tag[status-open]] +[!tag[archived]] +[search:title[task]] +[sort[modified]reverse[]] +[limit[120]]";
+	return [
+		"<$list filter=\"" + filter + "\">",
+		"<div class=\"perf-filter-heavy-row\"><$view field=\"title\"/> | <$view field=\"status\"/> | <$view field=\"text\"/></div>",
+		"</$list>"
+	].join("\n");
+}
+
+function pad(value,width) {
+	var text = String(value);
+	while(text.length < width) {
+		text = "0" + text;
+	}
+	return text;
+}

--- a/editions/perftest/tiddlers/tests/hot-child-walk.js
+++ b/editions/perftest/tiddlers/tests/hot-child-walk.js
@@ -1,0 +1,86 @@
+/*\
+title: $:/perf/tests/hot-child-walk.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Measures the base widget child walk with many simple children.
+
+\*/
+"use strict";
+
+exports.name = "hot-child-walk";
+exports.platform = "both";
+
+exports.run = function(context) {
+	return runScenario(context);
+};
+
+function runScenario(context) {
+	var wiki = context.wiki,
+		unrelatedTitle = "$:/temp/perftest/hot-child-walk/unrelated",
+		childCount = 1000,
+		parser = {tree: makeTextChildren(childCount)},
+		rendered,
+		renderMeasurement,
+		refreshMeasurement,
+		refreshCounter = 0;
+
+	wiki.clearTiddlerEventQueue();
+
+	renderMeasurement = context.measure("direct-child-render",function() {
+		rendered = renderParser(context,parser);
+		return {
+			phase: "render",
+			taxonomy: "child-walk",
+			scenarioId: "hot-child-walk-render",
+			scenarioTags: ["child-walk","base-widget","first-paint"],
+			scenarioChangeRelation: "none",
+			scenarioDescription: "Render a direct parse tree with many simple text children.",
+			fixtureName: "hot-child-walk",
+			fixtureItemCount: childCount,
+			petName: "hot child walk",
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	refreshMeasurement = context.measure("direct-child-refresh",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		wiki.addTiddler({title: unrelatedTitle, text: "hot-child-walk-" + refreshCounter++});
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "child-walk",
+			scenarioId: "hot-child-walk-refresh",
+			scenarioTags: ["child-walk","base-widget","background-edit"],
+			scenarioChangeRelation: "unrelated",
+			scenarioDescription: "Refresh a rendered widget with many simple children after an unrelated change.",
+			fixtureName: "hot-child-walk",
+			fixtureItemCount: childCount,
+			petName: "hot child walk",
+			changedTiddlerCount: 1,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	rendered.widgetNode.destroy();
+	wiki.deleteTiddler(unrelatedTitle);
+	wiki.clearTiddlerEventQueue();
+	return [renderMeasurement,refreshMeasurement];
+}
+
+function renderParser(context,parser) {
+	var widgetNode = context.wiki.makeWidget(parser,{document: context.document}),
+		wrapper = context.document.createElement("div");
+	widgetNode.render(wrapper,null);
+	return {widgetNode: widgetNode, wrapper: wrapper};
+}
+
+function makeTextChildren(childCount) {
+	var children = [];
+	for(var i = 0; i < childCount; i++) {
+		children.push({type: "text", text: "x"});
+	}
+	return children;
+}

--- a/editions/perftest/tiddlers/tests/large-body-render.js
+++ b/editions/perftest/tiddlers/tests/large-body-render.js
@@ -1,0 +1,133 @@
+/*\
+title: $:/perf/tests/large-body-render.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Measures render and refresh paths for large structured document bodies.
+
+\*/
+"use strict";
+
+exports.name = "large-body-render";
+exports.platform = "both";
+
+exports.run = function(context) {
+	return runScenario(context);
+};
+
+function runScenario(context) {
+	var wiki = context.wiki,
+		basePrefix = "$:/temp/perftest/large-body/",
+		sourceTitle = basePrefix + "source",
+		embeddedTitle = basePrefix + "embedded",
+		unrelatedTitle = basePrefix + "unrelated",
+		sectionCount = 40,
+		renderMeasurement,
+		unrelatedMeasurement,
+		relatedMeasurement,
+		rendered,
+		unrelatedCounter = 0,
+		relatedCounter = 0;
+
+	wiki.addTiddler({title: embeddedTitle, text: makeEmbeddedText(0)});
+	wiki.addTiddler({title: sourceTitle, text: makeSourceText(sectionCount,embeddedTitle)});
+
+	renderMeasurement = context.measure("initial-render",function() {
+		rendered = context.renderText("{{" + sourceTitle + "}}\n");
+		return {
+			phase: "render",
+			taxonomy: "render",
+			scenarioId: "large-body-initial-render",
+			scenarioTags: ["first-paint","large-document","body-render"],
+			scenarioChangeRelation: "none",
+			scenarioDescription: "Open a long structured document with many headings, paragraphs, tables, and inline transclusions.",
+			fixtureName: "large-body-render",
+			fixtureSectionCount: sectionCount,
+			petName: "large body render",
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	unrelatedMeasurement = context.measure("refresh-unrelated-change",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		wiki.addTiddler({title: unrelatedTitle, text: "unrelated-" + unrelatedCounter++});
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "refresh",
+			scenarioId: "large-body-refresh-unrelated-change",
+			scenarioTags: ["background-edit","large-document","non-visible-change"],
+			scenarioChangeRelation: "unrelated",
+			scenarioDescription: "Edit a non-related tiddler while a large document remains visible.",
+			fixtureName: "large-body-render",
+			fixtureSectionCount: sectionCount,
+			petName: "large body render",
+			changedTiddlerCount: 1,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	relatedMeasurement = context.measure("refresh-relevant-change",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		wiki.addTiddler({title: embeddedTitle, text: makeEmbeddedText(relatedCounter++)});
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "refresh",
+			scenarioId: "large-body-refresh-relevant-change",
+			scenarioTags: ["in-view-edit","large-document","embedded-refresh"],
+			scenarioChangeRelation: "relevant",
+			scenarioDescription: "Edit a transcluded section inside the visible large document.",
+			fixtureName: "large-body-render",
+			fixtureSectionCount: sectionCount,
+			petName: "large body render",
+			changedTiddlerCount: 1,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	rendered.widgetNode.destroy();
+	wiki.deleteTiddler(sourceTitle);
+	wiki.deleteTiddler(embeddedTitle);
+	wiki.deleteTiddler(unrelatedTitle);
+	wiki.clearTiddlerEventQueue();
+	return [renderMeasurement,unrelatedMeasurement,relatedMeasurement];
+}
+
+function makeSourceText(sectionCount,embeddedTitle) {
+	var lines = [];
+	for(var i = 0; i < sectionCount; i++) {
+		lines.push("!! Section " + (i + 1) + " Heading");
+		lines.push("");
+		lines.push("Paragraph " + i + " opening sentence with context. Additional supporting sentence for reading flow and DOM node generation. Third sentence to extend paragraph line count.");
+		lines.push("");
+		lines.push("|!Column A|!Column B|!Column C|");
+		lines.push("|Row " + i + " A|Row " + i + " B|Row " + i + " C|");
+		lines.push("|Row " + (i + 1) + " A|Row " + (i + 1) + " B|Row " + (i + 1) + " C|");
+		lines.push("");
+		if(i === Math.floor(sectionCount / 2)) {
+			lines.push("{{" + embeddedTitle + "}}");
+			lines.push("");
+		}
+		lines.push("* Item alpha " + i);
+		lines.push("* Item beta " + i);
+		lines.push("* Item gamma " + i);
+		lines.push("");
+	}
+	return lines.join("\n");
+}
+
+function makeEmbeddedText(revision) {
+	return [
+		"''Embedded Section'' — revision " + revision,
+		"",
+		"This embedded tiddler simulates a shared fragment refreshed independently.",
+		"",
+		"Inline content with ''bold'', //italic//, and `code`.",
+		""
+	].join("\n");
+}

--- a/editions/perftest/tiddlers/tests/medium-child-walk.js
+++ b/editions/perftest/tiddlers/tests/medium-child-walk.js
@@ -1,0 +1,153 @@
+/*\
+title: $:/perf/tests/medium-child-walk.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Measures the widget child walk with many moderate children and no intentional errors.
+
+\*/
+"use strict";
+
+exports.name = "medium-child-walk";
+exports.platform = "both";
+
+exports.run = function(context) {
+	return runScenario(context);
+};
+
+function runScenario(context) {
+	var wiki = context.wiki,
+		basePrefix = "$:/temp/perftest/medium-child-walk/",
+		itemPrefix = basePrefix + "item-",
+		unrelatedTitle = basePrefix + "unrelated",
+		childCount = 240,
+		parser,
+		rendered,
+		renderMeasurement,
+		unrelatedMeasurement,
+		relatedMeasurement,
+		unrelatedCounter = 0,
+		relatedCounter = 0;
+
+	seedFixture(wiki,itemPrefix,childCount);
+	wiki.clearTiddlerEventQueue();
+	parser = {tree: makeMediumChildren(itemPrefix,childCount)};
+
+	renderMeasurement = context.measure("medium-child-render",function() {
+		rendered = renderParser(context,parser);
+		return {
+			phase: "render",
+			taxonomy: "child-walk",
+			scenarioId: "medium-child-walk-render",
+			scenarioTags: ["child-walk","base-widget","first-paint","moderate-children"],
+			scenarioChangeRelation: "none",
+			scenarioDescription: "Render many direct children that each contain nested elements, attributes, and one transclusion.",
+			fixtureName: "medium-child-walk",
+			fixtureItemCount: childCount,
+			petName: "medium child walk",
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	unrelatedMeasurement = context.measure("medium-child-refresh-unrelated",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		wiki.addTiddler({title: unrelatedTitle, text: "medium-child-walk-" + unrelatedCounter++});
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "child-walk",
+			scenarioId: "medium-child-walk-refresh-unrelated",
+			scenarioTags: ["child-walk","base-widget","background-edit","moderate-children"],
+			scenarioChangeRelation: "unrelated",
+			scenarioDescription: "Refresh many moderate children after a tiddler outside the rendered view changes.",
+			fixtureName: "medium-child-walk",
+			fixtureItemCount: childCount,
+			petName: "medium child walk",
+			changedTiddlerCount: 1,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	relatedMeasurement = context.measure("medium-child-refresh-relevant",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		wiki.addTiddler({title: itemPrefix + Math.floor(childCount / 2), text: makeItemText(Math.floor(childCount / 2),relatedCounter++)});
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "child-walk",
+			scenarioId: "medium-child-walk-refresh-relevant",
+			scenarioTags: ["child-walk","base-widget","in-view-edit","moderate-children"],
+			scenarioChangeRelation: "relevant",
+			scenarioDescription: "Refresh many moderate children after one visible transcluded tiddler changes.",
+			fixtureName: "medium-child-walk",
+			fixtureItemCount: childCount,
+			petName: "medium child walk",
+			changedTiddlerCount: 1,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	rendered.widgetNode.destroy();
+	cleanupFixture(wiki,itemPrefix,unrelatedTitle,childCount);
+	wiki.clearTiddlerEventQueue();
+	return [renderMeasurement,unrelatedMeasurement,relatedMeasurement];
+}
+
+function renderParser(context,parser) {
+	var widgetNode = context.wiki.makeWidget(parser,{document: context.document}),
+		wrapper = context.document.createElement("div");
+	widgetNode.render(wrapper,null);
+	return {widgetNode: widgetNode, wrapper: wrapper};
+}
+
+function seedFixture(wiki,itemPrefix,childCount) {
+	for(var i = 0; i < childCount; i++) {
+		wiki.addTiddler({title: itemPrefix + i, text: makeItemText(i,0)});
+	}
+}
+
+function cleanupFixture(wiki,itemPrefix,unrelatedTitle,childCount) {
+	wiki.deleteTiddler(unrelatedTitle);
+	for(var i = 0; i < childCount; i++) {
+		wiki.deleteTiddler(itemPrefix + i);
+	}
+}
+
+function makeItemText(index,revision) {
+	return "Item " + index + " revision " + revision + " with ''bold'' and //italic// text.";
+}
+
+function makeMediumChildren(itemPrefix,childCount) {
+	var children = [];
+	for(var i = 0; i < childCount; i++) {
+		children.push({
+			type: "element",
+			tag: "div",
+			attributes: {
+				"class": {type: "string", value: "perf-medium-row"},
+				"data-index": {type: "string", value: String(i)},
+				"title": {type: "indirect", textReference: itemPrefix + i}
+			},
+			children: [
+				{type: "element", tag: "span", attributes: {
+					"class": {type: "string", value: "perf-medium-label"}
+				}, children: [
+					{type: "text", text: "Medium row " + i + ": "}
+				]},
+				{type: "transclude", attributes: {
+					"tiddler": {type: "string", value: itemPrefix + i}
+				}},
+				{type: "element", tag: "span", attributes: {
+					"class": {type: "string", value: "perf-medium-tail"}
+				}, children: [
+					{type: "text", text: " stable tail"}
+				]}
+			]
+		});
+	}
+	return children;
+}

--- a/editions/perftest/tiddlers/tests/parse-render-phases.js
+++ b/editions/perftest/tiddlers/tests/parse-render-phases.js
@@ -1,0 +1,116 @@
+/*\
+title: $:/perf/tests/parse-render-phases.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Captures powered, phase-separated timing for how wikitext parses into a parse tree and then renders into a widget tree plus DOM, with tree-size metrics for each representative input.
+
+\*/
+
+"use strict";
+
+exports.name = "parse-render-phases";
+exports.platform = "both";
+exports.warmup = 5;
+exports.iterations = 100;
+
+exports.run = function(context) {
+	var inputs = makeInputs(),
+		measurements = [];
+	for(var i = 0; i < inputs.length; i++) {
+		measurements.push.apply(measurements,measurePhases(context,inputs[i]));
+	}
+	return measurements;
+};
+
+function measurePhases(context,input) {
+	var wiki = context.wiki,
+		document = context.document,
+		text = input.text,
+		// Capture tree sizes once, outside the timed loops
+		referenceParser = wiki.parseText("text/vnd.tiddlywiki",text),
+		parseTreeNodes = countParseTree(referenceParser.tree),
+		reference = context.renderText(text),
+		widgetTreeNodes = countWidgetTree(reference.widgetNode),
+		domNodes = context.countDomNodes(reference.wrapper);
+	reference.widgetNode.destroy();
+	var parseMeasurement = context.measure(input.id + "-parse",function() {
+		wiki.parseText("text/vnd.tiddlywiki",text);
+		return phaseMetadata(input,"parse","text-to-parse-tree",{
+			parseTreeNodes: parseTreeNodes
+		});
+	});
+	var renderMeasurement = context.measure(input.id + "-render",function() {
+		var parser = wiki.parseText("text/vnd.tiddlywiki",text),
+			widgetNode = wiki.makeWidget(parser,{document: document}),
+			wrapper = document.createElement("div");
+		widgetNode.render(wrapper,null);
+		widgetNode.destroy();
+		return phaseMetadata(input,"render","parse-tree-to-widget-tree-and-dom",{
+			parseTreeNodes: parseTreeNodes,
+			widgetTreeNodes: widgetTreeNodes,
+			domNodes: domNodes
+		});
+	});
+	return [parseMeasurement,renderMeasurement];
+}
+
+function phaseMetadata(input,phase,taxonomy,extra) {
+	var metadata = {
+		mode: "main",
+		phase: phase,
+		taxonomy: taxonomy,
+		scenarioId: input.id + "-" + phase,
+		scenarioDescription: input.description,
+		fixtureName: "parse-render-phases",
+		petName: input.id + " " + phase,
+		inputBytes: input.text.length
+	};
+	return $tw.utils.extend(metadata,extra);
+}
+
+function countParseTree(nodes) {
+	var count = 0;
+	$tw.utils.each(nodes,function(node) {
+		count += 1;
+		if(node.children) {
+			count += countParseTree(node.children);
+		}
+	});
+	return count;
+}
+
+function countWidgetTree(widgetNode) {
+	var count = 1;
+	$tw.utils.each(widgetNode.children,function(child) {
+		count += countWidgetTree(child);
+	});
+	return count;
+}
+
+function makeInputs() {
+	return [
+		{
+			id: "structured",
+			description: "Rule-heavy prose: headings, formatted paragraphs, lists and links.",
+			text: makeStructured(30)
+		},
+		{
+			id: "widgety",
+			description: "Widget-heavy source: a list widget expanding many element and text widgets.",
+			text: "<$list filter=\"[range[40]]\" variable=\"index\">\n<span class=\"tc-perf-item\"><$text text=<<index>>/></span>\n</$list>"
+		}
+	];
+}
+
+function makeStructured(count) {
+	var lines = [];
+	for(var i = 0; i < count; i++) {
+		lines.push("!! Heading " + i);
+		lines.push("A paragraph carrying ''bold'', //italic// and a [[link|Target " + i + "]].");
+		lines.push("* first item " + i);
+		lines.push("* second item " + i);
+		lines.push("");
+	}
+	return lines.join("\n");
+}

--- a/editions/perftest/tiddlers/tests/parser-guard-regimes.js
+++ b/editions/perftest/tiddlers/tests/parser-guard-regimes.js
@@ -1,0 +1,112 @@
+/*\
+title: $:/perf/tests/parser-guard-regimes.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Separates the regimes in which an unclosed-delimiter guard changes the cost of parsing, since averaging them hides both the cost and the saving.
+
+Well formed source pays the guard's forward scan and gains nothing. Malformed source pays the scan once and then skips parsing the remainder of the tiddler as an inline run, so it should read faster. Adversarial source, carrying many openers that never close, makes every opener scan to the end of the source, so it hunts the quadratic worst case the guard introduces.
+
+\*/
+
+"use strict";
+
+exports.name = "parser-guard-regimes";
+exports.platform = "both";
+exports.warmup = 10;
+exports.iterations = 500;
+
+exports.run = function(context) {
+	var inputs = makeInputs(),
+		measurements = [];
+	for(var i = 0; i < inputs.length; i++) {
+		measurements.push(measureParse(context,inputs[i]));
+	}
+	return measurements;
+};
+
+function measureParse(context,input) {
+	var wiki = context.wiki,
+		text = input.text;
+	return context.measure(input.id,function() {
+		wiki.parseText("text/vnd.tiddlywiki",text);
+		return {
+			mode: "main",
+			phase: "parse",
+			taxonomy: "text-to-parse-tree",
+			scenarioId: input.id,
+			scenarioDescription: input.description,
+			fixtureName: "parser-guard-regimes",
+			petName: input.id,
+			inputBytes: text.length,
+			regime: input.regime,
+			prediction: input.prediction
+		};
+	});
+}
+
+function makeInputs() {
+	return [
+		{
+			id: "parse-well-formed",
+			regime: "well-formed",
+			prediction: "null: the guard scans to a closer that arrives quickly and gains nothing",
+			description: "Emphasis-rich prose in which every delimiter closes.",
+			text: makeWellFormed(60)
+		},
+		{
+			id: "parse-plain-blocks",
+			regime: "control",
+			prediction: "null: no delimiter appears, so only the block recovery scaffolding can charge for this",
+			description: "Block-dense prose carrying no delimiter of any kind, which isolates the cost of the recovery scaffolding from the cost of the rules.",
+			text: makePlain(60)
+		},
+		{
+			id: "parse-malformed-single",
+			regime: "malformed",
+			prediction: "cost: the rule parses the tail, finds no closer, rewinds and parses the tail again",
+			description: "One stray opener ahead of a large body that carries no delimiter of any kind, so the opener truly never closes.",
+			text: "A paragraph opening ''unclosed emphasis.\n\n" + makePlain(60)
+		},
+		{
+			id: "parse-adversarial-many",
+			regime: "adversarial",
+			prediction: "worst case: a second opener of the same kind closes the first, so only one opener of each kind can go unclosed",
+			description: "One unclosed opener of every delimiter kind ahead of a large plain body, which bounds the rewind cost at one re-parse per kind.",
+			text: makeAdversarial()
+		}
+	];
+}
+
+function makeWellFormed(count) {
+	var lines = [];
+	for(var i = 0; i < count; i++) {
+		lines.push("A paragraph carrying ''bold " + i + "'', //italic " + i + "//, __underscore__, ~~struck~~ and `code " + i + "`.");
+		lines.push("");
+	}
+	return lines.join("\n");
+}
+
+// The filler carries no delimiter character, so nothing downstream can close an opener by accident
+function makePlain(count) {
+	var lines = [];
+	for(var i = 0; i < count; i++) {
+		lines.push("!! Heading " + i);
+		lines.push("A plain paragraph of prose numbered " + i + " that carries no delimiter at all.");
+		lines.push("* first item " + i);
+		lines.push("* second item " + i);
+		lines.push("");
+	}
+	return lines.join("\n");
+}
+
+// A second opener of a kind closes the first, so at most one opener of each kind can go unclosed and the rewind cost stays bounded
+function makeAdversarial() {
+	var openers = ["''","//","__","~~","^^",",,"],
+		lines = [];
+	for(var i = 0; i < openers.length; i++) {
+		lines.push("Block " + i + " opens " + openers[i] + "an emphasis that never closes.");
+		lines.push("");
+	}
+	return lines.join("\n") + "\n" + makePlain(60);
+}

--- a/editions/perftest/tiddlers/tests/search-at-scale.js
+++ b/editions/perftest/tiddlers/tests/search-at-scale.js
@@ -1,0 +1,89 @@
+/*\
+title: $:/perf/tests/search-at-scale.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Measures full-text search cost over a large tiddler set; the community's most-reported scale wall. Search is un-indexed: every query scans every tiddler's title, tags and text. The indexed-tag arm and its matched scan arm return the SAME set, so the pair shows the honest cost of an O(1) index lookup versus an O(n) scan for identical results.
+
+\*/
+
+"use strict";
+
+exports.name = "search-at-scale";
+exports.platform = "both";
+exports.warmup = 2;
+exports.iterations = 10;
+
+var WORDS = ["detail","design","render","widget","filter","tiddler","project","status","report","archive","content","search","refresh","macro","transclude","paragraph"];
+
+exports.run = function(context) {
+	var wiki = context.wiki,
+		count = 5000,
+		prefix = "$:/temp/perftest/search/item-",
+		measurements = [];
+	seed(wiki,prefix,count);
+	// Warm the tag index so the indexed row measures a lookup, not a first build
+	wiki.filterTiddlers("[tag[perfitem-tagged]]");
+	try {
+		var battery = [
+			{id: "search-broad", filter: "[all[tiddlers]search[e]]", note: "one-character query: scans every tiddler, matches most (early-keystroke worst case)"},
+			{id: "search-word", filter: "[all[tiddlers]search[design]]", note: "specific common word: full scan, many matches (typical query)"},
+			{id: "search-title-only", filter: "[all[tiddlers]search:title[item]]", note: "title-only search: scans titles, skips body"},
+			{id: "lookup-indexed-tag", filter: "[tag[perfitem-tagged]]", note: "O(1) tag-index lookup returning the tagged tenth"},
+			{id: "lookup-scan-same-set", filter: "[all[tiddlers]search[beacon]]", note: "O(n) scan returning the SAME tenth (only the tagged carry 'beacon'); the honest index-vs-scan pair"}
+		];
+		for(var i = 0; i < battery.length; i++) {
+			measurements.push(measureFilter(context,count,battery[i]));
+		}
+	} finally{
+		cleanup(wiki,prefix,count);
+	}
+	return measurements;
+};
+
+function measureFilter(context,count,spec) {
+	var wiki = context.wiki,
+		results = [];
+	return context.measure(spec.id,function() {
+		results = wiki.filterTiddlers(spec.filter);
+		return {
+			mode: "main",
+			phase: "search",
+			taxonomy: "search",
+			scenarioId: spec.id,
+			scenarioDescription: spec.note,
+			fixtureName: "search-at-scale",
+			fixtureItemCount: count,
+			resultCount: results.length,
+			filterString: spec.filter
+		};
+	});
+}
+
+function seed(wiki,prefix,count) {
+	for(var i = 0; i < count; i++) {
+		var body = [];
+		for(var w = 0; w < 12; w++) {
+			body.push(WORDS[(i + w * 7) % WORDS.length]);
+		}
+		// Every tenth tiddler carries a distinctive tag AND the rare word "beacon",
+		// so a tag lookup and a scan for "beacon" return the identical set
+		var fields = {
+			title: prefix + i,
+			text: "Item " + i + ": " + body.join(" ") + "."
+		};
+		if(i % 10 === 0) {
+			fields.tags = ["perfitem-tagged"];
+			fields.text += " beacon";
+		}
+		wiki.addTiddler(new $tw.Tiddler(fields));
+	}
+	wiki.clearTiddlerEventQueue();
+}
+
+function cleanup(wiki,prefix,count) {
+	for(var i = 0; i < count; i++) {
+		wiki.deleteTiddler(prefix + i);
+	}
+	wiki.clearTiddlerEventQueue();
+}

--- a/editions/perftest/tiddlers/tests/story-river-many-open.js
+++ b/editions/perftest/tiddlers/tests/story-river-many-open.js
@@ -1,0 +1,137 @@
+/*\
+title: $:/perf/tests/story-river-many-open.js
+type: application/javascript
+tags: [[$:/tags/performance-test]]
+
+Measures render and refresh paths for a story-river style many-open workload.
+
+\*/
+"use strict";
+
+exports.name = "story-river-many-open";
+exports.platform = "both";
+
+exports.run = function(context) {
+	return runScenario(context);
+};
+
+function runScenario(context) {
+	var wiki = context.wiki,
+		basePrefix = "$:/temp/perftest/story-river/",
+		storyPrefix = basePrefix + "story-",
+		renderTitle = basePrefix + "source",
+		unrelatedTitle = basePrefix + "unrelated",
+		storyCount = 60,
+		relevantTitle = storyPrefix + "0000",
+		renderMeasurement,
+		unrelatedMeasurement,
+		relatedMeasurement,
+		rendered,
+		unrelatedCounter = 0,
+		relatedCounter = 0;
+
+	seedStoryItems(wiki,storyPrefix,storyCount);
+	wiki.addTiddler({title: renderTitle, text: makeSourceText(storyPrefix,storyCount)});
+
+	renderMeasurement = context.measure("initial-render",function() {
+		rendered = context.renderText("{{" + renderTitle + "}}\n");
+		return {
+			phase: "render",
+			taxonomy: "render",
+			scenarioId: "story-river-initial-render",
+			scenarioTags: ["story-river","many-open","first-paint"],
+			scenarioChangeRelation: "none",
+			scenarioDescription: "Open a story-river style view with many visible tiddlers.",
+			fixtureName: "story-river-many-open",
+			fixtureItemCount: storyCount,
+			petName: "story river many open",
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	unrelatedMeasurement = context.measure("refresh-unrelated-change",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		wiki.addTiddler({title: unrelatedTitle, text: "story-background-" + unrelatedCounter++});
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "refresh",
+			scenarioId: "story-river-refresh-unrelated-change",
+			scenarioTags: ["story-river","background-edit","non-visible-change"],
+			scenarioChangeRelation: "unrelated",
+			scenarioDescription: "Edit a non-visible tiddler while many story items remain open.",
+			fixtureName: "story-river-many-open",
+			fixtureItemCount: storyCount,
+			petName: "story river many open",
+			changedTiddlerCount: 1,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	relatedMeasurement = context.measure("refresh-relevant-change",function() {
+		var before = context.countDomNodes(rendered.wrapper);
+		wiki.addTiddler({title: relevantTitle, text: makeStoryText(0,relatedCounter++)});
+		context.refresh(rendered.widgetNode,wiki.changedTiddlers,rendered.wrapper);
+		wiki.clearTiddlerEventQueue();
+		return {
+			phase: "refresh",
+			taxonomy: "refresh",
+			scenarioId: "story-river-refresh-relevant-change",
+			scenarioTags: ["story-river","in-view-edit","visible-content-change"],
+			scenarioChangeRelation: "relevant",
+			scenarioDescription: "Edit a visible story-river item while many tiddlers remain open.",
+			fixtureName: "story-river-many-open",
+			fixtureItemCount: storyCount,
+			petName: "story river many open",
+			changedTiddlerCount: 1,
+			domNodeCountBefore: before,
+			domNodeCountAfter: context.countDomNodes(rendered.wrapper)
+		};
+	});
+
+	rendered.widgetNode.destroy();
+	cleanupStoryItems(wiki,basePrefix,storyPrefix,storyCount,renderTitle);
+	wiki.clearTiddlerEventQueue();
+	return [renderMeasurement,unrelatedMeasurement,relatedMeasurement];
+}
+
+function seedStoryItems(wiki,storyPrefix,storyCount) {
+	for(var i = 0; i < storyCount; i++) {
+		wiki.addTiddler({title: storyPrefix + pad(i,4), text: makeStoryText(i,0)});
+	}
+}
+
+function cleanupStoryItems(wiki,basePrefix,storyPrefix,storyCount,renderTitle) {
+	wiki.deleteTiddler(renderTitle);
+	wiki.deleteTiddler(basePrefix + "unrelated");
+	for(var i = 0; i < storyCount; i++) {
+		wiki.deleteTiddler(storyPrefix + pad(i,4));
+	}
+}
+
+function makeSourceText(storyPrefix,storyCount) {
+	return [
+		"<$list filter=\"[prefix[" + storyPrefix + "]] +[sort[]] +[limit[" + storyCount + "]]\">",
+		"<article class=\"perf-story-river-item\"><h3><$view field=\"title\"/></h3><div><$view field=\"text\"/></div></article>",
+		"</$list>"
+	].join("\n");
+}
+
+function makeStoryText(index,revision) {
+	return [
+		"Story item " + index + " revision " + revision,
+		"Line one for visible item context.",
+		"Line two with additional text for DOM work.",
+		"Line three with links [[Example" + index + "]] and [[Project" + (index % 10) + "]]."
+	].join("\n");
+}
+
+function pad(value,width) {
+	var text = String(value);
+	while(text.length < width) {
+		text = "0" + text;
+	}
+	return text;
+}

--- a/editions/perftest/tiddlywiki.info
+++ b/editions/perftest/tiddlywiki.info
@@ -1,0 +1,15 @@
+{
+	"description": "TiddlyWiki performance tests",
+	"plugins": [
+		"tiddlywiki/perftest"
+	],
+	"themes": [
+		"tiddlywiki/vanilla",
+		"tiddlywiki/snowwhite"
+	],
+	"build": {
+		"index": [
+			"--rendertiddler","$:/core/save/all","perftest.html","text/plain",
+			"--perf"]
+	}
+}

--- a/plugins/tiddlywiki/perftest/command.js
+++ b/plugins/tiddlywiki/perftest/command.js
@@ -1,0 +1,66 @@
+/*\
+title: $:/plugins/tiddlywiki/perftest/command.js
+type: application/javascript
+module-type: command
+
+Run performance tests on the command line.
+
+\*/
+"use strict";
+
+var perftest = require("./perftest.js");
+
+exports.info = {
+	name: "perf",
+	synchronous: false,
+	namedParameterMode: true
+};
+
+var Command = function(params,commander,callback) {
+	this.params = params;
+	this.commander = commander;
+	this.callback = callback;
+};
+
+Command.prototype.execute = function() {
+	var self = this;
+	var runOptions = {
+		runtime: "node"
+	};
+	if(this.params.output) {
+		runOptions.output = this.params.output;
+	}
+	if(this.params.iterations !== undefined) {
+		runOptions.defaultIterations = this.params.iterations;
+	}
+	if(this.params.baselineIterations !== undefined) {
+		runOptions.measurementBaselineIterations = this.params.baselineIterations;
+	}
+	if(this.params.warmupCapture !== undefined) {
+		runOptions.skipMeasurementDuringWarmup = this.params.warmupCapture !== "yes";
+	}
+	if(this.params.filter !== undefined) {
+		runOptions.testFilter = this.params.filter;
+	}
+	if(this.params.instrument !== undefined) {
+		runOptions.instrument = this.params.instrument;
+	}
+	runOptions.command = "--perf" +
+		(runOptions.output ? " output=" + runOptions.output : "") +
+		(runOptions.defaultIterations !== undefined ? " iterations=" + runOptions.defaultIterations : "") +
+		(runOptions.measurementBaselineIterations !== undefined ? " baselineIterations=" + runOptions.measurementBaselineIterations : "") +
+		(this.params.warmupCapture !== undefined ? " warmupCapture=" + this.params.warmupCapture : "") +
+		(runOptions.testFilter !== undefined ? " filter=" + runOptions.testFilter : "");
+	perftest.run(runOptions).then(function(results) {
+		perftest.reportToConsole(results);
+		if(self.params.output) {
+			perftest.writeResults(results,self.commander.outputPath,self.params.output);
+		}
+		self.callback(results.status === "failed" ? "Performance tests failed" : null);
+	}).catch(function(error) {
+		self.callback(error);
+	});
+	return null;
+};
+
+exports.Command = Command;

--- a/plugins/tiddlywiki/perftest/help.tid
+++ b/plugins/tiddlywiki/perftest/help.tid
@@ -1,0 +1,69 @@
+title: $:/language/Help/perf
+description: Run performance tests
+
+This runs performance tests in JavaScript tiddlers tagged with `$:/tags/performance-test`.
+
+```
+--perf [output=<filename>] [iterations=<number>] [baselineIterations=<number>] [warmupCapture=yes|no] [filter=<filter>] [instrument=yes|no]
+```
+
+''output'' - optional filename for writing JSON results. The filename is resolved relative to the output directory.
+''iterations'' - optional default measured iteration count for benchmarks that do not set `exports.iterations`.
+''baselineIterations'' - optional count used to calibrate measurement-overhead baseline subtraction. Default: 20.
+''warmupCapture'' - optional control for warmup measurement capture. Default: `no` (warmup keeps behavior but skips timing capture overhead where possible).
+''filter'' - optional filter for selecting benchmark tiddlers. The browser runner reads `$:/config/Performance/TestFilter` when no command option supplies a filter.
+''instrument'' - `yes` enables TiddlyWiki's own `$tw.perf` instrumentation for the run and reports the internal operations the fixtures drove (filter compilation and any `$tw.perf.measure`-wrapped call) with time AND invocation counts. Default: `no`. Note: instrumentation adds a small per-call timing overhead, so the fixture timings in an instrumented run read slightly higher than an uninstrumented one.
+
+For example:
+
+```
+tiddlywiki ./editions/perftest --output ./output/perftest --perf output=results.json iterations=100 baselineIterations=30 warmupCapture=no
+tiddlywiki ./editions/perftest --output ./output/perftest --perf output=hot-child-walk.json filter="[[$:/perf/tests/hot-child-walk.js]]"
+```
+
+The browser path is explicit because the default Playwright configuration targets `editions/test`:
+
+```
+tiddlywiki ./editions/perftest --build index
+./node_modules/.bin/playwright test --config=editions/perftest/playwright.config.js --project=chromium
+```
+
+Performance tests use this shape:
+
+```
+exports.name = "example";
+exports.platform = "both";
+exports.warmup = 5;
+exports.iterations = 50;
+exports.run = function(context) {
+	return context.measure("example-step",function() {
+		// Work to measure
+	});
+};
+```
+
+By default, each benchmark runs 5 warmup iterations, then 50 measured iterations. Warmup runs let the JavaScript engine, parser caches and widget setup settle; they finish before measurement begins and do not count in the reported samples.
+
+The JSON results include row-level summaries and the raw measured `samples`. The main timing fields are:
+
+* `median` - the middle measured run; a useful typical value.
+* `p75` - 75% of measured runs finished at or below this time.
+* `p90` - 90% of measured runs finished at or below this time.
+* `p95` - 95% of measured runs finished at or below this time.
+* `p99` - 99% of measured runs finished at or below this time; useful for tail-risk analysis.
+* `standardDeviation` - how spread out this run's measured samples were; lower values usually mean steadier results.
+
+Benchmarks may attach metadata such as `phase`, `mode`, `taxonomy`, `fixtureName`, `fixtureItemCount` and `petName`. The runner preserves that metadata in measurement rows and adds phase aggregate rows with `rowType: "phase"`.
+
+For human interpretation of refresh benchmarks, include scenario metadata fields:
+
+* `scenarioChangeRelation` - `relevant`, `unrelated`, or `none`.
+* `scenarioDescription` - plain-language explanation of what changed from a wiki user's point of view.
+* `scenarioTags` - short tags for grouping and reporting (for example `background-edit`, `in-view-edit`).
+
+Plugin tests can be added with the normal plugin mechanisms:
+
+```
+tiddlywiki +tiddlywiki/example ./editions/perftest --build index
+tiddlywiki ++/path/to/plugin ./editions/perftest --build index
+```

--- a/plugins/tiddlywiki/perftest/perftest.js
+++ b/plugins/tiddlywiki/perftest/perftest.js
@@ -1,0 +1,552 @@
+/*\
+title: $:/plugins/tiddlywiki/perftest/perftest.js
+type: application/javascript
+module-type: library
+
+Performance test discovery, execution and reporting.
+
+\*/
+"use strict";
+
+var DEFAULT_TEST_FILTER = "[all[tiddlers+shadows]type[application/javascript]tag[$:/tags/performance-test]]";
+var TEST_FILTER_CONFIG_TITLE = "$:/config/Performance/TestFilter";
+var DEFAULT_WARMUP = 5;
+var DEFAULT_ITERATIONS = 50;
+var DEFAULT_MEASUREMENT_BASELINE_ITERATIONS = 20;
+
+function now() {
+	if($tw.browser && window.performance && window.performance.now) {
+		return window.performance.now();
+	}
+	if(typeof process !== "undefined" && process.hrtime) {
+		var time = process.hrtime();
+		return (time[0] * 1000) + (time[1] / 1000000);
+	}
+	return Date.now();
+}
+
+function loadBenchmark(title) {
+	var code = $tw.wiki.getTiddlerText(title,""),
+		_exports = {},
+		context = {
+			$tw: $tw,
+			exports: _exports,
+			module: {exports: _exports},
+			console: console,
+			require: function(moduleTitle) {
+				return $tw.modules.execute(moduleTitle,title);
+			}
+		},
+		contextExports = $tw.utils.evalSandboxed(code,context,title,true);
+	return context.module.exports || contextExports || _exports;
+}
+
+function normalizePlatform(platform) {
+	return platform || "both";
+}
+
+function platformMatches(platform,runtime) {
+	platform = normalizePlatform(platform);
+	return platform === "both" || platform === runtime;
+}
+
+function parseCount(value,defaultValue) {
+	var parsed = parseInt(value,10);
+	return isNaN(parsed) ? defaultValue : parsed;
+}
+
+function sanitizeNonNegativeCount(value,defaultValue) {
+	var count = parseCount(value,defaultValue);
+	return count < 0 ? defaultValue : count;
+}
+
+function calibrateMeasurementBaseline(iterations) {
+	if(iterations <= 0) {
+		return 0;
+	}
+	var samples = [];
+	for(var i = 0; i < iterations; i++) {
+		var before = now();
+		var after = now();
+		samples.push(after - before);
+	}
+	return percentile(samples.sort(function(a,b) {return a - b;}),0.5) || 0;
+}
+
+function makeContext(options) {
+	var documentObject = $tw.browser ? document : $tw.fakeDocument;
+	var measurementBaselineIterations = sanitizeNonNegativeCount(options.measurementBaselineIterations,DEFAULT_MEASUREMENT_BASELINE_ITERATIONS);
+	var measurementBaselineMs = calibrateMeasurementBaseline(measurementBaselineIterations);
+	var skipMeasurementDuringWarmup = options.skipMeasurementDuringWarmup !== false;
+	var context = {
+		wiki: $tw.wiki,
+		document: documentObject,
+		performance: {now: now},
+		runtime: options.runtime,
+		isWarmup: false,
+		measurementBaselineIterations: measurementBaselineIterations,
+		measurementBaselineMs: measurementBaselineMs,
+		skipMeasurementDuringWarmup: skipMeasurementDuringWarmup,
+		countDomNodes: countDomNodes,
+		renderText: function(text) {
+			var parser = $tw.wiki.parseText("text/vnd.tiddlywiki",text),
+				widgetNode = $tw.wiki.makeWidget(parser,{document: documentObject}),
+				wrapper = documentObject.createElement("div");
+			widgetNode.render(wrapper,null);
+			return {widgetNode: widgetNode, wrapper: wrapper};
+		},
+		refresh: function(widgetNode,changes,wrapper) {
+			return widgetNode.refresh(changes,wrapper,null);
+		},
+		measure: function(label,fn,metadata) {
+			var result,
+				before,
+				after,
+				durationMs;
+			if(context.isWarmup && context.skipMeasurementDuringWarmup) {
+				result = fn();
+				durationMs = 0;
+			} else {
+				before = now();
+				result = fn();
+				after = now();
+				durationMs = Math.max(0,(after - before) - context.measurementBaselineMs);
+			}
+			return makeMeasurement(label,result,durationMs,metadata);
+		},
+		measureAsync: function(label,fn,metadata) {
+			var before,
+				durationMs;
+			if(context.isWarmup && context.skipMeasurementDuringWarmup) {
+				return Promise.resolve().then(fn).then(function(result) {
+					return makeMeasurement(label,result,0,metadata);
+				});
+			}
+			before = now();
+			return Promise.resolve().then(fn).then(function(result) {
+				durationMs = Math.max(0,(now() - before) - context.measurementBaselineMs);
+				return makeMeasurement(label,result,durationMs,metadata);
+			});
+		}
+	};
+	return context;
+}
+
+function makeMeasurement(label,result,durationMs,metadata) {
+	var measurement = {
+		label: label,
+		durationMs: durationMs
+	};
+	if(metadata) {
+		$tw.utils.extend(measurement,metadata);
+	}
+	if(result && typeof result === "object") {
+		$tw.utils.extend(measurement,result);
+		measurement.label = label;
+		if(measurement.durationMs === undefined) {
+			measurement.durationMs = durationMs;
+		}
+	}
+	return measurement;
+}
+
+function countDomNodes(node) {
+	var count = 0;
+	function walk(domNode) {
+		count++;
+		if(domNode.childNodes) {
+			for(var i = 0; i < domNode.childNodes.length; i++) {
+				walk(domNode.childNodes[i]);
+			}
+		}
+	}
+	if(node) {
+		walk(node);
+	}
+	return count;
+}
+
+function normalizeMeasurements(result) {
+	if(result === undefined || result === null) {
+		return [];
+	}
+	if($tw.utils.isArray(result)) {
+		return result;
+	}
+	return [result];
+}
+
+function percentile(sorted,rank) {
+	if(sorted.length === 0) {
+		return null;
+	}
+	return sorted[Math.max(0,Math.min(sorted.length - 1,Math.ceil(sorted.length * rank) - 1))];
+}
+
+function standardDeviation(values,mean) {
+	if(values.length === 0) {
+		return null;
+	}
+	var total = 0;
+	for(var i = 0; i < values.length; i++) {
+		total += Math.pow(values[i] - mean,2);
+	}
+	return Math.sqrt(total / values.length);
+}
+
+// Above this relative uncertainty a row reports as NOISY: it cannot support a claim of difference smaller than its own noise
+var RESOLVABLE_EFFECT_THRESHOLD_PCT = 5;
+
+function makeSummary(values) {
+	var sorted = values.slice(0).sort(function(a,b) {return a - b;}),
+		total = 0;
+	for(var i = 0; i < sorted.length; i++) {
+		total += sorted[i];
+	}
+	var n = sorted.length,
+		mean = n ? total / n : null,
+		median = percentile(sorted,0.5),
+		sd = mean === null ? null : standardDeviation(values,mean),
+		// Spread relative to the mean
+		cvPct = (mean && sd !== null && mean > 0) ? (sd / mean) * 100 : null,
+		// Relative standard error of the median: the smallest effect this row can resolve, its own noise floor
+		resolvableEffectPct = (median && sd !== null && n > 0 && median > 0) ? (1.2533 * sd / Math.sqrt(n)) / median * 100 : null,
+		trust = resolvableEffectPct === null ? "unknown" : (resolvableEffectPct <= RESOLVABLE_EFFECT_THRESHOLD_PCT ? "stable" : "noisy");
+	return {
+		samples: values,
+		sampleCount: n,
+		median: median,
+		p75: percentile(sorted,0.75),
+		p90: percentile(sorted,0.9),
+		p95: percentile(sorted,0.95),
+		p99: percentile(sorted,0.99),
+		min: n ? sorted[0] : null,
+		max: n ? sorted[sorted.length - 1] : null,
+		mean: mean,
+		standardDeviation: sd,
+		cvPct: cvPct,
+		resolvableEffectPct: resolvableEffectPct,
+		trust: trust
+	};
+}
+
+function mergeMeasurementMetadata(measurements) {
+	var metadata = Object.create(null);
+	$tw.utils.each(measurements,function(measurement) {
+		for(var name in measurement) {
+			if(name !== "durationMs" && name !== "label" && metadata[name] === undefined) {
+				metadata[name] = measurement[name];
+			}
+		}
+	});
+	return metadata;
+}
+
+function getMeasurementKey(measurement,name) {
+	return [
+		measurement.label || name,
+		measurement.phase || "",
+		measurement.mode || "",
+		measurement.taxonomy || ""
+	].join("\u0000");
+}
+
+function getPhaseKey(row) {
+	return [
+		row.title || "",
+		row.name || "",
+		row.phase || "",
+		row.mode || "",
+		row.taxonomy || ""
+	].join("\u0000");
+}
+
+function makePhaseRows(rows) {
+	var rowsByPhase = Object.create(null),
+		phaseRows = [];
+	$tw.utils.each(rows,function(row) {
+		if(!row.phase || row.error) {
+			return;
+		}
+		var key = getPhaseKey(row);
+		if(!rowsByPhase[key]) {
+			rowsByPhase[key] = [];
+		}
+		rowsByPhase[key].push(row);
+	});
+	for(var key in rowsByPhase) {
+		var sourceRows = rowsByPhase[key],
+			values = [];
+		$tw.utils.each(sourceRows,function(row) {
+			values.push.apply(values,row.samples || []);
+		});
+		phaseRows.push($tw.utils.extend({
+			rowType: "phase",
+			title: sourceRows[0].title,
+			name: sourceRows[0].name,
+			phase: sourceRows[0].phase,
+			mode: sourceRows[0].mode,
+			taxonomy: sourceRows[0].taxonomy,
+			iterations: sourceRows[0].iterations,
+			warmup: sourceRows[0].warmup,
+			error: null
+		},makeSummary(values)));
+	}
+	return phaseRows;
+}
+
+function makeErrorResults(error,options) {
+	return {
+		schemaVersion: 2,
+		status: "failed",
+		environment: makeEnvironment(options || {}),
+		benchmarks: [],
+		error: error && error.stack ? error.stack : String(error)
+	};
+}
+
+function makeEnvironment(options) {
+	var defaultWarmup = parseCount(options.defaultWarmup,DEFAULT_WARMUP),
+		defaultIterations = parseCount(options.defaultIterations,DEFAULT_ITERATIONS);
+	var environment = {
+		schemaVersion: 2,
+		defaultWarmup: defaultWarmup,
+		defaultIterations: defaultIterations,
+		runtime: options.runtime,
+		twVersion: $tw.version,
+		userAgent: $tw.browser ? navigator.userAgent : "node " + process.version,
+		timestamp: (new Date()).toISOString(),
+		command: options.command || null,
+		measurementBaselineIterations: sanitizeNonNegativeCount(options.measurementBaselineIterations,DEFAULT_MEASUREMENT_BASELINE_ITERATIONS),
+		skipMeasurementDuringWarmup: options.skipMeasurementDuringWarmup !== false,
+		testFilter: options.testFilter || $tw.wiki.getTiddlerText(TEST_FILTER_CONFIG_TITLE,DEFAULT_TEST_FILTER),
+		instrument: options.instrument === "yes"
+	};
+	if(typeof process !== "undefined") {
+		environment.nodeVersion = process.version;
+		environment.platform = process.platform;
+		environment.arch = process.arch;
+	}
+	return environment;
+}
+
+function runBenchmarkIteration(benchmark,context) {
+	try {
+		return Promise.resolve(benchmark.run(context));
+	} catch(error) {
+		return Promise.reject(error);
+	}
+}
+
+function runWarmup(benchmark,context,warmup) {
+	context.isWarmup = true;
+	var chain = Promise.resolve();
+	for(var i = 0; i < warmup; i++) {
+		chain = chain.then(function() {
+			return runBenchmarkIteration(benchmark,context);
+		});
+	}
+	return chain.then(function() {
+		context.isWarmup = false;
+	}).catch(function(error) {
+		context.isWarmup = false;
+		throw error;
+	});
+}
+
+function runMeasured(benchmark,context,iterations,onMeasurement) {
+	var chain = Promise.resolve();
+	for(var i = 0; i < iterations; i++) {
+		chain = chain.then(function() {
+			return runBenchmarkIteration(benchmark,context).then(function(runResult) {
+				$tw.utils.each(normalizeMeasurements(runResult),onMeasurement);
+			});
+		});
+	}
+	return chain;
+}
+
+function run(options) {
+	options = options || {};
+	var runtime = options.runtime || ($tw.browser ? "browser" : "node"),
+		defaultWarmup = parseCount(options.defaultWarmup,DEFAULT_WARMUP),
+		defaultIterations = parseCount(options.defaultIterations,DEFAULT_ITERATIONS),
+		measurementBaselineIterations = sanitizeNonNegativeCount(options.measurementBaselineIterations,DEFAULT_MEASUREMENT_BASELINE_ITERATIONS),
+		skipMeasurementDuringWarmup = options.skipMeasurementDuringWarmup !== false,
+		testFilter = options.testFilter || $tw.wiki.getTiddlerText(TEST_FILTER_CONFIG_TITLE,DEFAULT_TEST_FILTER),
+		titles = $tw.wiki.filterTiddlers(testFilter).sort(),
+		context = makeContext({
+			runtime: runtime,
+			measurementBaselineIterations: measurementBaselineIterations,
+			skipMeasurementDuringWarmup: skipMeasurementDuringWarmup
+		}),
+		results = {
+			schemaVersion: 2,
+			status: "passed",
+			environment: makeEnvironment({
+				runtime: runtime,
+				command: options.command,
+				defaultWarmup: defaultWarmup,
+				defaultIterations: defaultIterations,
+				measurementBaselineIterations: measurementBaselineIterations,
+				skipMeasurementDuringWarmup: skipMeasurementDuringWarmup,
+				testFilter: testFilter,
+				instrument: options.instrument
+			}),
+			benchmarks: []
+		},
+		chain = Promise.resolve();
+	// Enabling $tw.perf records time and invocations for core operations the fixtures drive, so the report can show internal work with counts that expose a mis-attributed hot spot
+	var instrument = options.instrument === "yes" && !!$tw.perf;
+	if(instrument) {
+		$tw.perf.enabled = true;
+		$tw.perf.measures = {};
+	}
+	$tw.utils.each(titles,function(title) {
+		chain = chain.then(function() {
+			var benchmark = loadBenchmark(title),
+				platform = normalizePlatform(benchmark.platform),
+				name = benchmark.name || title,
+				warmup = parseCount(benchmark.warmup,defaultWarmup),
+				iterations = parseCount(benchmark.iterations,defaultIterations),
+				measurementsByLabel = Object.create(null);
+			if(!platformMatches(platform,runtime)) {
+				return;
+			}
+			if(typeof benchmark.run !== "function") {
+				results.status = "failed";
+				results.benchmarks.push({title: title, name: name, error: "Missing run function"});
+				return;
+			}
+			return runWarmup(benchmark,context,warmup).then(function() {
+				return runMeasured(benchmark,context,iterations,function(measurement) {
+					var key = getMeasurementKey(measurement,name);
+					if(!measurementsByLabel[key]) {
+						measurementsByLabel[key] = [];
+					}
+					measurementsByLabel[key].push(measurement);
+				});
+			}).then(function() {
+				var measurementRows = [];
+				for(var label in measurementsByLabel) {
+					var measurements = measurementsByLabel[label],
+						summary = makeSummary(measurements.map(function(measurement) {
+							return measurement.durationMs;
+						})),
+						metadata = mergeMeasurementMetadata(measurements),
+						rowLabel = measurements[0].label || label;
+					measurementRows.push($tw.utils.extend({
+						rowType: "measurement",
+						title: title,
+						name: name,
+						label: rowLabel,
+						iterations: iterations,
+						warmup: warmup,
+						error: null
+					},metadata,summary));
+				}
+				results.benchmarks.push.apply(results.benchmarks,measurementRows);
+				results.benchmarks.push.apply(results.benchmarks,makePhaseRows(measurementRows));
+			}).catch(function(error) {
+				results.status = "failed";
+				results.benchmarks.push({
+					rowType: "measurement",
+					title: title,
+					name: name,
+					iterations: iterations,
+					warmup: warmup,
+					error: error && error.stack ? error.stack : String(error)
+				});
+			});
+		});
+	});
+	return chain.then(function() {
+		if(titles.length === 0) {
+			results.status = "failed";
+			results.error = "No performance tests found";
+		}
+		if(instrument) {
+			results.internalMeasures = captureInternalMeasures();
+		}
+		return results;
+	});
+}
+
+// Snapshot $tw.perf as rows sorted by total time; invocation counts distinguish a heavy call from death by a thousand cuts
+function captureInternalMeasures() {
+	var measures = ($tw.perf && $tw.perf.measures) || {},
+		rows = [];
+	for(var name in measures) {
+		rows.push({
+			name: name,
+			invocations: measures[name].invocations,
+			totalMs: measures[name].time,
+			avgMs: measures[name].invocations ? measures[name].time / measures[name].invocations : 0
+		});
+	}
+	rows.sort(function(a,b) {return b.totalMs - a.totalMs;});
+	return rows;
+}
+
+function reportToConsole(results) {
+	var noisy = 0;
+	console.log("Performance tests: " + results.status);
+	console.log("  Runtime: " + results.environment.runtime + " · TiddlyWiki " + results.environment.twVersion + " · " + results.environment.defaultIterations + " iterations after " + results.environment.defaultWarmup + " warmup runs");
+	console.log("  Honest reading: each row shows its median, spread (CV), and floor; the smallest change it can resolve. A row marked NOISY cannot support any claim below its floor: raise iterations or ignore differences that small.");
+	console.log("  To compare two versions, never read one whole run against another; between-session drift dwarfs most real changes. Interleave the versions in one session and use compare-runs (paired).");
+	$tw.utils.each(results.benchmarks,function(benchmark) {
+		if(benchmark.error) {
+			console.log("  " + benchmark.name + ": " + benchmark.error);
+		} else {
+			var mode = benchmark.mode ? " [" + benchmark.mode + "]" : "",
+				taxonomy = benchmark.taxonomy ? " (" + benchmark.taxonomy + ")" : "",
+				phase = benchmark.phase ? " phase:" + benchmark.phase : "",
+				label = benchmark.rowType === "phase" ? "phase aggregate" : benchmark.label,
+				petName = benchmark.petName ? " - " + benchmark.petName : "",
+				cv = benchmark.cvPct !== null && benchmark.cvPct !== undefined ? ", CV " + benchmark.cvPct.toFixed(0) + "%" : "",
+				floor = benchmark.resolvableEffectPct !== null && benchmark.resolvableEffectPct !== undefined ? ", floor ±" + benchmark.resolvableEffectPct.toFixed(1) + "%" : "",
+				flag = benchmark.trust === "noisy" ? "  ⚠ NOISY" : "";
+			if(benchmark.trust === "noisy") {
+				noisy++;
+			}
+			console.log("  " + benchmark.name + " / " + label + mode + taxonomy + phase + petName + ": median " + benchmark.median.toFixed(3) + "ms (n=" + benchmark.sampleCount + cv + floor + ")" + flag);
+		}
+	});
+	if(noisy > 0) {
+		console.log("  " + noisy + " row(s) marked NOISY: their spread swamps small effects. Any comparison on those rows needs more iterations before a difference is believable.");
+	}
+	if(results.internalMeasures && results.internalMeasures.length) {
+		console.log("  --- TiddlyWiki internal instrumentation ($tw.perf), by total time ---");
+		console.log("    Invocations are the honest half: a big share on few calls is a heavy call; the same share over many calls is death by a thousand cuts.");
+		$tw.utils.each(results.internalMeasures,function(m) {
+			console.log("    " + m.totalMs.toFixed(2) + "ms total, " + m.invocations + " calls, " + m.avgMs.toFixed(4) + "ms/call  " + m.name);
+		});
+	}
+}
+
+function reportToDom(results) {
+	var statusNode = document.createElement("div"),
+		jsonNode = document.createElement("script");
+	statusNode.className = "tw-perf-overall-result tw-perf-done " + (results.status === "passed" ? "tw-perf-passed" : "tw-perf-failed");
+	statusNode.textContent = "Performance tests: " + results.status;
+	jsonNode.id = "tw-perf-results";
+	jsonNode.type = "application/json";
+	jsonNode.textContent = JSON.stringify(results,null,2);
+	document.body.appendChild(statusNode);
+	document.body.appendChild(jsonNode);
+	window.$twPerfTestResults = results;
+}
+
+function writeResults(results,outputPath,filename) {
+	var fs = require("fs"),
+		path = require("path"),
+		filepath = path.resolve(outputPath,filename);
+	$tw.utils.createFileDirectories(filepath);
+	fs.writeFileSync(filepath,JSON.stringify(results,null,2),"utf8");
+}
+
+exports.run = run;
+exports.reportToConsole = reportToConsole;
+exports.reportToDom = reportToDom;
+exports.writeResults = writeResults;
+exports.makeErrorResults = makeErrorResults;

--- a/plugins/tiddlywiki/perftest/plugin.info
+++ b/plugins/tiddlywiki/perftest/plugin.info
@@ -1,0 +1,7 @@
+{
+	"title": "$:/plugins/tiddlywiki/perftest",
+	"name": "Performance Test",
+	"description": "Performance test runner",
+	"list": "readme",
+	"stability": "STABILITY_1_EXPERIMENTAL"
+}

--- a/plugins/tiddlywiki/perftest/readme.tid
+++ b/plugins/tiddlywiki/perftest/readme.tid
@@ -1,0 +1,19 @@
+title: $:/plugins/tiddlywiki/perftest/readme
+
+The performance test plugin runs JavaScript benchmark tiddlers tagged with `$:/tags/performance-test`.
+
+It provides the `--perf` command for Node.js and a browser startup runner for generated performance test editions.
+
+! Measurement honesty
+
+Benchmarks mislead more often than they inform. This harness builds the guardrails in so a result cannot quietly overstate itself:
+
+* ''Every row reports its own floor.'' Alongside the median, each measurement carries its spread (`cvPct`) and a resolvable-effect floor (`resolvableEffectPct`); the smallest change it could detect. A row whose floor swamps small effects is marked `trust: "noisy"`. A NOISY row cannot support a claim below its floor; raise `iterations` or ignore differences that small.
+
+* ''Compare paired, never snapshot.'' Between-session drift (machine load, thermal state) routinely runs ±10-40%; larger than most real changes. Comparing one whole run against another measures the weather, not the code. To compare two versions, acquire runs ''interleaved'' in one session and use `scripts/perf/compare-runs.js <before-dir> <after-dir>`, which works from the within-pair delta so drift cancels.
+
+* ''Alternate the within-pair order.'' Always running `before` then `after` lets a slow monotonic drift (the machine warming up over the session) fall entirely on the always-second version, which then reads as a systematic change the confidence interval will wrongly confirm. Alternate the order each pair; before/after, then after/before; so the drift cancels across pairs rather than accruing to one side.
+
+* ''Inconclusive is a first-class verdict.'' `compare-runs` reports a 95% confidence interval on each delta. When the interval straddles zero it reads INCONCLUSIVE; not "no change", and never a number dressed up as a win. It also reports the resolution floor: the smallest effect the run set could resolve.
+
+* ''Verify a hot function by counting, not sampling.'' A CPU sampling profiler attributes time to functions it never truly ran (stale-stack and aliasing errors). Before optimising a "hot" function, confirm it with a call count. A negative result; "already fast", "no resolvable difference"; is a real finding worth keeping.

--- a/plugins/tiddlywiki/perftest/startup.js
+++ b/plugins/tiddlywiki/perftest/startup.js
@@ -1,0 +1,24 @@
+/*\
+title: $:/plugins/tiddlywiki/perftest/startup.js
+type: application/javascript
+module-type: startup
+
+Run performance tests in generated browser editions.
+
+\*/
+"use strict";
+
+var perftest = require("./perftest.js");
+
+exports.name = "perftest";
+exports.platforms = ["browser"];
+exports.after = ["render"];
+exports.synchronous = true;
+
+exports.startup = function() {
+	perftest.run({runtime: "browser", command: "browser startup"}).then(function(results) {
+		perftest.reportToDom(results);
+	}).catch(function(error) {
+		perftest.reportToDom(perftest.makeErrorResults(error,{runtime: "browser"}));
+	});
+};

--- a/scripts/perf/call-census.js
+++ b/scripts/perf/call-census.js
@@ -1,0 +1,97 @@
+/*
+Deterministic call census for TiddlyWiki hot paths.
+
+	node scripts/perf/call-census.js <edition-path> [renders]
+
+Boots an edition, instruments core functions to count their calls over a parse and
+render workload, and reports the counts. A CPU sampling profiler mis-attributes time
+(stale frames, inlining, aliasing); an exact count catches the ghost before you
+optimise it. If the profiler calls a function hot but the census shows few calls,
+the profiler is wrong.
+*/
+"use strict";
+
+var path = require("path");
+
+function instrument(counts, obj, method, label) {
+	if(!obj || typeof obj[method] !== "function") {
+		return;
+	}
+	var original = obj[method];
+	counts[label] = 0;
+	obj[method] = function() {
+		counts[label]++;
+		return original.apply(this, arguments);
+	};
+}
+
+function main() {
+	var editionPath = process.argv[2];
+	var renders = parseInt(process.argv[3], 10);
+	if(!editionPath) {
+		console.log("Usage: node scripts/perf/call-census.js <edition-path> [renders]");
+		process.exit(1);
+	}
+	if(isNaN(renders) || renders < 1) {
+		renders = 3;
+	}
+	var $tw = require(path.resolve("./boot/boot.js")).TiddlyWiki();
+	$tw.boot.argv = [path.resolve(editionPath)];
+	$tw.boot.boot(function() {
+		var counts = Object.create(null);
+		var Widget = $tw.modules.execute("$:/core/modules/widgets/widget.js").widget;
+		var WikiParser = $tw.Wiki.parsers["text/vnd.tiddlywiki"];
+		// Parse path
+		instrument(counts, $tw.Wiki.prototype, "parseText", "Wiki.parseText");
+		instrument(counts, $tw.Wiki.prototype, "makeWidget", "Wiki.makeWidget");
+		instrument(counts, WikiParser && WikiParser.prototype, "findNextMatch", "WikiParser.findNextMatch");
+		instrument(counts, $tw.WikiRuleBase && $tw.WikiRuleBase.prototype, "findNextMatch", "WikiRule.findNextMatch");
+		// Widget-tree build + refresh machinery (base methods every widget shares)
+		instrument(counts, Widget.prototype, "makeChildWidget", "Widget.makeChildWidget");
+		instrument(counts, Widget.prototype, "makeChildWidgets", "Widget.makeChildWidgets");
+		instrument(counts, Widget.prototype, "initialise", "Widget.initialise");
+		instrument(counts, Widget.prototype, "computeAttributes", "Widget.computeAttributes");
+		instrument(counts, Widget.prototype, "getVariableInfo", "Widget.getVariableInfo");
+		instrument(counts, Widget.prototype, "refreshChildren", "Widget.refreshChildren");
+		// Store + data
+		instrument(counts, $tw.Wiki.prototype, "getTiddler", "Wiki.getTiddler");
+		instrument(counts, $tw.Wiki.prototype, "getCacheForTiddler", "Wiki.getCacheForTiddler");
+		instrument(counts, $tw.Wiki.prototype, "getTiddlerData", "Wiki.getTiddlerData");
+		instrument(counts, $tw.utils, "parseJSONSafe", "utils.parseJSONSafe");
+
+		var titles = [];
+		$tw.wiki.each(function(tiddler, title) {
+			var type = tiddler.fields.type;
+			if(type && type !== "text/vnd.tiddlywiki") {
+				return;
+			}
+			if(typeof tiddler.fields.text !== "string" || tiddler.fields.text === "") {
+				return;
+			}
+			titles.push(title);
+		});
+		var rendered = 0;
+		for(var r = 0; r < renders; r++) {
+			for(var i = 0; i < titles.length; i++) {
+				var parser = $tw.wiki.parseText("text/vnd.tiddlywiki", $tw.wiki.getTiddlerText(titles[i]));
+				try {
+					var widget = $tw.wiki.makeWidget(parser, {document: $tw.fakeDocument});
+					var wrapper = $tw.fakeDocument.createElement("div");
+					widget.render(wrapper, null);
+					widget.destroy();
+					rendered++;
+				} catch(e) {}
+			}
+		}
+		var workload = renders + " x " + titles.length + " tiddlers (" + rendered + " rendered)";
+		console.log("Call census over " + workload + ":");
+		Object.keys(counts).sort(function(a, b) {
+			return counts[b] - counts[a];
+		}).forEach(function(label) {
+			var perRender = rendered > 0 ? (counts[label] / rendered) : 0;
+			console.log("  " + String(counts[label]).padStart(10) + "  " + perRender.toFixed(1).padStart(8) + "/render  " + label);
+		});
+	});
+}
+
+main();

--- a/scripts/perf/compare-runs.js
+++ b/scripts/perf/compare-runs.js
@@ -1,0 +1,160 @@
+/*
+Honest paired A/B comparison for TiddlyWiki perftest runs.
+
+	node scripts/perf/compare-runs.js <before-dir> <after-dir> [--json out.json]
+
+Each directory holds run-*.json files produced by `--perf`, acquired interleaved
+(before, after, before, after, ...) in one session. The tool pairs before[i] with
+after[i] and works from the within-pair delta, so between-session drift (machine
+load, thermal state), which routinely exceeds the effect being hunted, cancels out.
+Each delta is reported with a 95% confidence interval; a CI that straddles zero
+reads INCONCLUSIVE, never a number dressed up as a win.
+*/
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+function usage() {
+	console.log("Usage: node scripts/perf/compare-runs.js <before-dir> <after-dir> [--json out.json]");
+	console.log("  Directories hold run-*.json from --perf, acquired interleaved (before, after, before, after, ...).");
+}
+
+function loadRuns(dir) {
+	return fs.readdirSync(dir)
+		.filter((f) => /^run-\d+\.json$/.test(f))
+		.sort((a, b) => parseInt(a.match(/\d+/)[0], 10) - parseInt(b.match(/\d+/)[0], 10))
+		.map((f) => {
+			const json = JSON.parse(fs.readFileSync(path.join(dir, f), "utf8"));
+			const byKey = new Map();
+			for(const row of json.benchmarks || []) {
+				if(row.rowType === "measurement" && !row.error && typeof row.median === "number") {
+					byKey.set(measurementKey(row), row.median);
+				}
+			}
+			return { file: f, timestamp: json.environment && json.environment.timestamp, byKey };
+		});
+}
+
+function measurementKey(row) {
+	return [row.name || "", row.label || "", row.phase || "", row.mode || ""].join(" | ");
+}
+
+function median(values) {
+	const a = values.slice().sort((x, y) => x - y);
+	const m = Math.floor(a.length / 2);
+	return a.length % 2 ? a[m] : (a[m - 1] + a[m]) / 2;
+}
+
+function mean(values) {
+	return values.reduce((s, x) => s + x, 0) / values.length;
+}
+
+function stddev(values, mu) {
+	if(values.length < 2) return 0;
+	return Math.sqrt(values.reduce((s, x) => s + (x - mu) * (x - mu), 0) / (values.length - 1));
+}
+
+// Warn when the two sets were acquired as snapshots (all before, then all after)
+// rather than interleaved: snapshot pairs cannot cancel drift.
+function looksInterleaved(before, after) {
+	const bt = before.map((r) => r.timestamp).filter(Boolean).map((t) => Date.parse(t));
+	const at = after.map((r) => r.timestamp).filter(Boolean).map((t) => Date.parse(t));
+	if(bt.length === 0 || at.length === 0) return null;
+	// Interleaved if the two time ranges overlap; snapshot if one set fully precedes the other.
+	const beforeMax = Math.max(...bt), afterMin = Math.min(...at);
+	const afterMax = Math.max(...at), beforeMin = Math.min(...bt);
+	return !(beforeMax < afterMin || afterMax < beforeMin);
+}
+
+function compare(beforeDir, afterDir) {
+	const before = loadRuns(beforeDir);
+	const after = loadRuns(afterDir);
+	const pairs = Math.min(before.length, after.length);
+	if(pairs < 2) {
+		throw new Error(`Need at least 2 paired runs in each directory; found ${before.length} before / ${after.length} after.`);
+	}
+	const keys = [...before[0].byKey.keys()].filter(
+		(k) => before.every((r) => r.byKey.has(k)) && after.every((r) => r.byKey.has(k))
+	).sort();
+	const results = [];
+	for(const key of keys) {
+		const deltas = [];
+		for(let i = 0; i < pairs; i++) {
+			const b = before[i].byKey.get(key), a = after[i].byKey.get(key);
+			if(b > 0) deltas.push((a - b) / b * 100);
+		}
+		if(deltas.length < 2) continue;
+		const dMean = mean(deltas);
+		const dMedian = median(deltas);
+		const se = stddev(deltas, dMean) / Math.sqrt(deltas.length);
+		const ci95 = 1.96 * se; // half-width of the 95% CI on the mean delta
+		const lo = dMean - ci95, hi = dMean + ci95;
+		let verdict;
+		if(lo > 0) verdict = "regression";
+		else if(hi < 0) verdict = "improvement";
+		else verdict = "inconclusive"; // the CI straddles zero; the rig cannot resolve this
+		results.push({
+			key, pairs: deltas.length,
+			beforeMedian: median(before.map((r) => r.byKey.get(key))),
+			afterMedian: median(after.map((r) => r.byKey.get(key))),
+			deltaMedianPct: dMedian, deltaMeanPct: dMean,
+			ci95Pct: ci95, ciLoPct: lo, ciHiPct: hi,
+			verdict
+		});
+	}
+	return { pairs, interleaved: looksInterleaved(before, after), keys: results };
+}
+
+function fmtPct(x) {
+	return (x >= 0 ? "+" : "") + x.toFixed(1) + "%";
+}
+
+function print(report) {
+	console.log("=== Paired A/B (before -> after), drift-cancelled ===");
+	console.log(`pairs=${report.pairs}  keys=${report.keys.length}`);
+	if(report.interleaved === false) {
+		console.log("  ⚠ WARNING: the two run sets do NOT overlap in time; they look like SNAPSHOTS, not interleaved.");
+		console.log("    Between-session drift is uncancelled here; treat every delta below as unreliable. Re-acquire interleaved.");
+	} else if(report.interleaved === null) {
+		console.log("  (could not verify interleaving from timestamps)");
+	}
+	// The rig's own resolution: the median CI half-width across keys; the smallest effect it can call.
+	const floor = report.keys.length ? median(report.keys.map((k) => k.ci95Pct)) : null;
+	if(floor !== null) {
+		console.log(`  Resolution floor (median 95% CI half-width): ±${floor.toFixed(1)}%. Deltas smaller than this are inconclusive by construction.`);
+	}
+	const counts = { improvement: 0, regression: 0, inconclusive: 0 };
+	report.keys.forEach((k) => { counts[k.verdict]++; });
+	console.log(`  Verdicts: ${counts.improvement} improvement, ${counts.regression} regression, ${counts.inconclusive} inconclusive`);
+	console.log("");
+	console.log("KEY\tbefore_ms\tafter_ms\tΔmedian\tΔmean\t95% CI\tverdict");
+	report.keys
+		.slice()
+		.sort((a, b) => Math.abs(b.deltaMeanPct) - Math.abs(a.deltaMeanPct))
+		.forEach((k) => {
+			const tag = k.verdict === "inconclusive" ? "inconclusive" : k.verdict.toUpperCase();
+			console.log(
+				`${k.key}\t${k.beforeMedian.toFixed(3)}\t${k.afterMedian.toFixed(3)}\t` +
+				`${fmtPct(k.deltaMedianPct)}\t${fmtPct(k.deltaMeanPct)}\t[${fmtPct(k.ciLoPct)}, ${fmtPct(k.ciHiPct)}]\t${tag}`
+			);
+		});
+}
+
+function main() {
+	const args = process.argv.slice(2);
+	let jsonOut = null;
+	const positional = [];
+	for(let i = 0; i < args.length; i++) {
+		if(args[i] === "--json") { jsonOut = args[++i]; }
+		else { positional.push(args[i]); }
+	}
+	if(positional.length < 2) { usage(); process.exit(1); }
+	const report = compare(positional[0], positional[1]);
+	print(report);
+	if(jsonOut) {
+		fs.writeFileSync(jsonOut, JSON.stringify(report, null, 2), "utf8");
+	}
+}
+
+main();


### PR DESCRIPTION
Add a benchmark harness for the parse, render, refresh and filter paths. This defines a Performance Testing harness that can get pulled into mirrors of `master` and `working-branch` to have interleaved testing run (batch testing A/B then B/A style).

* Runs benchmark tiddlers tagged `$:/tags/performance-test` through a `--perf` command on Node and a browser runner
* Report every measurement with its spread and a resolvable-effect floor, and mark noise-dominated rows (so nobody quotes noise as signal)
* Compare two versions with `scripts/perf/compare-runs.js`, which pairs interleaved runs so session drift cancels, and reads inconclusive when the confidence interval straddles zero
* Count core function calls with `scripts/perf/call-census.js` (a sampling profiler mis-attributes time and points at functions that barely ran)
* Surface TiddlyWiki's own `$tw.perf` instrumentation with `instrument=yes`, reporting invocation counts alongside time
* Cover child walks, transclusion, filters, search at scale, bulk sync, story river, large bodies, parse and render phases, and the real content corpus (tw5com edition tiddlers)

---

A run on 5.5.0-prerelease (Node v24, 40 iterations) shows:

* A filter-heavy list of 2000 tiddlers renders in 66 ms, and `$tw.perf` attributes 61 ms of that to the filter itself, about 92%.
* An indexed lookup beats a scan by roughly 15 times for the same 500 results (0.46 ms against 6.75 ms). (Search skips the index, so every query scans every tiddler's title, tags and text.)
* Rendering costs about 4.6 times parsing (1.48 ms against 0.32 ms).
* 25 of 33 rows read noisy in that run. Longer runs or further design considerations may be needed.

The `Performance Findings` tiddler in the perftest edition records the snapshot and the command to reproduce it.

This PR will remain a draft for now, both to refine the Performance Testing harness and to leverage it against my other PRs.