### PR TITLE
Annotate the parse tree of lists

### DIFF
--- a/core/modules/parsers/wikiparser/rules/list.js
+++ b/core/modules/parsers/wikiparser/rules/list.js
@@ -67,6 +67,7 @@ Parse the most recent match
 exports.parse = function() {
 	// Array of parse tree nodes for the previous row of the list
 	var listStack = [];
+	var blankLineBefore = false;
 	// Cycle through the items in the list
 	while(true) {
 		// Match the list marker
@@ -133,6 +134,12 @@ exports.parse = function() {
 		var lastListChildren = listStack[listStack.length-1].children,
 			lastListItem = lastListChildren[lastListChildren.length-1],
 			classes = this.parser.parseClasses();
+		// Record what only this row knows: its marker string and whether a
+		// blank line separated it from the previous row
+		lastListItem.rowMarker = match[0];
+		if(blankLineBefore) {
+			lastListItem.blankLineBefore = true;
+		}
 		var classEnd = this.parser.pos;
 		this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
 		var tree = this.parser.parseInlineRun(/(\r?\n)/mg);
@@ -145,7 +152,9 @@ exports.parse = function() {
 			lastListItem.attributes.class.end = classEnd;
 		}
 		// Consume any whitespace following the list item
+		var trailingStart = this.parser.pos;
 		this.parser.skipWhitespace();
+		blankLineBefore = /\r?\n[^\S\n\r]*\r?\n/.test(this.parser.source.substring(trailingStart,this.parser.pos));
 	}
 	// Return the root element of the list
 	return [listStack[0]];

--- a/editions/test/tiddlers/tests/test-wikitext-list-annotations.js
+++ b/editions/test/tiddlers/tests/test-wikitext-list-annotations.js
@@ -1,0 +1,45 @@
+/*\
+title: test-wikitext-list-annotations.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Regression tests: two facts about a list exist only in the source and must
+be annotated. Red without the list.js rule change:
+
+* rowMarker records the full marker string of each item (e.g. "*#" in
+  mixed nesting); the tag nesting alone cannot always reproduce it
+* blankLineBefore marks an item that followed a blank line: the parser
+  merges same-type lists across blank lines into ONE node, so the
+  separator is otherwise unrecoverable
+
+Reproduce in the browser F12 console:
+
+	$tw.wiki.parseText("text/vnd.tiddlywiki","* one\n*# two\n\n* three\n").tree
+	// one ul node: its first li has rowMarker "*", the nested ol li has
+	// rowMarker "*#", and the li for "three" has blankLineBefore true
+
+\*/
+
+"use strict";
+
+describe("WikiText list annotation tests", function() {
+
+	var wiki = $tw.test.wiki();
+
+	var parse = function(text) {
+		return wiki.parseText("text/vnd.tiddlywiki",text).tree;
+	};
+
+	it("should annotate list rows with their marker and blank line merges", function() {
+		var tree = parse("* one\n*# two\n\n* three\n");
+		var items = tree[0].children;
+		expect(items[0].rowMarker).toBe("*");
+		expect(items[0].children[1].children[0].rowMarker).toBe("*#");
+		// The parser merged the two runs into this single list; only the
+		// annotation still knows about the separating blank line
+		expect(items[1].rowMarker).toBe("*");
+		expect(items[1].blankLineBefore).toBe(true);
+		expect(items[0].blankLineBefore).toBeUndefined();
+	});
+
+});

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9912-list-annotations.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9912-list-annotations.tid
@@ -1,0 +1,13 @@
+change-category: developer
+change-type: enhancement
+created: 20260713002940000
+description: Lists annotate their parse tree nodes
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/issues/9912
+modified: 20260713002940000
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9912
+type: text/vnd.tiddlywiki
+
+List items in the parse tree now carry `rowMarker` with the exact marker text that produced them, e.g. `*#` in mixed nesting or the `;`/`:` description-list forms, and the first item after two list runs merged across a blank line carries `blankLineBefore: true`. Consumers can reproduce the exact marker strings and the original list runs, which the tag nesting alone cannot. The new fields are purely additive; rendered output is unchanged.


### PR DESCRIPTION
Record the facts about a list that existed only in the source: each item's full row marker and the blank line between merged list runs. 

- Fixes #9912.

* Record rowMarker on every list item; the tag nesting alone cannot reproduce mixed markers like *# or the ;/: description-list forms
* Record blankLineBefore on the first item after a blank-line merge; the parser folds same-type lists across blank lines into one node, so the separator was unrecoverable from the tree
* Note for third-party code: the new fields are purely additive; rendered output is unchanged


Part of #9908.
