### PR TITLE
Make block spans and block position consistent

### DIFF
--- a/core/modules/parsers/wikiparser/rules/table.js
+++ b/core/modules/parsers/wikiparser/rules/table.js
@@ -128,6 +128,20 @@ var processRow = function(prevColumns) {
 	return tree;
 };
 
+/*
+The row regexps consume the terminating line end, which belongs to the gap
+between blocks, not to the node spans
+*/
+function trimLineEnd(source,pos,floor) {
+	if(pos > floor && source.charAt(pos - 1) === "\n") {
+		pos -= 1;
+	}
+	if(pos > floor && source.charAt(pos - 1) === "\r") {
+		pos -= 1;
+	}
+	return pos;
+}
+
 exports.parse = function() {
 	var rowContainerTypes = {"c":"caption", "h":"thead", "":"tbody", "f":"tfoot"},
 		table = {type: "element", tag: "table", children: []},
@@ -174,11 +188,11 @@ exports.parse = function() {
 				// Process the row
 				theRow.children = processRow.call(this,prevColumns);
 				this.parser.pos = rowMatch.index + rowMatch[0].length;
-				theRow.end = this.parser.pos;
+				theRow.end = trimLineEnd(this.parser.source,this.parser.pos,rowMatch.index);
 				// Increment the row count
 				rowCount++;
 			}
-			rowContainer.end = this.parser.pos;
+			rowContainer.end = trimLineEnd(this.parser.source,this.parser.pos,rowContainer.start);
 		}
 		rowMatch = rowRegExp.exec(this.parser.source);
 	}

