### PR TITLE
replace resolve-colour with faster and recursion aware javascript functionality

### DIFF
--- a/core/modules/filters/colour-resolve.js
+++ b/core/modules/filters/colour-resolve.js
@@ -31,30 +31,111 @@ function getPalette(name, options) {
 Parse a palette entry value to extract a reference to another entry.
 Returns the target entry name if it's a simple reference, null otherwise.
 */
-function parseReference(value) {
+function parseReference(value,widget) {
 	if(typeof value !== "string" || value === "") {
 		return null;
 	}
-	var match;
-	// [tf.colour[name]]
+	var pos,attribute,widgetType,variableName,targetName,match,node,orderedAttributes,endPos,result;
+	// [tf.colour[name]] - literal string operand
 	match = value.match(/^\s*\[tf\.colour\[([^\]]+)\]\]\s*$/);
 	if(match) {
 		return match[1];
 	}
-	// <<colour name>> or <<color name>>
-	match = value.match(/^\s*<<colou?r\s+(\S+)\s*>>\s*$/);
+	// [tf.colour<name>] - variable reference operand
+	match = value.match(/^\s*\[tf\.colour<([^>]+)>\]\s*$/);
 	if(match) {
-		return match[1];
+		if(widget) {
+			result = widget.getVariable(match[1]);
+			if(typeof result === "string" && result !== "") {
+				return result;
+			}
+		}
+		return null;
 	}
-	// <$transclude ... $variable="colour" ... name="name" ... />
-	match = value.match(/^\s*<\$transclude[^>]*\$variable="colou?r"[^>]*name="([^"]+)"[^/]*\/>\s*$/);
+	// [tf.colour{name}] - text reference operand
+	match = value.match(/^\s*\[tf\.colour\{([^}]+)\}\]\s*$/);
 	if(match) {
-		return match[1];
+		if(widget) {
+			result = widget.wiki.getTextReference(match[1],"",widget.getVariable("currentTiddler"));
+			if(typeof result === "string" && result !== "") {
+				return result;
+			}
+		}
+		return null;
 	}
-	// <$macrocall ... $name="colour" ... name="name" ... />
-	match = value.match(/^\s*<\$macrocall[^>]*\$name="colou?r"[^>]*name="([^"]+)"[^>]*\/>\s*$/);
-	if(match) {
-		return match[1];
+	// <<colour name>> or <<colour "name">> or <<colour name=value>> or <<colour name={{{filter}}}>> etc.
+	pos = $tw.utils.skipWhiteSpace(value,0);
+	node = $tw.utils.parseMacroInvocationAsTransclusion(value,pos);
+	if(node && node.attributes.$variable && /^colou?r$/i.test(node.attributes.$variable.value)) {
+		endPos = $tw.utils.skipWhiteSpace(value,node.end);
+		if(endPos === value.length) {
+			orderedAttributes = node.orderedAttributes || [];
+			if(orderedAttributes.length > 0) {
+				// Find the parameter named "name", or the first positional parameter
+				var targetParam = null;
+				for(var i = 0; i < orderedAttributes.length; i++) {
+					if(orderedAttributes[i].name === "name") {
+						targetParam = orderedAttributes[i];
+						break;
+					}
+				}
+				if(!targetParam) {
+					for(var i = 0; i < orderedAttributes.length; i++) {
+						if(orderedAttributes[i].isPositional) {
+							targetParam = orderedAttributes[i];
+							break;
+						}
+					}
+				}
+				if(!targetParam) {
+					targetParam = orderedAttributes[0];
+				}
+				if(widget) {
+					result = widget.computeAttribute(targetParam);
+					if(typeof result === "string" && result !== "") {
+						return result;
+					}
+				} else if(targetParam.type === "string") {
+					return targetParam.value;
+				}
+			}
+		}
+	}
+	// Use the core parameter parser for widget tags
+	pos = $tw.utils.skipWhiteSpace(value,0);
+	if(value.substr(pos,11).toLowerCase() === "<$transclude") {
+		widgetType = "transclude";
+		pos += 11;
+	} else if(value.substr(pos,10).toLowerCase() === "<$macrocall") {
+		widgetType = "macrocall";
+		pos += 10;
+	} else {
+		return null;
+	}
+	// Parse attributes using the core parameter parser
+	variableName = null;
+	targetName = null;
+	attribute = $tw.utils.parseAttribute(value,pos);
+	while(attribute) {
+		if(attribute.type === "string") {
+			if(widgetType === "transclude" && attribute.name === "$variable" && /^colou?r$/i.test(attribute.value)) {
+				variableName = attribute.value;
+			} else if(widgetType === "macrocall" && attribute.name === "$name" && /^colou?r$/i.test(attribute.value)) {
+				variableName = attribute.value;
+			} else if(attribute.name === "name") {
+				targetName = attribute.value;
+			}
+		} else if(attribute.name === "name" && widget) {
+			result = widget.computeAttribute(attribute);
+			if(typeof result === "string" && result !== "") {
+				targetName = result;
+			}
+		}
+		pos = attribute.end;
+		attribute = $tw.utils.parseAttribute(value,pos);
+	}
+	if(variableName !== null && targetName !== null) {
+		return targetName;
 	}
 	return null;
 }
