### PR TITLE
Return a marker node from the whitespace pragma

### DIFF
--- a/core/modules/parsers/wikiparser/rules/whitespace.js
+++ b/core/modules/parsers/wikiparser/rules/whitespace.js
@@ -31,11 +31,13 @@ Parse the most recent match
 */
 exports.parse = function() {
 	var self = this;
+	var start = this.match.index;
 	// Move past the pragma invocation
 	this.parser.pos = this.matchRegExp.lastIndex;
 	// Parse whitespace delimited tokens terminated by a line break
 	var reMatch = /[^\S\n]*(\S+)|(\r?\n)/mg,
-		tokens = [];
+		tokens = [],
+		end = this.parser.pos;
 	reMatch.lastIndex = this.parser.pos;
 	var match = reMatch.exec(this.parser.source);
 	while(match && match.index === this.parser.pos) {
@@ -47,6 +49,7 @@ exports.parse = function() {
 		// Process the token
 		if(match[1]) {
 			tokens.push(match[1]);
+			end = reMatch.lastIndex;
 		}
 		// Match the next token
 		match = reMatch.exec(this.parser.source);
@@ -62,6 +65,14 @@ exports.parse = function() {
 				break;
 		}
 	});
-	// No parse tree nodes to return
-	return [];
+	// No widget to render, return a void node so the pragma survives in the parse tree
+	return [{
+		type: "void",
+		attributes: {
+			values: {type: "string", value: tokens.join(" ")}
+		},
+		children: [],
+		start: start,
+		end: end
+	}];
 };

--- a/editions/test/tiddlers/tests/test-wikitext-whitespace-pragma.js
+++ b/editions/test/tiddlers/tests/test-wikitext-whitespace-pragma.js
@@ -1,0 +1,43 @@
+/*\
+title: test-wikitext-whitespace-pragma.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Regression test: the \whitespace pragma must leave a trace in the parse
+tree. It was the only pragma whose rule returned an empty array, so no
+consumer could know the pragma was present or reproduce it; \rules and
+pragma comments both return marker nodes. The rule now returns a void
+marker node (rendered as a pass-through, no DOM node) carrying the token
+list and exact source positions. Red without the whitespace.js rule change.
+
+Reproduce in the browser F12 console:
+
+	$tw.wiki.parseText("text/vnd.tiddlywiki","\\whitespace trim\nContent\n").tree
+	// tree[0] must be {type: "void", rule: "whitespace", start: 0, end: 16}
+	// with attributes.values.value === "trim"; the rest of the tiddler is
+	// chained as its children
+
+\*/
+
+"use strict";
+
+describe("WikiText whitespace pragma tests", function() {
+
+	var wiki = $tw.test.wiki();
+
+	var parse = function(text) {
+		return wiki.parseText("text/vnd.tiddlywiki",text).tree;
+	};
+
+	it("should return a void marker node for the whitespace pragma", function() {
+		var tree = parse("\\whitespace trim\nContent\n");
+		expect(tree[0].type).toBe("void");
+		expect(tree[0].rule).toBe("whitespace");
+		expect(tree[0].attributes.values.value).toBe("trim");
+		expect(tree[0].start).toBe(0);
+		expect(tree[0].end).toBe(16);
+		// Pragmas chain the rest of the tiddler as their children
+		expect(tree[0].children[0].tag).toBe("p");
+	});
+
+});

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9909-whitespace-pragma-node.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9909-whitespace-pragma-node.tid
@@ -1,0 +1,13 @@
+change-category: developer
+change-type: enhancement
+created: 20260712235154000
+description: The \whitespace pragma leaves a void marker node in the parse tree
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/issues/9909
+modified: 20260712235154000
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9909
+type: text/vnd.tiddlywiki
+
+The `\whitespace` pragma now leaves a void marker node in the parse tree, carrying its keyword list in a `values` attribute and exact source positions. For consistency, it behaves like `\rules` and pragma comments, which already leave marker nodes; it was the only pragma that vanished from the tree. Void nodes render as a pass-through, so rendered output is unchanged.


### PR DESCRIPTION
Record the \whitespace pragma in the parse tree as a void marker node, matching \rules and pragma comments.

- Fixes #9909.

* Return a void node carrying the keyword list in a values attribute and exact source positions, instead of an empty array
* Render the node as a pass-through; measured cost is within noise
* Note for third-party code: trees of tiddlers using \whitespace gain one node level at the pragma position, matching the \rules shape


Part of #9908.