--- a/core/modules/parsers/wikiparser/rules/typedblock.js
+++ b/core/modules/parsers/wikiparser/rules/typedblock.js
@@ -39,9 +39,10 @@ exports.parse = function() {
 	// Save the type
 	var parseType = this.match[1],
 		renderType = this.match[2];
+	// The span starts at the opening $$$ marker, not at the content
+	var start = this.match.index;
 	// Move past the match
 	this.parser.pos = this.matchRegExp.lastIndex;
-	var start = this.parser.pos;
 	// Look for the end of the block
 	reEnd.lastIndex = this.parser.pos;
 	var match = reEnd.exec(this.parser.source),

--- a/core/modules/parsers/wikiparser/wikiparser.js
+++ b/core/modules/parsers/wikiparser/wikiparser.js
@@ -248,8 +248,40 @@ WikiParser.prototype.parseBlock = function(terminatorRegExpString) {
 		if(subTree.length > 0) {
 			if(subTree[0].start === undefined) subTree[0].start = start;
 			if(subTree[subTree.length - 1].end === undefined) subTree[subTree.length - 1].end = this.pos;
+			// A block rule must consume its terminating line end to parse,
+			// but the separator belongs to the gap between blocks, not to
+			// the block's span. Never trim into a child's span, e.g. an
+			// unterminated quote whose last text node keeps its newline
+			var lastNode = subTree[subTree.length - 1];
+			if(typeof lastNode.start === "number" && typeof lastNode.end === "number") {
+				var floor = lastNode.start,
+					probe = lastNode;
+				while(probe.children && probe.children.length) {
+					probe = probe.children[probe.children.length - 1];
+					if(typeof probe.end === "number" && probe.end > floor) {
+						floor = probe.end;
+					}
+				}
+				var end = lastNode.end;
+				if(end > floor && this.source.charAt(end - 1) === "\n") {
+					end -= 1;
+					if(end > floor && this.source.charAt(end - 1) === "\r") {
+						end -= 1;
+					}
+					while(end > floor && (this.source.charAt(end - 1) === " " || this.source.charAt(end - 1) === "\t")) {
+						end -= 1;
+					}
+					lastNode.end = end;
+				}
+			}
 		}
-		$tw.utils.each(subTree, function (node) { node.rule = nextMatch.rule.name; });
+		$tw.utils.each(subTree, function (node) {
+			node.rule = nextMatch.rule.name;
+			// The parse position is not recoverable from the tree: a rule
+			// like macrocallblock produces the same node shape as its inline
+			// twin, but block position decides the separators around it
+			node.blockPosition = true;
+		});
 		return subTree;
 	}
 	// Treat it as a paragraph if we didn't find a block rule

--- a/editions/test/tiddlers/tests/test-wikitext-block-spans.js
+++ b/editions/test/tiddlers/tests/test-wikitext-block-spans.js
@@ -1,0 +1,139 @@
+/*\
+title: test-wikitext-block-spans.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Span discipline: a block node's span must end at its last syntactic byte.
+Line ends and blank lines that separate blocks belong to the gaps between
+sibling spans, never inside a span. Without this, every consumer that maps
+spans back to syntax has to know per rule whether the trailing line end was
+consumed, and a serializer must repair or trim tails per rule.
+
+One spec per block rule (and one per pragma rule, whose spans must also end
+at their own syntax before the chained children begin), so a red spec names
+the offending rule directly.
+
+Reproduce a single case in the browser F12 console, e.g. for the table:
+
+	var tree = $tw.wiki.parseText("text/vnd.tiddlywiki","|a|b|\n|c|d|\n\nafter").tree;
+	var table = tree[0];
+	// the span must end at the last "|", not after the newline:
+	"\n\r".indexOf($tw.wiki.getTiddlerText !== null && "|a|b|\n|c|d|\n\nafter".charAt(table.end - 1)) === -1
+
+\*/
+
+"use strict";
+
+describe("WikiText block span tests", function() {
+
+	var wiki = $tw.test.wiki();
+
+	/*
+	Find the first node with the given rule name, depth first
+	*/
+	function findRule(nodes,rule) {
+		var found = null;
+		$tw.utils.each(nodes,function(node) {
+			if(node.rule === rule) {
+				found = node;
+				return false;
+			}
+			if(node.children) {
+				found = findRule(node.children,rule);
+				return !found;
+			}
+		});
+		return found;
+	}
+
+	/*
+	Parse the source, locate the rule's node and assert its span covers
+	exactly the construct: it starts at the first syntactic byte (all
+	specimens place the construct at position 0) and it does not end at a
+	consumed line end
+	*/
+	function expectCleanSpanEnd(source,rule) {
+		var tree = wiki.parseText("text/vnd.tiddlywiki",source).tree;
+		var node = findRule(tree,rule);
+		expect(node ? node.rule : "NODE NOT FOUND for " + rule).toBe(rule);
+		if(node.start !== 0) {
+			expect(rule + " span starts at " + node.start).toBe(rule + " span starts at its first syntactic byte");
+		}
+		var lastByte = source.charAt(node.end - 1);
+		if(lastByte === "\n" || lastByte === "\r") {
+			// Fail with a readable message naming the offending span
+			expect(rule + " span " + node.start + ".." + node.end + " ends with " + JSON.stringify(lastByte)).toBe(rule + " span ends at its last syntactic byte");
+		}
+		// Block dispatched nodes carry blockPosition; paragraphs signal block
+		// position through their rule name instead, and pragmas are
+		// dispatched separately
+		var pragmaRules = ["macrodef","fnprocdef","whitespace","import","commentblock"];
+		if(rule !== "parseblock" && pragmaRules.indexOf(rule) === -1) {
+			expect(rule + " blockPosition is " + node.blockPosition).toBe(rule + " blockPosition is true");
+		}
+	}
+
+	it("should end the paragraph span at its text", function() {
+		expectCleanSpanEnd("some text\n\nafter","parseblock");
+	});
+
+	it("should end the heading span at its text", function() {
+		expectCleanSpanEnd("! Heading\n\nafter","heading");
+	});
+
+	it("should end the horizrule span at the last dash", function() {
+		expectCleanSpanEnd("---\n\nafter","horizrule");
+	});
+
+	it("should end the codeblock span at the closing fence", function() {
+		expectCleanSpanEnd("```\nvar x = 1;\n```\n\nafter","codeblock");
+	});
+
+	it("should end the typedblock span at the closing marker", function() {
+		expectCleanSpanEnd("$$$text/plain\nhello\n$$$\n\nafter","typedblock");
+	});
+
+	it("should end the transcludeblock span at the closing braces", function() {
+		expectCleanSpanEnd("{{MyTiddler}}\n\nafter","transcludeblock");
+	});
+
+	it("should end the filteredtranscludeblock span at the closing brace", function() {
+		expectCleanSpanEnd("{{{ [tag[x]] }}}\n\nafter","filteredtranscludeblock");
+	});
+
+	it("should end the macrocallblock span at the closing marker", function() {
+		expectCleanSpanEnd("<<mac>>\n\nafter","macrocallblock");
+	});
+
+	it("should end the styleblock span at the closing marker", function() {
+		expectCleanSpanEnd("@@.myClass\ntext\n@@\n\nafter","styleblock");
+	});
+
+	it("should end the table span at the last pipe", function() {
+		expectCleanSpanEnd("|a|b|\n|c|d|\n\nafter","table");
+	});
+
+	it("should end the list span at the last item", function() {
+		expectCleanSpanEnd("* one\n* two\n\nafter","list");
+	});
+
+	it("should end the quoteblock span at the closing marker", function() {
+		expectCleanSpanEnd("<<<\nquote\n<<<\n\nafter","quoteblock");
+	});
+
+	it("should end the block html span at the close tag", function() {
+		expectCleanSpanEnd("<div>\n\nfoo\n\n</div>\n\nafter","html");
+	});
+
+	it("should end the block conditional span at the endif marker", function() {
+		expectCleanSpanEnd("<%if [[x]]%>\n\nfoo\n<%endif%>\n\nafter","conditional");
+	});
+
+	it("should end the pragma spans at their own syntax", function() {
+		expectCleanSpanEnd("\\define myMacro() nothing\n\nafter","macrodef");
+		expectCleanSpanEnd("\\procedure myProc()\nnothing\n\\end\n\nafter","fnprocdef");
+		expectCleanSpanEnd("\\import [[Defs]]\nafter","import");
+		expectCleanSpanEnd("<!-- comment -->\n\nafter","commentblock");
+	});
+
+});

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -82,7 +82,7 @@ describe("WikiText parser tests", function() {
 		);
 		expect(parse("<div attribute={{TiddlerTitle!!field}}>\n\nsome text</div>")).toEqual(
 
-			[ { type : "element", start : 0, attributes : { attribute : { start : 4, name : "attribute", type : "indirect", textReference : "TiddlerTitle!!field", end : 38 } }, orderedAttributes: [ { start : 4, name : "attribute", type : "indirect", textReference : "TiddlerTitle!!field", end : 38 } ], tag : "div", rule: "html", end : 56, openTagStart: 0, openTagEnd: 39, closeTagStart: 50, closeTagEnd: 56, isBlock : true, children : [ { type : "element", tag : "p", rule: "parseblock", start : 41, end : 50, children : [ { type : "text", text : "some text", start : 41, end : 50 } ] } ] } ]
+			[ { type : "element", start : 0, attributes : { attribute : { start : 4, name : "attribute", type : "indirect", textReference : "TiddlerTitle!!field", end : 38 } }, orderedAttributes: [ { start : 4, name : "attribute", type : "indirect", textReference : "TiddlerTitle!!field", end : 38 } ], tag : "div", rule: "html", end : 56, openTagStart: 0, openTagEnd: 39, closeTagStart: 50, closeTagEnd: 56, isBlock : true, blockPosition : true, children : [ { type : "element", tag : "p", rule: "parseblock", start : 41, end : 50, children : [ { type : "text", text : "some text", start : 41, end : 50 } ] } ] } ]
 
 		);
 		expect(parse("<div><div attribute={{TiddlerTitle!!field}}>\n\nsome text</div></div>")).toEqual(
@@ -92,7 +92,7 @@ describe("WikiText parser tests", function() {
 		);
 		expect(parse("<div><div attribute={{TiddlerTitle!!field}}>\n\n!some heading</div></div>")).toEqual(
 
-			[ { type : "element", tag : "p", rule: "parseblock", start: 0, end: 71, children : [ { type : "element", start : 0, end: 71, openTagStart: 0, openTagEnd: 5, closeTagStart: 71, closeTagEnd: 71, attributes : {  }, orderedAttributes: [ ], tag : "div", rule: "html", isBlock : false, children : [ { type : "element", start : 5, attributes : { attribute : { start : 9, name : "attribute", type : "indirect", textReference : "TiddlerTitle!!field", end : 43 } }, orderedAttributes: [ { start : 9, name : "attribute", type : "indirect", textReference : "TiddlerTitle!!field", end : 43 } ], tag : "div", end : 71, openTagStart: 5, openTagEnd: 44, closeTagStart: 71, closeTagEnd: 71, rule: "html", isBlock : true, children : [ { type : "element", tag : "h1", start: 46, end: 71, rule: "heading", attributes : { class : { type : "string", value : "", start: 47, end: 47 } }, children : [ { type : "text", text : "some heading</div></div>", start : 47, end : 71 } ] } ] } ] } ] } ]
+			[ { type : "element", tag : "p", rule: "parseblock", start: 0, end: 71, children : [ { type : "element", start : 0, end: 71, openTagStart: 0, openTagEnd: 5, closeTagStart: 71, closeTagEnd: 71, attributes : {  }, orderedAttributes: [ ], tag : "div", rule: "html", isBlock : false, children : [ { type : "element", start : 5, attributes : { attribute : { start : 9, name : "attribute", type : "indirect", textReference : "TiddlerTitle!!field", end : 43 } }, orderedAttributes: [ { start : 9, name : "attribute", type : "indirect", textReference : "TiddlerTitle!!field", end : 43 } ], tag : "div", end : 71, openTagStart: 5, openTagEnd: 44, closeTagStart: 71, closeTagEnd: 71, rule: "html", isBlock : true, children : [ { type : "element", tag : "h1", start: 46, end: 71, rule: "heading", blockPosition : true, attributes : { class : { type : "string", value : "", start: 47, end: 47 } }, children : [ { type : "text", text : "some heading</div></div>", start : 47, end : 71 } ] } ] } ] } ] } ]
 
 		);
 		expect(parse("<div><div attribute={{TiddlerTitle!!field}}>\n!some heading</div></div>")).toEqual(
@@ -243,12 +243,12 @@ describe("WikiText parser tests", function() {
 	it("should block mode filtered transclusions", function() {
 		expect(parse("{{{ filter }}}")).toEqual(
 
-			[ { type: "list", attributes: { filter: { type: "string", value: " filter ", start: 3, end: 11 } }, isBlock: true, start: 0, end: 14, rule: "filteredtranscludeblock" } ]
+			[ { type: "list", attributes: { filter: { type: "string", value: " filter ", start: 3, end: 11 } }, isBlock: true, blockPosition: true, start: 0, end: 14, rule: "filteredtranscludeblock" } ]
 
 		);
 		expect(parse("{{{ fil\nter }}}")).toEqual(
 
-			[ { type: "list", attributes: { filter: { type: "string", value: " fil\nter ", start: 3, end: 12 } }, isBlock: true, start: 0, end: 15, rule: "filteredtranscludeblock" } ]
+			[ { type: "list", attributes: { filter: { type: "string", value: " fil\nter ", start: 3, end: 12 } }, isBlock: true, blockPosition: true, start: 0, end: 15, rule: "filteredtranscludeblock" } ]
 
 		);
 	});
@@ -296,37 +296,37 @@ describe("WikiText parser tests", function() {
 	it("should parse block macro calls", function() {
 		expect(parse("<<john>>\n<<paul>>\r\n<<george>>\n<<ringo>>")).toEqual(
 
-			[ { type: "transclude", start: 0, rule: "macrocallblock", attributes: { $variable: { name: "$variable", type: "string", value: "john" }}, orderedAttributes: [ { name: "$variable", type: "string", value: "john" }], end: 8, isBlock: true }, { type: "transclude", start: 9, rule: "macrocallblock", attributes: { $variable: { name: "$variable", type: "string", value: "paul" }}, orderedAttributes: [ { name: "$variable", type: "string", value: "paul" }], end: 17, isBlock: true }, { type: "transclude", start: 19, rule: "macrocallblock", attributes: { $variable: { name: "$variable", type: "string", value: "george" }}, orderedAttributes: [ { name: "$variable", type: "string", value: "george" }], end: 29, isBlock: true }, { type: "transclude", start: 30, rule: "macrocallblock", attributes: { $variable: { name: "$variable", type: "string", value: "ringo" }}, orderedAttributes: [ { name: "$variable", type: "string", value: "ringo" }], end: 39, isBlock: true } ]
+			[ { type: "transclude", start: 0, rule: "macrocallblock", attributes: { $variable: { name: "$variable", type: "string", value: "john" }}, orderedAttributes: [ { name: "$variable", type: "string", value: "john" }], end: 8, isBlock: true, blockPosition: true }, { type: "transclude", start: 9, rule: "macrocallblock", attributes: { $variable: { name: "$variable", type: "string", value: "paul" }}, orderedAttributes: [ { name: "$variable", type: "string", value: "paul" }], end: 17, isBlock: true, blockPosition: true }, { type: "transclude", start: 19, rule: "macrocallblock", attributes: { $variable: { name: "$variable", type: "string", value: "george" }}, orderedAttributes: [ { name: "$variable", type: "string", value: "george" }], end: 29, isBlock: true, blockPosition: true }, { type: "transclude", start: 30, rule: "macrocallblock", attributes: { $variable: { name: "$variable", type: "string", value: "ringo" }}, orderedAttributes: [ { name: "$variable", type: "string", value: "ringo" }], end: 39, isBlock: true, blockPosition: true } ]
 
 		);
 		expect(parse("<<john one:val1 two: 'val \"2\"' three: \"val '3'\" four: \"\"\"val 4\"5'\"\"\" five: [[val 5]] >>")).toEqual(
 
-			[{"type":"transclude","start":0,"end":87,"rule":"macrocallblock","attributes":{"$variable":{"name":"$variable","type":"string","value":"john"},"one":{"name":"one","assignmentOperator":":","type":"string","value":"val1","start":6,"end":15},"two":{"name":"two","assignmentOperator":":","type":"string","value":"val \"2\"","quoted":true,"start":15,"end":30},"three":{"name":"three","assignmentOperator":":","type":"string","value":"val '3'","quoted":true,"start":30,"end":47},"four":{"name":"four","assignmentOperator":":","type":"string","value":"val 4\"5'","quoted":true,"start":47,"end":68},"five":{"name":"five","assignmentOperator":":","type":"string","value":"val 5","quoted":true,"start":68,"end":84}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"one","assignmentOperator":":","type":"string","value":"val1","start":6,"end":15},{"name":"two","assignmentOperator":":","type":"string","value":"val \"2\"","quoted":true,"start":15,"end":30},{"name":"three","assignmentOperator":":","type":"string","value":"val '3'","quoted":true,"start":30,"end":47},{"name":"four","assignmentOperator":":","type":"string","value":"val 4\"5'","quoted":true,"start":47,"end":68},{"name":"five","assignmentOperator":":","type":"string","value":"val 5","quoted":true,"start":68,"end":84}],"isBlock":true}]
+			[{"type":"transclude","start":0,"end":87,"rule":"macrocallblock","attributes":{"$variable":{"name":"$variable","type":"string","value":"john"},"one":{"name":"one","assignmentOperator":":","type":"string","value":"val1","start":6,"end":15},"two":{"name":"two","assignmentOperator":":","type":"string","value":"val \"2\"","quoted":true,"start":15,"end":30},"three":{"name":"three","assignmentOperator":":","type":"string","value":"val '3'","quoted":true,"start":30,"end":47},"four":{"name":"four","assignmentOperator":":","type":"string","value":"val 4\"5'","quoted":true,"start":47,"end":68},"five":{"name":"five","assignmentOperator":":","type":"string","value":"val 5","quoted":true,"start":68,"end":84}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"one","assignmentOperator":":","type":"string","value":"val1","start":6,"end":15},{"name":"two","assignmentOperator":":","type":"string","value":"val \"2\"","quoted":true,"start":15,"end":30},{"name":"three","assignmentOperator":":","type":"string","value":"val '3'","quoted":true,"start":30,"end":47},{"name":"four","assignmentOperator":":","type":"string","value":"val 4\"5'","quoted":true,"start":47,"end":68},{"name":"five","assignmentOperator":":","type":"string","value":"val 5","quoted":true,"start":68,"end":84}],"isBlock":true,"blockPosition":true}]
 
 		);
 		expect(parse("<< carrots\n\n<<john>>")).toEqual(
 
-			[ { type: "element", tag: "p", rule: "parseblock", start : 0, end : 10, children: [ { type: "text", text: "<< carrots", start : 0, end : 10 } ] }, { type: "transclude", start: 12, rule: "macrocallblock", attributes: { $variable: {name: "$variable", type:"string", value: "john"} }, orderedAttributes: [ {name: "$variable", type:"string", value: "john"} ], end: 20, isBlock: true } ]
+			[ { type: "element", tag: "p", rule: "parseblock", start : 0, end : 10, children: [ { type: "text", text: "<< carrots", start : 0, end : 10 } ] }, { type: "transclude", start: 12, rule: "macrocallblock", attributes: { $variable: {name: "$variable", type:"string", value: "john"} }, orderedAttributes: [ {name: "$variable", type:"string", value: "john"} ], end: 20, isBlock: true, blockPosition: true } ]
 
 		);
 		expect(parse("before\n\n<<john>>")).toEqual(
 
-			[ { type: "element", tag: "p", rule: "parseblock", start : 0, end : 6, children: [ { type: "text", text: "before", start : 0, end : 6 } ] }, { type: "transclude", start: 8, rule: "macrocallblock", attributes: { $variable: {name: "$variable", type:"string", value: "john"} }, orderedAttributes: [ {name: "$variable", type:"string", value: "john"} ], end: 16, isBlock: true } ]
+			[ { type: "element", tag: "p", rule: "parseblock", start : 0, end : 6, children: [ { type: "text", text: "before", start : 0, end : 6 } ] }, { type: "transclude", start: 8, rule: "macrocallblock", attributes: { $variable: {name: "$variable", type:"string", value: "john"} }, orderedAttributes: [ {name: "$variable", type:"string", value: "john"} ], end: 16, isBlock: true, blockPosition: true } ]
 
 		);
 		expect(parse("<<john>>\nafter")).toEqual(
 
-			[ { type: "transclude", start: 0, rule: "macrocallblock", attributes: { $variable: {name: "$variable", type:"string", value: "john"} }, orderedAttributes: [ {name: "$variable", type:"string", value: "john"} ], end: 8, isBlock: true }, { type: "element", tag: "p", rule: "parseblock", start: 9, end: 14, children: [ { type: "text", text: "after", start: 9, end: 14 } ] } ]
+			[ { type: "transclude", start: 0, rule: "macrocallblock", attributes: { $variable: {name: "$variable", type:"string", value: "john"} }, orderedAttributes: [ {name: "$variable", type:"string", value: "john"} ], end: 8, isBlock: true, blockPosition: true }, { type: "element", tag: "p", rule: "parseblock", start: 9, end: 14, children: [ { type: "text", text: "after", start: 9, end: 14 } ] } ]
 
 		);
 		expect(parse("<<multiline arg:\"\"\"\n\nwikitext\n\"\"\" >>")).toEqual(
 
-			[{"type":"transclude","start":0,"end":36,"rule":"macrocallblock","attributes":{"$variable":{"name":"$variable","type":"string","value":"multiline"},"arg":{"name":"arg","assignmentOperator":":","type":"string","value":"\n\nwikitext\n","quoted":true,"start":11,"end":33}},"orderedAttributes":[{"name":"$variable","type":"string","value":"multiline"},{"name":"arg","assignmentOperator":":","type":"string","value":"\n\nwikitext\n","quoted":true,"start":11,"end":33}],"isBlock":true}]
+			[{"type":"transclude","start":0,"end":36,"rule":"macrocallblock","attributes":{"$variable":{"name":"$variable","type":"string","value":"multiline"},"arg":{"name":"arg","assignmentOperator":":","type":"string","value":"\n\nwikitext\n","quoted":true,"start":11,"end":33}},"orderedAttributes":[{"name":"$variable","type":"string","value":"multiline"},{"name":"arg","assignmentOperator":":","type":"string","value":"\n\nwikitext\n","quoted":true,"start":11,"end":33}],"isBlock":true,"blockPosition":true}]
 
 		);
 		expect(parse("<<outie one:'my <<innie>>' >>")).toEqual(
 
-			[ { type: "transclude", start: 0, rule: "macrocallblock", attributes: { $variable: {name: "$variable", type:"string", value: "outie"}, one: {name: "one", assignmentOperator: ":", type:"string", value: "my <<innie>>", quoted: true, start: 7, end: 26} }, orderedAttributes: [ {name: "$variable", type:"string", value: "outie"}, {name: "one", assignmentOperator: ":", type:"string", value: "my <<innie>>", quoted: true, start: 7, end: 26} ], end: 29, isBlock: true } ]
+			[ { type: "transclude", start: 0, rule: "macrocallblock", attributes: { $variable: {name: "$variable", type:"string", value: "outie"}, one: {name: "one", assignmentOperator: ":", type:"string", value: "my <<innie>>", quoted: true, start: 7, end: 26} }, orderedAttributes: [ {name: "$variable", type:"string", value: "outie"}, {name: "one", assignmentOperator: ":", type:"string", value: "my <<innie>>", quoted: true, start: 7, end: 26} ], end: 29, isBlock: true, blockPosition: true } ]
 
 		);
 	});
@@ -334,12 +334,12 @@ describe("WikiText parser tests", function() {
 	it("should parse tricky macrocall parameters", function() {
 		expect(parse("<<john pa>am>>")).toEqual(
 
-			[{"type":"transclude","start":0,"end":14,"attributes":{"0":{"name":"0","type":"string","value":"pa>am","start":6,"end":12,"isPositional":true},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"pa>am","start":6,"end":12,"isPositional":true}],"isBlock":true,"rule":"macrocallblock"}]
+			[{"type":"transclude","start":0,"end":14,"attributes":{"0":{"name":"0","type":"string","value":"pa>am","start":6,"end":12,"isPositional":true},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"pa>am","start":6,"end":12,"isPositional":true}],"isBlock":true,"blockPosition":true,"rule":"macrocallblock"}]
 
 		);
 		expect(parse("<<john param> >>")).toEqual(
 
-			[{"type":"transclude","start":0,"end":16,"attributes":{"0":{"name":"0","type":"string","value":"param>","start":6,"end":13,"isPositional":true},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"param>","start":6,"end":13,"isPositional":true}],"isBlock":true,"rule":"macrocallblock"}]
+			[{"type":"transclude","start":0,"end":16,"attributes":{"0":{"name":"0","type":"string","value":"param>","start":6,"end":13,"isPositional":true},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"param>","start":6,"end":13,"isPositional":true}],"isBlock":true,"blockPosition":true,"rule":"macrocallblock"}]
 
 		);
 		expect(parse("<<john param>>>")).toEqual(
@@ -350,7 +350,7 @@ describe("WikiText parser tests", function() {
 		// equals signs should be allowed
 		expect(parse("<<john var>=4 >>")).toEqual(
 
-			[{"type":"transclude","start":0,"end":16,"attributes":{"0":{"name":"0","type":"string","value":"var>=4","start":6,"end":13,"isPositional":true},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"var>=4","start":6,"end":13,"isPositional":true}],"isBlock":true,"rule":"macrocallblock"}]
+			[{"type":"transclude","start":0,"end":16,"attributes":{"0":{"name":"0","type":"string","value":"var>=4","start":6,"end":13,"isPositional":true},"$variable":{"name":"$variable","type":"string","value":"john"}},"orderedAttributes":[{"name":"$variable","type":"string","value":"john"},{"name":"0","type":"string","value":"var>=4","start":6,"end":13,"isPositional":true}],"isBlock":true,"blockPosition":true,"rule":"macrocallblock"}]
 
 		);
 
@@ -359,7 +359,7 @@ describe("WikiText parser tests", function() {
 	it("should parse horizontal rules", function() {
 		expect(parse("---Not a rule\n\n----\n\nBetween\n\n---")).toEqual(
 
-			[ { type : "element", tag : "p", rule: "parseblock", start : 0, end : 13, children : [ { type : "entity", entity : "&mdash;", start: 0, end: 3, rule: "dash" }, { type : "text", text : "Not a rule", start : 3, end : 13 } ] }, { type : "element", tag : "hr", start: 15, end: 20, rule: "horizrule" }, { type : "element", tag : "p", rule: "parseblock", start : 21, end : 28, children : [ { type : "text", text : "Between", start : 21, end : 28 } ] }, { type : "element", tag : "hr", start: 30, end: 33, rule: "horizrule" } ]
+			[ { type : "element", tag : "p", rule: "parseblock", start : 0, end : 13, children : [ { type : "entity", entity : "&mdash;", start: 0, end: 3, rule: "dash" }, { type : "text", text : "Not a rule", start : 3, end : 13 } ] }, { type : "element", tag : "hr", start: 15, end: 19, rule: "horizrule", blockPosition : true }, { type : "element", tag : "p", rule: "parseblock", start : 21, end : 28, children : [ { type : "text", text : "Between", start : 21, end : 28 } ] }, { type : "element", tag : "hr", start: 30, end: 33, rule: "horizrule", blockPosition : true } ]
 
 		);
 
@@ -385,6 +385,7 @@ describe("WikiText parser tests", function() {
 			start: 0,
 			end: 33,
 			rule: "table",
+			blockPosition: true,
 			children: [{
 				type: "element",
 				tag: "tbody",
@@ -400,7 +401,7 @@ describe("WikiText parser tests", function() {
 						{ name: "class", type: "string", value: "evenRow" },
 					],
 					start: 0,
-					end: 18,
+					end: 17,
 					children: [{
 						type: "element",
 						tag: "th",

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9914-block-span-discipline.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9914-block-span-discipline.tid
@@ -1,0 +1,13 @@
+change-category: developer
+change-type: bugfix
+created: 20260713004843000
+description: Block node spans cover exactly their own syntax and record their parse position
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/issues/9914
+modified: 20260713004843000
+release: 5.5.0
+tags: $:/tags/ChangeNote
+type: text/vnd.tiddlywiki
+title: $:/changenotes/5.5.0/#9914
+
+Block node spans now end at their last syntactic byte; for consistency, separators live in the gaps between spans. This shifts `start`/`end` for `transcludeblock`, `filteredtranscludeblock`, `horizrule`, `styleblock`, `typedblock` and `table` (positions first shipped in v5.4.0), and `typedblock` now starts at its opening `$$$`. Every block dispatched node also carries `blockPosition: true`, so block vs inline position is recoverable; `isBlock` is untouched. Rendered output is unchanged.


### PR DESCRIPTION
Cover exactly the block syntax with block node spans and record the parse position; separators live in the gaps. 

- Fixes #9914.

* Trim one trailing line end run at the block dispatch, never into a child's span; fix the table row and container ends and the typedblock start directly in their rules
* Stamp blockPosition beside the rule name; isBlock is untouched for rendering compatibility
* Note for third-party code: start/end shift for six block rules (positions shipped in v5.4.0) and block nodes gain blockPosition; rendering is unchanged


Part of #9908.