@@ -63,7 +144,7 @@ function parseReference(value) {
 Recursively resolve a palette entry name to its terminal entry.
 Returns the name of the terminal entry.
 */
-function resolveEntry(name, palette, visited) {
+function resolveEntry(name, palette, visited, widget) {
 	if(visited.indexOf(name) !== -1) {
 		return name;
 	}
@@ -72,9 +153,9 @@ function resolveEntry(name, palette, visited) {
 	if(value === undefined || value === null) {
 		return name;
 	}
-	var target = parseReference(value);
+	var target = parseReference(value, widget);
 	if(target) {
-		return resolveEntry(target, palette, visited);
+		return resolveEntry(target, palette, visited, widget);
 	}
 	return name;
 }
@@ -96,7 +177,7 @@ exports["colour-resolve"] = function(source, operator, options) {
 	if(operator.prefix === "!") {
 		source(function(tiddler, title) {
 			var value = palette[title];
-			if(value === undefined || value === null || parseReference(value) === null) {
+			if(value === undefined || value === null || parseReference(value, options.widget) === null) {
 				if(mode === "colour") {
 					results.push(value || "");
 				} else {
@@ -107,7 +188,7 @@ exports["colour-resolve"] = function(source, operator, options) {
 	} else {
 		source(function(tiddler, title) {
 			var visited = [];
-			var resolved = resolveEntry(title, palette, visited);
+			var resolved = resolveEntry(title, palette, visited, options.widget);
 			if(mode === "colour") {
 				results.push(palette[resolved] || "");
 			} else {

--- a/core/modules/filters/colour-resolve.js
+++ b/core/modules/filters/colour-resolve.js
@@ -1,0 +1,111 @@
+/*\
+title: $:/core/modules/filters/colour-resolve.js
+type: application/javascript
+module-type: filteroperator
+
+Filter operator for resolving colour palette entry reference chains
+
+\*/
+
+"use strict";
+
+/*
+Get the consolidated palette dictionary
+*/
+function getConsolidatedPalette(options) {
+	var tiddler = options.wiki.getTiddler("$:/temp/palette-consolidated");
+	if(tiddler) {
+		return options.wiki.getTiddlerData(tiddler);
+	}
+	return null;
+}
+
+/*
+Parse a palette entry value to extract a reference to another entry.
+Returns the target entry name if it's a simple reference, null otherwise.
+*/
+function parseReference(value) {
+	if(typeof value !== "string" || value === "") {
+		return null;
+	}
+	var match;
+	// [tf.colour[name]]
+	match = value.match(/^\s*\[tf\.colour\[([^\]]+)\]\]\s*$/);
+	if(match) {
+		return match[1];
+	}
+	// <<colour name>> or <<color name>>
+	match = value.match(/^\s*<<colou?r\s+(\S+)\s*>>\s*$/);
+	if(match) {
+		return match[1];
+	}
+	// <$transclude ... $variable="colour" ... name="name" ... />
+	match = value.match(/^\s*<\$transclude[^>]*\$variable="colou?r"[^>]*name="([^"]+)"[^/]*\/>\s*$/);
+	if(match) {
+		return match[1];
+	}
+	// <$macrocall ... $name="colour" ... name="name" ... />
+	match = value.match(/^\s*<\$macrocall[^>]*\$name="colou?r"[^>]*name="([^"]+)"[^>]*\/>\s*$/);
+	if(match) {
+		return match[1];
+	}
+	return null;
+}
+
+/*
+Recursively resolve a palette entry name to its terminal entry.
+Returns the name of the terminal entry.
+*/
+function resolveEntry(name, palette, visited) {
+	if(visited.indexOf(name) !== -1) {
+		return name;
+	}
+	visited.push(name);
+	var value = palette[name];
+	if(value === undefined || value === null) {
+		return name;
+	}
+	var target = parseReference(value);
+	if(target) {
+		return resolveEntry(target, palette, visited);
+	}
+	return name;
+}
+
+/*
+Export our filter function
+*/
+exports["colour-resolve"] = function(source, operator, options) {
+	var results = [];
+	var mode = (((operator.suffixes || [])[0] || ["name"])[0] || "name").toLowerCase();
+	var palette = getConsolidatedPalette(options);
+	if(!palette) {
+		source(function(tiddler, title) {
+			results.push(title);
+		});
+		return results;
+	}
+	if(operator.prefix === "!") {
+		source(function(tiddler, title) {
+			var value = palette[title];
+			if(value === undefined || value === null || parseReference(value) === null) {
+				if(mode === "colour") {
+					results.push(value || "");
+				} else {
+					results.push(title);
+				}
+			}
+		});
+	} else {
+		source(function(tiddler, title) {
+			var visited = [];
+			var resolved = resolveEntry(title, palette, visited);
+			if(mode === "colour") {
+				results.push(palette[resolved] || "");
+			} else {
+				results.push(resolved);
+			}
+		});
+	}
+	return results;
+};

--- a/core/modules/filters/colour-resolve.js
+++ b/core/modules/filters/colour-resolve.js
@@ -149,11 +149,17 @@ function resolveEntry(name, palette, visited, widget) {
 		return name;
 	}
 	visited.push(name);
+	// First, try to resolve the input title itself as a reference
+	var target = parseReference(name, widget);
+	if(target) {
+		return resolveEntry(target, palette, visited, widget);
+	}
+	// Otherwise, look up the palette entry value and resolve that
 	var value = palette[name];
 	if(value === undefined || value === null) {
 		return name;
 	}
-	var target = parseReference(value, widget);
+	target = parseReference(value, widget);
 	if(target) {
 		return resolveEntry(target, palette, visited, widget);
 	}

--- a/core/modules/filters/colour-resolve.js
+++ b/core/modules/filters/colour-resolve.js
@@ -36,6 +36,11 @@ function parseReference(value,widget) {
 		return null;
 	}
 	var pos,attribute,widgetType,variableName,targetName,match,node,orderedAttributes,endPos,result;
+	// Quick bail: references must start with [ or <
+	var firstChar = value.charCodeAt(0);
+	if(firstChar !== 91 && firstChar !== 60) { // [ and <
+		return null;
+	}
 	// [tf.colour[name]] - literal string operand
 	match = value.match(/^\s*\[tf\.colour\[([^\]]+)\]\]\s*$/);
 	if(match) {
@@ -63,79 +68,84 @@ function parseReference(value,widget) {
 		}
 		return null;
 	}
-	// <<colour name>> or <<colour "name">> or <<colour name=value>> or <<colour name={{{filter}}}>> etc.
+	// Bail if not [ or < after leading whitespace
 	pos = $tw.utils.skipWhiteSpace(value,0);
-	node = $tw.utils.parseMacroInvocationAsTransclusion(value,pos);
-	if(node && node.attributes.$variable && /^colou?r$/i.test(node.attributes.$variable.value)) {
-		endPos = $tw.utils.skipWhiteSpace(value,node.end);
-		if(endPos === value.length) {
-			orderedAttributes = node.orderedAttributes || [];
-			if(orderedAttributes.length > 0) {
-				// Find the parameter named "name", or the first positional parameter
-				var targetParam = null;
-				for(var i = 0; i < orderedAttributes.length; i++) {
-					if(orderedAttributes[i].name === "name") {
-						targetParam = orderedAttributes[i];
-						break;
-					}
-				}
-				if(!targetParam) {
-					for(var i = 0; i < orderedAttributes.length; i++) {
-						if(orderedAttributes[i].isPositional) {
-							targetParam = orderedAttributes[i];
-							break;
+	firstChar = value.charCodeAt(pos);
+	if(firstChar === 60) { // <
+		// <<colour ... macro invocation
+		if(value.charCodeAt(pos + 1) === 60) { // <<
+			node = $tw.utils.parseMacroInvocationAsTransclusion(value,pos);
+			if(node && node.attributes.$variable && /^colou?r$/i.test(node.attributes.$variable.value)) {
+				endPos = $tw.utils.skipWhiteSpace(value,node.end);
+				if(endPos === value.length) {
+					orderedAttributes = node.orderedAttributes || [];
+					if(orderedAttributes.length > 0) {
+						// Find the parameter named "name", or the first positional parameter
+						var targetParam = null;
+						for(var i = 0; i < orderedAttributes.length; i++) {
+							if(orderedAttributes[i].name === "name") {
+								targetParam = orderedAttributes[i];
+								break;
+							}
+						}
+						if(!targetParam) {
+							for(var i = 0; i < orderedAttributes.length; i++) {
+								if(orderedAttributes[i].isPositional) {
+									targetParam = orderedAttributes[i];
+									break;
+								}
+							}
+						}
+						if(!targetParam) {
+							targetParam = orderedAttributes[0];
+						}
+						if(widget) {
+							result = widget.computeAttribute(targetParam);
+							if(typeof result === "string" && result !== "") {
+								return result;
+							}
+						} else if(targetParam.type === "string") {
+							return targetParam.value;
 						}
 					}
 				}
-				if(!targetParam) {
-					targetParam = orderedAttributes[0];
-				}
-				if(widget) {
-					result = widget.computeAttribute(targetParam);
-					if(typeof result === "string" && result !== "") {
-						return result;
-					}
-				} else if(targetParam.type === "string") {
-					return targetParam.value;
-				}
 			}
 		}
-	}
-	// Use the core parameter parser for widget tags
-	pos = $tw.utils.skipWhiteSpace(value,0);
-	if(value.substr(pos,11).toLowerCase() === "<$transclude") {
-		widgetType = "transclude";
-		pos += 11;
-	} else if(value.substr(pos,10).toLowerCase() === "<$macrocall") {
-		widgetType = "macrocall";
-		pos += 10;
-	} else {
-		return null;
-	}
-	// Parse attributes using the core parameter parser
-	variableName = null;
-	targetName = null;
-	attribute = $tw.utils.parseAttribute(value,pos);
-	while(attribute) {
-		if(attribute.type === "string") {
-			if(widgetType === "transclude" && attribute.name === "$variable" && /^colou?r$/i.test(attribute.value)) {
-				variableName = attribute.value;
-			} else if(widgetType === "macrocall" && attribute.name === "$name" && /^colou?r$/i.test(attribute.value)) {
-				variableName = attribute.value;
-			} else if(attribute.name === "name") {
-				targetName = attribute.value;
-			}
-		} else if(attribute.name === "name" && widget) {
-			result = widget.computeAttribute(attribute);
-			if(typeof result === "string" && result !== "") {
-				targetName = result;
-			}
+		// <$transclude or <$macrocall widget tag
+		if(value.substr(pos,11).toLowerCase() === "<$transclude") {
+			widgetType = "transclude";
+			pos += 11;
+		} else if(value.substr(pos,10).toLowerCase() === "<$macrocall") {
+			widgetType = "macrocall";
+			pos += 10;
+		} else {
+			return null;
 		}
-		pos = attribute.end;
+		// Parse attributes using the core parameter parser
+		variableName = null;
+		targetName = null;
 		attribute = $tw.utils.parseAttribute(value,pos);
-	}
-	if(variableName !== null && targetName !== null) {
-		return targetName;
+		while(attribute) {
+			if(attribute.type === "string") {
+				if(widgetType === "transclude" && attribute.name === "$variable" && /^colou?r$/i.test(attribute.value)) {
+					variableName = attribute.value;
+				} else if(widgetType === "macrocall" && attribute.name === "$name" && /^colou?r$/i.test(attribute.value)) {
+					variableName = attribute.value;
+				} else if(attribute.name === "name") {
+					targetName = attribute.value;
+				}
+			} else if(attribute.name === "name" && widget) {
+				result = widget.computeAttribute(attribute);
+				if(typeof result === "string" && result !== "") {
+					targetName = result;
+				}
+			}
+			pos = attribute.end;
+			attribute = $tw.utils.parseAttribute(value,pos);
+		}
+		if(variableName !== null && targetName !== null) {
+			return targetName;
+		}
 	}
 	return null;
 }
@@ -149,19 +159,17 @@ function resolveEntry(name, palette, visited, widget) {
 		return name;
 	}
 	visited.push(name);
-	// First, try to resolve the input title itself as a reference
-	var target = parseReference(name, widget);
-	if(target) {
-		return resolveEntry(target, palette, visited, widget);
-	}
-	// Otherwise, look up the palette entry value and resolve that
+	// Look up the palette entry value
 	var value = palette[name];
 	if(value === undefined || value === null) {
 		return name;
 	}
-	target = parseReference(value, widget);
-	if(target) {
-		return resolveEntry(target, palette, visited, widget);
+	// Only parse if it looks like a reference
+	if(typeof value === "string" && (value.charCodeAt(0) === 91 || value.charCodeAt(0) === 60)) {
+		var target = parseReference(value, widget);
+		if(target) {
+			return resolveEntry(target, palette, visited, widget);
+		}
 	}
 	return name;
 }
@@ -180,12 +188,19 @@ exports["colour-resolve"] = function(source, operator, options) {
 		});
 		return results;
 	}
+	var widget = options.widget;
 	if(operator.prefix === "!") {
 		source(function(tiddler, title) {
 			var value = palette[title];
-			if(value === undefined || value === null || parseReference(value, options.widget) === null) {
+			if(value === undefined || value === null) {
 				if(mode === "colour") {
-					results.push(value || "");
+					results.push("");
+				} else {
+					results.push(title);
+				}
+			} else if(typeof value !== "string" || (value.charCodeAt(0) !== 91 && value.charCodeAt(0) !== 60) || parseReference(value, widget) === null) {
+				if(mode === "colour") {
+					results.push(value);
 				} else {
 					results.push(title);
 				}
@@ -194,7 +209,7 @@ exports["colour-resolve"] = function(source, operator, options) {
 	} else {
 		source(function(tiddler, title) {
 			var visited = [];
-			var resolved = resolveEntry(title, palette, visited, options.widget);
+			var resolved = resolveEntry(title, palette, visited, widget);
 			if(mode === "colour") {
 				results.push(palette[resolved] || "");
 			} else {

--- a/core/modules/filters/colour-resolve.js
+++ b/core/modules/filters/colour-resolve.js
@@ -10,9 +10,16 @@ Filter operator for resolving colour palette entry reference chains
 "use strict";
 
 /*
-Get the consolidated palette dictionary
+Get a palette dictionary by name, or the consolidated palette if no name given
 */
-function getConsolidatedPalette(options) {
+function getPalette(name, options) {
+	if(name) {
+		var tiddler = options.wiki.getTiddler(name);
+		if(tiddler) {
+			return options.wiki.getTiddlerData(tiddler);
+		}
+		return null;
+	}
 	var tiddler = options.wiki.getTiddler("$:/temp/palette-consolidated");
 	if(tiddler) {
 		return options.wiki.getTiddlerData(tiddler);
@@ -78,7 +85,8 @@ Export our filter function
 exports["colour-resolve"] = function(source, operator, options) {
 	var results = [];
 	var mode = (((operator.suffixes || [])[0] || ["name"])[0] || "name").toLowerCase();
-	var palette = getConsolidatedPalette(options);
+	var paletteName = operator.operand || "";
+	var palette = getPalette(paletteName, options);
 	if(!palette) {
 		source(function(tiddler, title) {
 			results.push(title);

--- a/core/modules/filters/is/colourspace.js
+++ b/core/modules/filters/is/colourspace.js
@@ -1,0 +1,33 @@
+/*\
+title: $:/core/modules/filters/is/colourspace.js
+type: application/javascript
+module-type: isfilteroperator
+
+Filter function for [is[colourspace]] and [is[colorspace]]
+
+\*/
+
+"use strict";
+
+/*
+Export our filter function
+*/
+exports.colourspace = function(source,prefix,options) {
+	var results = [];
+	if(prefix === "!") {
+		source(function(tiddler,title) {
+			if(!$tw.utils.parseCSSColorObject(title)) {
+				results.push(title);
+			}
+		});
+	} else {
+		source(function(tiddler,title) {
+			if($tw.utils.parseCSSColorObject(title)) {
+				results.push(title);
+			}
+		});
+	}
+	return results;
+};
+
+exports.colorspace = exports.colourspace;

--- a/core/modules/utils/dom/color-utils.js
+++ b/core/modules/utils/dom/color-utils.js
@@ -35,18 +35,13 @@ exports.parseCSSColor = function(colourString) {
 /*
 Preferred way to parse a Color.js colour
 */
-var parseCSSColorObjectCache = Object.create(null);
 exports.parseCSSColorObject = function(colourString) {
-	if(colourString in parseCSSColorObjectCache) {
-		return parseCSSColorObjectCache[colourString];
-	}
 	var c = null;
 	try {
 		c = new Color(colourString);
 	} catch(e) {
 		// Return null if there is an error
 	}
-	parseCSSColorObjectCache[colourString] = c;
 	return c;
 };
 

--- a/core/modules/utils/dom/color-utils.js
+++ b/core/modules/utils/dom/color-utils.js
@@ -35,13 +35,18 @@ exports.parseCSSColor = function(colourString) {
 /*
 Preferred way to parse a Color.js colour
 */
+var parseCSSColorObjectCache = Object.create(null);
 exports.parseCSSColorObject = function(colourString) {
+	if(colourString in parseCSSColorObjectCache) {
+		return parseCSSColorObjectCache[colourString];
+	}
 	var c = null;
 	try {
 		c = new Color(colourString);
 	} catch(e) {
 		// Return null if there is an error
 	}
+	parseCSSColorObjectCache[colourString] = c;
 	return c;
 };
 

--- a/core/ui/PaletteEditor.tid
+++ b/core/ui/PaletteEditor.tid
@@ -18,9 +18,11 @@ title: $:/PaletteEditor
 <br>
 <%if [<colourName>colour-resolve:colour{$:/palette}is[colourspace]] %>
 <$edit-text index={{{ [<colourName>colour-resolve{$:/palette}] }}} type="color" tag="input" class="tc-palette-manager-colour-input"/>
-<%elseif [<colourName>!prefix[?]] %>
+<%elseif [<colourName>!prefix[?]then<currentTiddler>getindex<colourName>!match[]] %>
 <$wikify name="bgColour" text={{{ [subfilter<tf.palette.getindex>] }}}>
-<div style.background-color=<<bgColour>> style.height="2em" style.width="100%" style.border-radius="2px" style.margin="3px" class="tc-palette-manager-colour-input" />
+<%if [<bgColour>is[colourspace]] %>
+<div style.background-color=<<bgColour>> style.height="2em" style.width="100%" style.border-radius="2px" style.margin="3px 0" class="tc-palette-manager-colour-input" />
+<% endif %>
 </$wikify>
 <% endif %>
 <%if [<currentTiddler>getindex<colourName>!is[colourspace]then<colourName>colour-resolve:colour{$:/palette}is[colourspace]] %>

--- a/core/ui/PaletteEditor.tid
+++ b/core/ui/PaletteEditor.tid
@@ -9,23 +9,15 @@ title: $:/PaletteEditor
 \end
 \define colour-tooltip(showhide) $showhide$ editor for $(newColourName)$ 
 
-\define resolve-colour(macrocall)
-\import $:/core/macros/utils
-\whitespace trim
-<$wikify name="name" text="""$macrocall$""">
-<<name>>
-</$wikify>
-\end
-
 \define delete-colour-index-actions() <$action-setfield $index=<<colourName>>/>
 \define palette-manager-colour-row-segment()
 \whitespace trim
 <$edit-text index=<<colourName>> tag="input" placeholder=<<edit-colour-placeholder>> default=""/>
 <br>
-<$edit-text index=<<colourName>> type="color" tag="input" class="tc-palette-manager-colour-input"/>
+<$edit-text index={{{ [<colourName>colour-resolve[]] }}} type="color" tag="input" class="tc-palette-manager-colour-input"/>
 <$list filter="[<currentTiddler>getindex<colourName>removeprefix[<<]removesuffix[>>]] [<currentTiddler>getindex<colourName>removeprefix[<$]removesuffix[/>]]" variable="ignore">
 <$set name="state" value={{{ [[$:/state/palettemanager/]addsuffix<currentTiddler>addsuffix[/]addsuffix<colourName>] }}}>
-<$wikify name="newColourName" text="""<$macrocall $name="resolve-colour" macrocall={{{ [<currentTiddler>getindex<colourName>] }}}/>""">
+<$let newColourName={{{ [<colourName>colour-resolve[]] }}} >
 <$reveal state=<<state>> type="nomatch" text="show">
 <$button tooltip=<<colour-tooltip show>> aria-label=<<colour-tooltip show>> class="tc-btn-invisible" set=<<state>> setTo="show">{{$:/core/images/down-arrow}}<$text text=<<newColourName>> class="tc-small-gap-left"/></$button><br>
 </$reveal>
@@ -39,7 +31,7 @@ title: $:/PaletteEditor
 <br><br>
 </$set>
 </$reveal>
-</$wikify>
+</$let>
 </$set>
 </$list>
 \end
@@ -53,7 +45,10 @@ title: $:/PaletteEditor
 {{$:/core/images/delete-button}}</$button>
 </span>
 ''<$macrocall $name="describePaletteColour" colour=<<colourName>>/>''<br/>
-<$macrocall $name="colourName" $output="text/plain"/>
+<$macrocall $name="colourName" $output="text/plain"/><br/>
+<span style.background-color={{{ [<colourName>colour-resolve:colour[]] }}} style.color=<<contrastcolour target={{{ [<colourName>colour-resolve:colour[]] }}} colourA="#ffffff" colourB="#000000">> class="tc-palette-manager-colour-swatch">
+<$text text={{{ [<colourName>colour-resolve:colour[]] }}}/>
+</span>
 </td>
 <td>
 <<palette-manager-colour-row-segment>>

--- a/core/ui/PaletteEditor.tid
+++ b/core/ui/PaletteEditor.tid
@@ -14,10 +14,10 @@ title: $:/PaletteEditor
 \whitespace trim
 <$edit-text index=<<colourName>> tag="input" placeholder=<<edit-colour-placeholder>> default=""/>
 <br>
-<$edit-text index={{{ [<colourName>colour-resolve[]] }}} type="color" tag="input" class="tc-palette-manager-colour-input"/>
+<$edit-text index={{{ [<colourName>colour-resolve{$:/palette}] }}} type="color" tag="input" class="tc-palette-manager-colour-input"/>
 <$list filter="[<currentTiddler>getindex<colourName>removeprefix[<<]removesuffix[>>]] [<currentTiddler>getindex<colourName>removeprefix[<$]removesuffix[/>]]" variable="ignore">
 <$set name="state" value={{{ [[$:/state/palettemanager/]addsuffix<currentTiddler>addsuffix[/]addsuffix<colourName>] }}}>
-<$let newColourName={{{ [<colourName>colour-resolve[]] }}} >
+<$let newColourName={{{ [<colourName>colour-resolve{$:/palette}] }}} >
 <$reveal state=<<state>> type="nomatch" text="show">
 <$button tooltip=<<colour-tooltip show>> aria-label=<<colour-tooltip show>> class="tc-btn-invisible" set=<<state>> setTo="show">{{$:/core/images/down-arrow}}<$text text=<<newColourName>> class="tc-small-gap-left"/></$button><br>
 </$reveal>

--- a/core/ui/PaletteEditor.tid
+++ b/core/ui/PaletteEditor.tid
@@ -11,6 +11,8 @@ title: $:/PaletteEditor
 
 \function tf.palette.getcolour() [<paletteColours>getindex<colourName>]
 
+\function tf.palette.input.prefix() [[$:/temp/paletteeditor/input/]addsuffix<currentTiddler>]
+
 \procedure tp.paletteeditor.resolved.input.actions()
 <%if [<colourEditTiddler>get[text]is[colourspace]] %>
 <$action-setfield $index=<<colourName>> $value={{{ [<colourEditTiddler>get[text]] }}}/>
@@ -20,7 +22,7 @@ title: $:/PaletteEditor
 \end
 
 \procedure tp.paletteeditor.input.actions()
-<%if [<colourEditTiddler>getindex<colourName>colour-resolve:colour<colourEditTiddler>is[colourspace]] %>
+<%if [<colourName>colour-resolve:colour<colourEditTiddler>is[colourspace]] %>
 <$action-setfield $index=<<colourName>> $value={{{ [<colourEditTiddler>getindex<colourName>] }}}/>
 <% else %>
 <$action-setfield $index=<<colourName>> $value="transparent"/>
@@ -29,6 +31,7 @@ title: $:/PaletteEditor
 
 \procedure tp.paletteeditor.colour.input.actions()
 <$action-setfield $tiddler=<<colourEditTiddler>> text=<<actionValue>>/>
+<$action-setfield $tiddler=<<colourRefreshTitle>> text="yes"/>
 \end
 
 \procedure tp.paletteeditor.dropdown.button.show.actions()
@@ -54,9 +57,15 @@ title: $:/PaletteEditor
 	inputActions=<<tp.paletteeditor.input.actions>>
 />
 <br/>
-<$let rawValue={{{ [<paletteColours>getindex<colourName>] }}}>
+<$let rawValue={{{ [<paletteColours>getindex<colourName>] }}} colourEditTiddler={{{ [<colourName>colour-resolve{$:/palette}addprefix[/]addprefix<currentTiddler>addprefix[$:/temp/paletteeditor/input/]] }}} colourRefreshTitle={{{ [<colourEditTiddler>addsuffix[/refresh]] }}}>
 <%if [<colourName>colour-resolve:colour{$:/palette}is[colourspace]] %>
-<$edit-text index={{{ [<colourName>colour-resolve{$:/palette}] }}} type="color" tag="input" class="tc-palette-manager-colour-input"/>
+<$edit-text
+	index={{{ [<colourName>colour-resolve{$:/palette}] }}}
+	type="color"
+	tag="input"
+	class="tc-palette-manager-colour-input"
+	inputActions=<<tp.paletteeditor.colour.input.actions>>
+/>
 <%elseif [<colourName>!prefix[?]then<rawValue>!match[]] %>
 <$let bgColour={{{ [subfilter<tf.palette.getcolour>] }}} >
 <%if [<bgColour>is[colourspace]] %>

--- a/core/ui/PaletteEditor.tid
+++ b/core/ui/PaletteEditor.tid
@@ -9,15 +9,22 @@ title: $:/PaletteEditor
 \end
 \define colour-tooltip(showhide) $showhide$ editor for $(newColourName)$ 
 
+\function tf.palette.getindex() [<currentTiddler>getindex<colourName>]
+
 \define delete-colour-index-actions() <$action-setfield $index=<<colourName>>/>
 \define palette-manager-colour-row-segment()
 \whitespace trim
 <$edit-text index=<<colourName>> tag="input" placeholder=<<edit-colour-placeholder>> default=""/>
 <br>
+<%if [<colourName>colour-resolve:colour{$:/palette}is[colourspace]] %>
 <$edit-text index={{{ [<colourName>colour-resolve{$:/palette}] }}} type="color" tag="input" class="tc-palette-manager-colour-input"/>
-<$list filter="[<currentTiddler>getindex<colourName>removeprefix[<<]removesuffix[>>]] [<currentTiddler>getindex<colourName>removeprefix[<$]removesuffix[/>]]" variable="ignore">
-<$set name="state" value={{{ [[$:/state/palettemanager/]addsuffix<currentTiddler>addsuffix[/]addsuffix<colourName>] }}}>
-<$let newColourName={{{ [<colourName>colour-resolve{$:/palette}] }}} >
+<%elseif [<colourName>!prefix[?]] %>
+<$wikify name="bgColour" text={{{ [subfilter<tf.palette.getindex>] }}}>
+<div style.background-color=<<bgColour>> style.height="2em" style.width="100%" style.border-radius="2px" style.margin="3px" class="tc-palette-manager-colour-input" />
+</$wikify>
+<% endif %>
+<%if [<currentTiddler>getindex<colourName>!is[colourspace]then<colourName>colour-resolve:colour{$:/palette}is[colourspace]] %>
+<$let state={{{ [[$:/state/palettemanager/]addsuffix<currentTiddler>addsuffix[/]addsuffix<colourName>] }}} newColourName={{{ [<colourName>colour-resolve{$:/palette}] }}} >
 <$reveal state=<<state>> type="nomatch" text="show">
 <$button tooltip=<<colour-tooltip show>> aria-label=<<colour-tooltip show>> class="tc-btn-invisible" set=<<state>> setTo="show">{{$:/core/images/down-arrow}}<$text text=<<newColourName>> class="tc-small-gap-left"/></$button><br>
 </$reveal>
@@ -32,8 +39,7 @@ title: $:/PaletteEditor
 </$set>
 </$reveal>
 </$let>
-</$set>
-</$list>
+<% endif %>
 \end
 
 \define palette-manager-colour-row()

--- a/core/ui/PaletteEditor.tid
+++ b/core/ui/PaletteEditor.tid
@@ -9,39 +9,95 @@ title: $:/PaletteEditor
 \end
 \define colour-tooltip(showhide) $showhide$ editor for $(newColourName)$ 
 
-\function tf.palette.getindex() [<currentTiddler>getindex<colourName>]
+\function tf.palette.getcolour() [<paletteColours>getindex<colourName>]
+
+\procedure tp.paletteeditor.resolved.input.actions()
+<%if [<colourEditTiddler>get[text]is[colourspace]] %>
+<$action-setfield $index=<<colourName>> $value={{{ [<colourEditTiddler>get[text]] }}}/>
+<% else %>
+<$action-setfield $index=<<colourName>> $value="transparent"/>
+<% endif %>
+\end
+
+\procedure tp.paletteeditor.input.actions()
+<%if [<colourEditTiddler>getindex<colourName>colour-resolve:colour<colourEditTiddler>is[colourspace]] %>
+<$action-setfield $index=<<colourName>> $value={{{ [<colourEditTiddler>getindex<colourName>] }}}/>
+<% else %>
+<$action-setfield $index=<<colourName>> $value="transparent"/>
+<% endif %>
+\end
+
+\procedure tp.paletteeditor.colour.input.actions()
+<$action-setfield $tiddler=<<colourEditTiddler>> text=<<actionValue>>/>
+\end
+
+\procedure tp.paletteeditor.dropdown.button.show.actions()
+<$action-setfield $tiddler=<<colourEditTiddler>> text={{{ [<colourName>colour-resolve:colour{$:/palette}] }}}/>
+<$action-setfield $tiddler=<<state>> text="show"/>
+\end
+
+\procedure tp.paletteeditor.dropdown.button.hide.actions()
+<$action-deletetiddler $tiddler=<<state>>/>
+<$action-deletetiddler $tiddler=<<colourEditTiddler>>/>
+\end
 
 \define delete-colour-index-actions() <$action-setfield $index=<<colourName>>/>
 \define palette-manager-colour-row-segment()
 \whitespace trim
-<$edit-text index=<<colourName>> tag="input" placeholder=<<edit-colour-placeholder>> default=""/>
-<br>
+<$let colourEditTiddler="$:/temp/palette-colours/copy">
+<$edit-text
+	tiddler=<<colourEditTiddler>>
+	index=<<colourName>>
+	tag="input"
+	placeholder=<<edit-colour-placeholder>>
+	default=""
+	inputActions=<<tp.paletteeditor.input.actions>>
+/>
+<br/>
+<$let rawValue={{{ [<paletteColours>getindex<colourName>] }}}>
 <%if [<colourName>colour-resolve:colour{$:/palette}is[colourspace]] %>
 <$edit-text index={{{ [<colourName>colour-resolve{$:/palette}] }}} type="color" tag="input" class="tc-palette-manager-colour-input"/>
-<%elseif [<colourName>!prefix[?]then<currentTiddler>getindex<colourName>!match[]] %>
-<$wikify name="bgColour" text={{{ [subfilter<tf.palette.getindex>] }}}>
+<%elseif [<colourName>!prefix[?]then<rawValue>!match[]] %>
+<$let bgColour={{{ [subfilter<tf.palette.getcolour>] }}} >
 <%if [<bgColour>is[colourspace]] %>
-<div style.background-color=<<bgColour>> style.height="2em" style.width="100%" style.border-radius="2px" style.margin="3px 0" class="tc-palette-manager-colour-input" />
+<div style.background-color=<<bgColour>> style.height="2em" style.width="100%" style.border-color=<<colour foreground>> style.border-width="1px" style.border-style="solid" style.border-radius="2px" style.margin="3px 0" class="tc-palette-manager-colour-input" />
 <% endif %>
-</$wikify>
+</$let>
 <% endif %>
-<%if [<currentTiddler>getindex<colourName>!is[colourspace]then<colourName>colour-resolve:colour{$:/palette}is[colourspace]] %>
-<$let state={{{ [[$:/state/palettemanager/]addsuffix<currentTiddler>addsuffix[/]addsuffix<colourName>] }}} newColourName={{{ [<colourName>colour-resolve{$:/palette}] }}} >
+<%if [<rawValue>!is[colourspace]then<colourName>colour-resolve:colour{$:/palette}is[colourspace]then<colourName>colour-resolve{$:/palette}!match<colourName>] %>
+<$let state={{{ [[$:/state/palettemanager/]addsuffix<currentTiddler>addsuffix[/]addsuffix<colourName>] }}} newColourName={{{ [<colourName>colour-resolve:colour{$:/palette}is[colourspace]then<colourName>colour-resolve{$:/palette}else<colourName>] }}} colourEditTiddler={{{ [[$:/temp/paletteeditor/input/]addsuffix<currentTiddler>addsuffix[/]addsuffix<newColourName>] }}} >
 <$reveal state=<<state>> type="nomatch" text="show">
-<$button tooltip=<<colour-tooltip show>> aria-label=<<colour-tooltip show>> class="tc-btn-invisible" set=<<state>> setTo="show">{{$:/core/images/down-arrow}}<$text text=<<newColourName>> class="tc-small-gap-left"/></$button><br>
+<$button tooltip=<<colour-tooltip show>> aria-label=<<colour-tooltip show>> class="tc-btn-invisible tc-small-gap-right" actions=<<tp.paletteeditor.dropdown.button.show.actions>>>{{$:/core/images/down-arrow}}<$text text={{{ [<colourName>colour-resolve:colour{$:/palette}is[colourspace]then<colourName>colour-resolve{$:/palette}else<colourName>] }}}/></$button><br>
 </$reveal>
 <$reveal state=<<state>> type="match" text="show">
-<$button tooltip=<<colour-tooltip hide>> aria-label=<<colour-tooltip show>> class="tc-btn-invisible" actions="""<$action-deletetiddler $tiddler=<<state>>/>""">{{$:/core/images/up-arrow}}<$text text=<<newColourName>> class="tc-small-gap-left"/></$button><br>
+<$button tooltip=<<colour-tooltip hide>> aria-label=<<colour-tooltip hide>> class="tc-btn-invisible tc-small-gap-right" actions=<<tp.paletteeditor.dropdown.button.hide.actions>>>{{$:/core/images/up-arrow}}<$text text=<<newColourName>>/></$button><br>
 </$reveal>
 <$reveal state=<<state>> type="match" text="show">
-<$set name="colourName" value=<<newColourName>>>
-<br>
-<<palette-manager-colour-row-segment>>
-<br><br>
-</$set>
+<$let colourName=<<newColourName>> colourRefreshTitle={{{ [[$:/temp/paletteeditor/input/]addsuffix<currentTiddler>addsuffix[/]addsuffix<newColourName>addsuffix[/refresh]] }}}>
+<br/>
+<$edit-text
+	tiddler=<<colourEditTiddler>>
+	tag="input"
+	placeholder=<<edit-colour-placeholder>>
+	default=""
+	inputActions=<<tp.paletteeditor.resolved.input.actions>>
+	refreshTitle=<<colourRefreshTitle>>
+/>
+<br/>
+<$edit-text
+	index=<<newColourName>>
+	type="color"
+	tag="input"
+	class="tc-palette-manager-colour-input"
+	inputActions=<<tp.paletteeditor.colour.input.actions>>
+/>
+<br/><br/>
+</$let>
 </$reveal>
 </$let>
 <% endif %>
+</$let>
+</$let>
 \end
 
 \define palette-manager-colour-row()
@@ -73,7 +129,7 @@ title: $:/PaletteEditor
 </table>
 \end
 \whitespace trim
-<$set name="currentTiddler" value={{$:/palette}}>
+<$let currentTiddler={{$:/palette}} paletteColours="$:/temp/palette/copy">
 
 <<lingo Prompt>>&#32;<$link to={{$:/palette}}><$macrocall $name="currentTiddler" $output="text/plain"/></$link>
 
@@ -92,3 +148,5 @@ title: $:/PaletteEditor
 <$checkbox tiddler="$:/state/palettemanager/showexternal" field="text" checked="yes" unchecked="no"><span class="tc-small-gap-left"><<lingo Names/External/Show>></span></$checkbox>
 
 <<palette-manager-table>>
+
+</$let>

--- a/core/ui/PaletteEditor.tid
+++ b/core/ui/PaletteEditor.tid
@@ -129,7 +129,7 @@ title: $:/PaletteEditor
 </table>
 \end
 \whitespace trim
-<$let currentTiddler={{$:/palette}} paletteColours="$:/temp/palette/copy">
+<$let currentTiddler={{$:/palette}} paletteColours="$:/temp/palette-colours/copy">
 
 <<lingo Prompt>>&#32;<$link to={{$:/palette}}><$macrocall $name="currentTiddler" $output="text/plain"/></$link>
 

--- a/core/ui/PaletteEditor.tid
+++ b/core/ui/PaletteEditor.tid
@@ -45,10 +45,7 @@ title: $:/PaletteEditor
 {{$:/core/images/delete-button}}</$button>
 </span>
 ''<$macrocall $name="describePaletteColour" colour=<<colourName>>/>''<br/>
-<$macrocall $name="colourName" $output="text/plain"/><br/>
-<span style.background-color={{{ [<colourName>colour-resolve:colour[]] }}} style.color=<<contrastcolour target={{{ [<colourName>colour-resolve:colour[]] }}} colourA="#ffffff" colourB="#000000">> class="tc-palette-manager-colour-swatch">
-<$text text={{{ [<colourName>colour-resolve:colour[]] }}}/>
-</span>
+<$macrocall $name="colourName" $output="text/plain"/>
 </td>
 <td>
 <<palette-manager-colour-row-segment>>

--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -75,6 +75,9 @@ tags: $:/tags/Macro
 			<$action-setfield $tiddler=<<outputPalette>> $index={{{ [<entry-name>addprefix[?recursion-]] }}} $value={{{ [[the definition of ']addsuffix<entry-name>addsuffix[' is recursive]] }}}/>
 		</$list>
 	</$let>
+	<!-- Save the consolidated palette as a copy for reuse in the $:/PaletteEditor -->
+	<$action-setfield $tiddler={{{ [<outputPalette>addsuffix[/copy]] }}} type="application/x-tiddler-dictionary"/>
+	<$action-setfield $tiddler={{{ [<outputPalette>addsuffix[/copy]] }}} text={{{ [<consolidatedPalette>get[text]] }}}/>
 </$let>
 \end actions-compile-palette
 

--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -84,7 +84,7 @@ tags: $:/tags/Macro
 
 \procedure actions-recompile-current-palette()
 \procedure tv-action-refresh-policy() always
-<$transclude $variable="actions-compile-palette" inputPalette={{{ [{$:/palette}!is[missing]] :else[[$:/palettes/Vanilla]] }}} outputPalette="$:/temp/palette-colours"/>
+<$transclude $variable="actions-compile-palette" inputPalette={{{ [{$:/palette}is[shadow]] [{$:/palette}is[tiddler]] :else[[$:/palettes/Vanilla]] }}} outputPalette="$:/temp/palette-colours"/>
 \end actions-recompile-current-palette
 
 \procedure tv-palette-name() $:/temp/palette-colours


### PR DESCRIPTION
add is[colourspace] filter, add colour-resolve[] filter, edit PaletteEditor

This PR targets the colour-improvements branch.
It adds an `is[colourspace]` filter with the `is[colorspace]` equivalent which checks a given input string if it's a valid color string from any valid colour space.
It adds a `[index]colour-resolve[palette]` filter operator which resolves the given index of the given palette until it finds a valid colour. It returns the corresponding index by default which can be switched to the colour by `[index]colour-resolve:colour[palette]`.
It also edits the $:/PaletteEditor removing the `<$wikify>` widgets and the `resolve-colour` macro and using the `colour-resolve` filter. The $:/PaletteEditor could be tweaked further, I'm not yet fully happy with it but for the functionality it's sufficient.