### PR TITLE
[Bug] Fix the CSV parser blanking a table

### DIFF
--- a/core/modules/utils/csv.js
+++ b/core/modules/utils/csv.js
@@ -15,7 +15,8 @@ var getCellInfo = function(text, start, length, SEPARATOR) {
 	var isCellQuoted = text.charAt(start) === QUOTE;
 	var cellStart = isCellQuoted ? start + 1 : start;
 	
-	if(text.charAt(i) === SEPARATOR) {
+	// A quote licenses a separator inside the cell, so only an unquoted cell reads an immediate separator as empty
+	if(!isCellQuoted && text.charAt(cellStart) === SEPARATOR) {
 		return [cellStart, cellStart, false];
 	}
 	

--- a/editions/test/tiddlers/tests/test-csv.js
+++ b/editions/test/tiddlers/tests/test-csv.js
@@ -1,0 +1,41 @@
+/*\
+title: test-csv.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Tests the CSV parser.
+
+\*/
+
+"use strict";
+
+describe("CSV tests", function() {
+
+	it("parses a simple table", function() {
+		expect($tw.utils.parseCsvString("a,b,c\n1,2,3")).toEqual([["a","b","c"],["1","2","3"]]);
+	});
+
+	it("parses a table whose first cell reads empty", function() {
+		expect($tw.utils.parseCsvString(",b,c\n1,2,3")).toEqual([["","b","c"],["1","2","3"]]);
+	});
+
+	it("parses an empty cell in the middle of a row", function() {
+		expect($tw.utils.parseCsvString("a,,c")).toEqual([["a","","c"]]);
+	});
+
+	it("parses quoted cells", function() {
+		expect($tw.utils.parseCsvString('a,"b,still b",c')).toEqual([["a","b,still b","c"]]);
+	});
+
+	it("parses a quoted cell holding an escaped quote", function() {
+		expect($tw.utils.parseCsvString('a,"b ""quoted""",c')).toEqual([["a",'b "quoted"',"c"]]);
+	});
+
+	it("honours a custom separator", function() {
+		expect($tw.utils.parseCsvString("a;b;c",{separator: ";"})).toEqual([["a","b","c"]]);
+	});
+
+	it("parses a table with a header row into hashmaps", function() {
+		expect($tw.utils.parseCsvStringWithHeader("a,b\n1,2")).toEqual([{a: "1", b: "2"}]);
+	});
+});

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9919.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9919.tid
@@ -1,0 +1,13 @@
+title: $:/changenotes/5.5.0/#9919
+created: 20260712000000000
+modified: 20260712000000000
+description: Fix the CSV parser returning every cell empty
+release: 5.5.0
+tags: $:/tags/ChangeNote
+change-type: bugfix
+change-category: internal
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9919
+github-contributors: joshuafontany
+type: text/vnd.tiddlywiki
+
+`getCellInfo` read its loop variable before the loop declared it, so hoisting made it undefined and the parser tested the first character of the whole text rather than the first character of the cell. Any CSV opening with a separator therefore returned every cell empty, and the table rendered blank.


### PR DESCRIPTION
`getCellInfo` reads the loop variable `i` four lines before the `for` that declares it. Hoisting makes it `undefined`, so `text.charAt(undefined)` reads the first character of the whole text rather than the first character of the cell.

Any CSV whose first character equals the separator therefore returns every cell empty:

```
$tw.utils.parseCsvString(",b,c\n1,2,3")
-> [["","","","",""],["","","","",""]]
```

The table renders blank, with nothing to say why.

- Test the cell against its own start rather than against the hoisted `i`
- Keep a separator inside a quoted cell literal, since a quoted cell may legitimately open with one
- Cover the parser with tests, which it had none of

The quoted-cell guard matters: the existing wiki testcase `Separator in quoted cells` fails without it.
