### PR TITLE
Annotate the parse tree of conditional shortcuts

### DIFF
--- a/core/modules/parsers/wikiparser/rules/conditional.js
+++ b/core/modules/parsers/wikiparser/rules/conditional.js
@@ -54,11 +54,13 @@ exports.parse = function() {
 };
 
 exports.parseIfClause = function(filterCondition) {
-	// Create the list widget
+	// Create the list widget; isConditional marks it as synthesized from the
+	// conditional shortcut syntax rather than written as a $list widget
 	var listWidget = {
 		type: "list",
 		tag: "$list",
 		isBlock: this.is.block,
+		isConditional: true,
 		children: [
 			{
 				type: "list-template",
@@ -79,6 +81,9 @@ exports.parseIfClause = function(filterCondition) {
 	var reEndString = "\\<\\%\\s*(endif)\\s*\\%\\>|\\<\\%\\s*(else)\\s*\\%\\>|\\<\\%\\s*(elseif)\\s+([\\s\\S]+?)\\%\\>",
 		ex;
 	if(hasLineBreak) {
+		// A serializer cannot see the blank line that switches this body to
+		// block mode, so record it
+		listWidget.children[0].blockContent = true;
 		ex = this.parser.parseBlocksTerminatedExtended(reEndString);
 	} else {
 		var reEnd = new RegExp(reEndString,"mg");
@@ -97,6 +102,7 @@ exports.parseIfClause = function(filterCondition) {
 			var reEndString = "\\<\\%\\s*(endif)\\s*\\%\\>",
 				ex;
 			if(hasLineBreak) {
+				listWidget.children[1].blockContent = true;
 				ex = this.parser.parseBlocksTerminatedExtended(reEndString);
 			} else {
 				var reEnd = new RegExp(reEndString,"mg");
@@ -107,6 +113,9 @@ exports.parseIfClause = function(filterCondition) {
 		} else if(ex.match[3] === "elseif") {
 			// Parse the elseif clause by reusing this parser, passing the new filter condition
 			listWidget.children[1].children = this.parseIfClause(ex.match[4]);
+			// Record the clause span from its marker to the end of the construct
+			listWidget.children[1].children[0].start = ex.match.index;
+			listWidget.children[1].children[0].end = this.parser.pos;
 		}
 	}
 	// Return the parse tree node

--- a/editions/test/tiddlers/tests/test-wikitext-conditional-annotations.js
+++ b/editions/test/tiddlers/tests/test-wikitext-conditional-annotations.js
@@ -1,0 +1,53 @@
+/*\
+title: test-wikitext-conditional-annotations.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Regression tests: the <%if%> shortcut compiles to $list widgets that are
+indistinguishable from hand-written ones, so the parse tree must annotate
+what only exists in the source. Red without the conditional.js rule change:
+
+* isConditional marks the widgets synthesized from the shortcut syntax
+* the synthesized elseif clause carries a span from its marker to the end
+  of the construct
+* blockContent on a clause body container records the blank line after the
+  marker that switched the body to block mode (without it, tree-only
+  serialization collapses block conditionals to inline form)
+
+Reproduce in the browser F12 console:
+
+	$tw.wiki.parseText("text/vnd.tiddlywiki",
+		"<%if [[x]]%>\n\nfoo\n<%elseif [[y]]%>\n\nbar\n<%endif%>\n").tree
+	// tree[0] is the $list widget: isConditional true, children[0] (the
+	// $list-template) has blockContent true; the elseif clause sits in
+	// children[1].children[0] with start 18 (its marker) and end 49 (after
+	// the endif marker)
+
+\*/
+
+"use strict";
+
+describe("WikiText conditional annotation tests", function() {
+
+	var wiki = $tw.test.wiki();
+
+	var parse = function(text) {
+		return wiki.parseText("text/vnd.tiddlywiki",text).tree;
+	};
+
+	it("should annotate conditional shortcut clauses", function() {
+		var tree = parse("<%if [[x]]%>\n\nfoo\n<%elseif [[y]]%>\n\nbar\n<%endif%>\n");
+		var ifWidget = tree[0];
+		expect(ifWidget.isConditional).toBe(true);
+		expect(ifWidget.children[0].blockContent).toBe(true);
+		var elseifClause = ifWidget.children[1].children[0];
+		expect(elseifClause.isConditional).toBe(true);
+		// Synthesized clauses carry no rule name; that distinguishes them
+		// from a real nested conditional in an else body
+		expect(elseifClause.rule).toBeUndefined();
+		expect(elseifClause.start).toBe(18);
+		expect(elseifClause.end).toBe(49);
+		expect(elseifClause.children[0].blockContent).toBe(true);
+	});
+
+});

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9910-conditional-annotations.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9910-conditional-annotations.tid
@@ -1,0 +1,13 @@
+change-category: developer
+change-type: enhancement
+created: 20260713001110000
+description: Conditional shortcuts annotate their parse tree nodes
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/issues/9910
+modified: 20260713001110000
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9910
+type: text/vnd.tiddlywiki
+
+The `$list` widgets synthesized by the `<%if%>` conditional shortcut now carry `isConditional: true`, following the `isProcedureDefinition` precedent; `<%elseif%>` clauses carry their exact source spans, and clause bodies that a blank line switched to block mode carry `blockContent: true`. Consumers can distinguish conditional shortcuts from hand-written `$list` widgets and reproduce the original clause layout. The new fields are purely additive; rendered output is unchanged.


### PR DESCRIPTION
Make the <%if%> shortcut distinguishable from hand-written $list widgets in the parse tree.

- Fixes #9910.

* Stamp isConditional on the synthesized $list widgets, following the isProcedureDefinition precedent
* Record each elseif clause span from its marker to the end of the construct
* Record blockContent on clause bodies that a blank line switched to block mode, so the tree can reproduce block vs inline layout
* Note for third-party code: the new fields are purely additive; rendered output is unchanged


Part of #9908.
