### PR TITLE
Annotate the parse tree of quote blocks

### DIFF
--- a/core/modules/parsers/wikiparser/rules/quoteblock.js
+++ b/core/modules/parsers/wikiparser/rules/quoteblock.js
@@ -20,13 +20,16 @@ exports.init = function(parser) {
 
 exports.parse = function() {
 	var classes = ["tc-quote"];
-	// Get all the details of the match
-	var reEndString = "^\\s*" + this.match[1] + "(?!<)";
+	// Get all the details of the match; a nested quote re-enters this rule
+	// instance and overwrites this.match, so capture the marker now
+	var marker = this.match[1];
+	var reEndString = "^\\s*" + marker + "(?!<)";
 	// Move past the <s
 	this.parser.pos = this.matchRegExp.lastIndex;
 	// Parse any classes, whitespace and then the optional cite itself
 	var classStart = this.parser.pos;
-	classes.push.apply(classes, this.parser.parseClasses());
+	var userClasses = this.parser.parseClasses();
+	classes.push.apply(classes, userClasses);
 	var classEnd = this.parser.pos;
 	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
 	var citeStart = this.parser.pos;
@@ -39,6 +42,7 @@ exports.parse = function() {
 		tree.unshift({
 			type: "element",
 			tag: "cite",
+			isQuoteCite: true,
 			children: cite,
 			start: citeStart,
 			end: citeEnd
@@ -54,15 +58,20 @@ exports.parse = function() {
 		tree.push({
 			type: "element",
 			tag: "cite",
+			isQuoteCite: true,
 			children: cite,
 			start: citeStart,
 			end: citeEnd
 		});
 	}
-	// Return the blockquote element
+	// Return the blockquote element; the marker depth and the raw class list
+	// are not recoverable from the class attribute, which fuses the classes
+	// with the synthesized tc-quote
 	return [{
 		type: "element",
 		tag: "blockquote",
+		marker: marker,
+		userClasses: userClasses,
 		attributes: {
 			class: { type: "string", value: classes.join(" "), start: classStart, end: classEnd },
 		},

--- a/editions/test/tiddlers/tests/test-wikitext-quoteblock-annotations.js
+++ b/editions/test/tiddlers/tests/test-wikitext-quoteblock-annotations.js
@@ -1,0 +1,55 @@
+/*\
+title: test-wikitext-quoteblock-annotations.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Regression tests: three facts about a <<< quote block exist only in the
+source and must be annotated. Red without the quoteblock.js rule change:
+
+* marker records the depth (<<< vs <<<<); without it nested quotes cannot
+  be reproduced from the tree in parseable form
+* userClasses records the raw class list; the class attribute fuses it
+  with the synthesized tc-quote
+* isQuoteCite distinguishes the synthesized cite elements from literal
+  <cite> markup in the quote body
+
+The nested case also guards a re-entrancy bug: a nested quote re-enters
+the same rule instance and overwrites this.match, so the outer quote
+recorded the inner quote's marker until the marker was captured before
+parsing the body.
+
+Reproduce in the browser F12 console:
+
+	$tw.wiki.parseText("text/vnd.tiddlywiki",
+		"<<<.myClass.other\nQuote\n<<< The Cite\n").tree
+	// tree[0]: marker "<<<", userClasses ["myClass","other"], and the
+	// trailing cite child has isQuoteCite true
+
+\*/
+
+"use strict";
+
+describe("WikiText quoteblock annotation tests", function() {
+
+	var wiki = $tw.test.wiki();
+
+	var parse = function(text) {
+		return wiki.parseText("text/vnd.tiddlywiki",text).tree;
+	};
+
+	it("should annotate quote blocks with marker, classes and cites", function() {
+		var tree = parse("<<<.myClass.other\nQuote\n<<< The Cite\n");
+		expect(tree[0].marker).toBe("<<<");
+		expect(tree[0].userClasses).toEqual(["myClass","other"]);
+		var cite = tree[0].children[1];
+		expect(cite.tag).toBe("cite");
+		expect(cite.isQuoteCite).toBe(true);
+	});
+
+	it("should record each quote's own marker when nesting", function() {
+		var tree = parse("<<< Outer Cite\nA\n\n<<<< Deep\nB\n<<<<\n<<<\n");
+		expect(tree[0].marker).toBe("<<<");
+		expect(tree[0].children[2].marker).toBe("<<<<");
+	});
+
+});

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9911-quoteblock-annotations.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9911-quoteblock-annotations.tid
@@ -1,0 +1,13 @@
+change-category: developer
+change-type: enhancement
+created: 20260713002208000
+description: Quote blocks annotate their parse tree nodes
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/issues/9911
+modified: 20260713002208000
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9911
+type: text/vnd.tiddlywiki
+
+Blockquote nodes produced by the `<<<` quote block rule now carry the `marker` depth and the `userClasses` list, and the synthesized cite elements carry `isQuoteCite: true`, following the `isProcedureDefinition` precedent. Consumers can reproduce nested quotes in parseable form and can distinguish user classes and cites from the fused `class` attribute and from literal `<cite>` markup. The new fields are purely additive; rendered output is unchanged.


### PR DESCRIPTION
Record the facts about a <<< quote block that existed only in the source: marker depth, user classes, and which cite elements are synthesized.

- Fixes #9911.

* Record marker and userClasses on the blockquote node and stamp isQuoteCite on the synthesized cite elements; without them nested quotes emit unparseable <<< at every level and user classes fuse with the synthesized tc-quote
* Capture the marker before parsing the body; a nested quote re-enters the same rule instance and overwrites this.match
* Note for third-party code: the new fields are purely additive; rendered output is unchanged


Part of #9908.
