### PR TITLE
Allow in-memory wiki configuration in loadWikiTiddlers

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2242,22 +2242,25 @@ $tw.loadWikiTiddlers = function(wikiPath,options) {
 	options = options || {};
 	var parentPaths = options.parentPaths || [],
 		wikiInfoPath = path.resolve(wikiPath,$tw.config.wikiInfo),
-		wikiInfo,
+		wikiInfo = options.wikiInfo,
 		pluginFields;
-	// Bail if we don't have a wiki info file
-	if(fs.existsSync(wikiInfoPath)) {
-		wikiInfo = $tw.utils.parseJSONSafe(fs.readFileSync(wikiInfoPath,"utf8"),function() {return null;});
-		if(!wikiInfo) {
-			console.log("warning: invalid JSON in tiddlywiki.info file at " + wikiInfoPath);
-			wikiInfo = {};
+	// Use options.wikiInfo when provided; otherwise load tiddlywiki.info from disk
+	if(!wikiInfo) {
+		if(fs.existsSync(wikiInfoPath)) {
+			wikiInfo = $tw.utils.parseJSONSafe(fs.readFileSync(wikiInfoPath,"utf8"),function() {return null;});
+			if(!wikiInfo) {
+				console.log("warning: invalid JSON in tiddlywiki.info file at " + wikiInfoPath);
+				wikiInfo = {};
+			}
+		} else {
+			return null;
 		}
-	} else {
-		return null;
 	}
 	// Save the path to the tiddlers folder for the filesystemadaptor
 	var config = wikiInfo.config || {};
+	var tiddlersLocation = config["default-tiddler-location"] || $tw.config.wikiTiddlersSubDir;
 	if($tw.boot.wikiPath == wikiPath) {
-		$tw.boot.wikiTiddlersPath = path.resolve($tw.boot.wikiPath,config["default-tiddler-location"] || $tw.config.wikiTiddlersSubDir);
+		$tw.boot.wikiTiddlersPath = path.resolve($tw.boot.wikiPath,tiddlersLocation);
 	}
 	// Load any parent wikis
 	if(wikiInfo.includeWikis) {
@@ -2285,7 +2288,7 @@ $tw.loadWikiTiddlers = function(wikiPath,options) {
 	$tw.loadPlugins(wikiInfo.themes,$tw.config.themesPath,$tw.config.themesEnvVar);
 	$tw.loadPlugins(wikiInfo.languages,$tw.config.languagesPath,$tw.config.languagesEnvVar);
 	// Load the wiki files, registering them as writable
-	var resolvedWikiPath = path.resolve(wikiPath,$tw.config.wikiTiddlersSubDir);
+	var resolvedWikiPath = path.resolve(wikiPath,tiddlersLocation);
 	$tw.utils.each($tw.loadTiddlersFromPath(resolvedWikiPath),function(tiddlerFile) {
 		if(!options.readOnly && tiddlerFile.filepath) {
 			$tw.utils.each(tiddlerFile.tiddlers,function(tiddler) {

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1962,10 +1962,10 @@ $tw.loadTiddlersFromPath = function(filepath,excludeRegExp) {
 Load all the tiddlers defined by a `tiddlywiki.files` specification file
 filepath: pathname of the directory containing the specification file
 */
-$tw.loadTiddlersFromSpecification = function(filepath,excludeRegExp) {
+$tw.loadTiddlersFromSpecification = function(filepath,excludeRegExp,filesInfo) {
 	var tiddlers = [];
-	// Read the specification
-	var filesInfo = $tw.utils.parseJSONSafe(fs.readFileSync(filepath + path.sep + "tiddlywiki.files","utf8"), function(e) {
+	// Read the specification unless it was supplied by the caller
+	filesInfo = filesInfo || $tw.utils.parseJSONSafe(fs.readFileSync(filepath + path.sep + "tiddlywiki.files","utf8"), function(e) {
 		console.log("Warning: tiddlywiki.files in " + filepath + " invalid: " + e.message);
 		return {};
 	});
@@ -2237,6 +2237,9 @@ path: path of wiki directory
 options:
 	parentPaths: array of parent paths that we mustn't recurse into
 	readOnly: true if the tiddler file paths should not be retained
+	wikiInfo: optional in-memory equivalent of tiddlywiki.info
+	filesInfo: optional in-memory equivalent of tiddlywiki.files, resolved relative
+		to the configured tiddler location
 */
 $tw.loadWikiTiddlers = function(wikiPath,options) {
 	options = options || {};
@@ -2288,8 +2291,11 @@ $tw.loadWikiTiddlers = function(wikiPath,options) {
 	$tw.loadPlugins(wikiInfo.themes,$tw.config.themesPath,$tw.config.themesEnvVar);
 	$tw.loadPlugins(wikiInfo.languages,$tw.config.languagesPath,$tw.config.languagesEnvVar);
 	// Load the wiki files, registering them as writable
-	var resolvedWikiPath = path.resolve(wikiPath,tiddlersLocation);
-	$tw.utils.each($tw.loadTiddlersFromPath(resolvedWikiPath),function(tiddlerFile) {
+	var resolvedWikiPath = path.resolve(wikiPath,tiddlersLocation),
+		tiddlerFiles = options.filesInfo ?
+			$tw.loadTiddlersFromSpecification(resolvedWikiPath,$tw.boot.excludeRegExp,options.filesInfo) :
+			$tw.loadTiddlersFromPath(resolvedWikiPath);
+	$tw.utils.each(tiddlerFiles,function(tiddlerFile) {
 		if(!options.readOnly && tiddlerFile.filepath) {
 			$tw.utils.each(tiddlerFile.tiddlers,function(tiddler) {
 				$tw.boot.files[tiddler.title] = {

--- a/editions/test/tiddlers/tests/test-load-wiki-tiddlers.js
+++ b/editions/test/tiddlers/tests/test-load-wiki-tiddlers.js
@@ -1,0 +1,77 @@
+/*\
+title: test-load-wiki-tiddlers.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Tests for loading wiki configuration supplied by an embedding application.
+
+\*/
+"use strict";
+
+if($tw.node) {
+	var fs = require("fs"),
+		os = require("os"),
+		path = require("path");
+
+	describe("$tw.loadWikiTiddlers in-memory configuration",function() {
+		it("loads a flat wiki using in-memory wikiInfo and filesInfo",function() {
+			var wikiPath = fs.mkdtempSync(path.join(os.tmpdir(),"tw-memory-wiki-")),
+				title = "InjectedFlatWikiNote",
+				filepath = path.join(wikiPath,title + ".md"),
+				oldTiddler = $tw.wiki.getTiddler(title),
+				oldWikiPath = $tw.boot.wikiPath,
+				oldWikiTiddlersPath = $tw.boot.wikiTiddlersPath,
+				oldFiles = $tw.boot.files,
+				oldOriginalPaths = $tw.wiki.getTiddler("$:/config/OriginalTiddlerPaths");
+			fs.writeFileSync(filepath,"# In-memory configuration\n","utf8");
+			try {
+				$tw.boot.wikiPath = wikiPath;
+				$tw.boot.files = Object.create(null);
+				var wikiInfo = $tw.loadWikiTiddlers(wikiPath,{
+					wikiInfo: {
+						plugins: [],
+						themes: [],
+						languages: [],
+						config: {
+							"default-tiddler-location": "."
+						}
+					},
+					filesInfo: {
+						directories: [{
+							path: ".",
+							filesRegExp: "^.*\\.md$",
+							isTiddlerFile: false,
+							isEditableFile: true,
+							fields: {
+								title: {source: "basename"},
+								type: "text/markdown"
+							}
+						}]
+					}
+				});
+				expect(wikiInfo).toBeTruthy();
+				expect($tw.boot.wikiTiddlersPath).toBe(wikiPath);
+				expect($tw.wiki.getTiddlerText(title)).toBe("# In-memory configuration\n");
+				expect($tw.wiki.getTiddler(title).fields.type).toBe("text/markdown");
+				expect($tw.boot.files[title].filepath).toBe(filepath);
+				expect(fs.existsSync(path.join(wikiPath,"tiddlywiki.info"))).toBe(false);
+				expect(fs.existsSync(path.join(wikiPath,"tiddlywiki.files"))).toBe(false);
+			} finally{
+				if(oldTiddler) {
+					$tw.wiki.addTiddler(oldTiddler);
+				} else {
+					$tw.wiki.deleteTiddler(title);
+				}
+				if(oldOriginalPaths) {
+					$tw.wiki.addTiddler(oldOriginalPaths);
+				} else {
+					$tw.wiki.deleteTiddler("$:/config/OriginalTiddlerPaths");
+				}
+				$tw.boot.files = oldFiles;
+				$tw.boot.wikiPath = oldWikiPath;
+				$tw.boot.wikiTiddlersPath = oldWikiTiddlersPath;
+				fs.rmSync(wikiPath,{recursive: true,force: true});
+			}
+		});
+	});
+}

--- a/editions/tw5.com/tiddlers/nodejs/tiddlywiki.files_Files.tid
+++ b/editions/tw5.com/tiddlers/nodejs/tiddlywiki.files_Files.tid
@@ -8,6 +8,8 @@ type: text/vnd.tiddlywiki
 
 A `tiddlywiki.files` JSON file in a sub-folder within [[a TiddlyWiki folder|TiddlyWikiFolders]] overrides the usual logic for recursively scanning the folder for tiddler files. Instead, the `tiddlywiki.files` file specifies instructions for loading tiddlers from specific files and folders.
 
+Embedding applications can provide the same specification in memory with the `filesInfo` option of `$tw.loadWikiTiddlers()`. The paths in an in-memory specification are resolved in exactly the same way as an on-disk `tiddlywiki.files` file. This allows applications to manage a flat wiki folder without creating either configuration file on disk.
+
 The format of the file is an object with two optional properties:
 
 * ''tiddlers'' - an array of objects describing external files with the ability to override or modify any of the fields read from the file

--- a/editions/tw5.com/tiddlers/nodejs/tiddlywiki.info_Files.tid
+++ b/editions/tw5.com/tiddlers/nodejs/tiddlywiki.info_Files.tid
@@ -28,7 +28,7 @@ Note that the build targets of included wikis are merged if a target of that nam
 
 Configuration options include:
 
-* ''default-tiddler-location'' - a string path to the default location for the filesystem adaptor to save new tiddlers (resolved relative to the wiki folder)
+* ''default-tiddler-location'' - a string path to the default location used both when loading tiddlers from the wiki folder and when the filesystem adaptor saves new tiddlers (resolved relative to the wiki folder). Defaults to the wiki folder's `tiddlers/` directory.
 
 * ''retain-original-tiddler-path'' - If true, the server will generate a tiddler [[$:/config/OriginalTiddlerPaths]] containing the original file paths of each tiddler in the wiki
 

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9937.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9937.tid
@@ -1,0 +1,13 @@
+change-category: nodejs
+change-type: enhancement
+created: 20260722201600000
+description: loadWikiTiddlers accepts options.wikiInfo and honors default-tiddler-location when loading
+github-contributors: linonetwo
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9937
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9937
+type: text/vnd.tiddlywiki
+
+* `$tw.loadWikiTiddlers` accepts `options.wikiInfo`, so the wiki info can be supplied in memory without a `tiddlywiki.info` file on disk
+* Loading tiddlers now uses `config["default-tiddler-location"]` (falling back to `$tw.config.wikiTiddlersSubDir`), matching the path used when saving

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9937.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9937.tid
@@ -1,7 +1,7 @@
 change-category: nodejs
 change-type: enhancement
 created: 20260722201600000
-description: loadWikiTiddlers accepts options.wikiInfo and honors default-tiddler-location when loading
+description: loadWikiTiddlers accepts in-memory wiki configuration and honors default-tiddler-location when loading
 github-contributors: linonetwo
 github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9937
 release: 5.5.0
@@ -10,4 +10,5 @@ title: $:/changenotes/5.5.0/#9937
 type: text/vnd.tiddlywiki
 
 * `$tw.loadWikiTiddlers` accepts `options.wikiInfo`, so the wiki info can be supplied in memory without a `tiddlywiki.info` file on disk
+* `$tw.loadWikiTiddlers` accepts `options.filesInfo`, so a `tiddlywiki.files` specification can be supplied in memory without writing it to disk
 * Loading tiddlers now uses `config["default-tiddler-location"]` (falling back to `$tw.config.wikiTiddlersSubDir`), matching the path used when saving

--- a/plugins/tiddlywiki/dom-to-image/startup.js
+++ b/plugins/tiddlywiki/dom-to-image/startup.js
@@ -8,85 +8,84 @@ dom-to-image initialisation
 \*/
 (function(){
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
-"use strict";
+	/*jslint node: true, browser: true */
+	/*global $tw: false */
+	"use strict";
 
-// Export name and synchronous status
-exports.name = "dom-to-image";
-exports.after = ["rootwidget"];
-exports.before = ["render"];
-exports.synchronous = true;
+	// Export name and synchronous status
+	exports.name = "dom-to-image";
+	exports.after = ["rootwidget"];
+	exports.before = ["render"];
+	exports.synchronous = true;
 
-exports.startup = function() {
-	var getPropertiesWithPrefix = function(properties,prefix) {
-		var result = Object.create(null);
-		$tw.utils.each(properties,function(value,name) {
-			if(name.indexOf(prefix) === 0) {
-				result[name.substring(prefix.length)] = properties[name];
+	exports.startup = function() {
+		var getPropertiesWithPrefix = function(properties,prefix) {
+			var result = Object.create(null);
+			$tw.utils.each(properties,function(value,name) {
+				if(name.indexOf(prefix) === 0) {
+					result[name.substring(prefix.length)] = properties[name];
+				}
+			});
+			return result;
+		};
+		$tw.rootWidget.addEventListener("tm-save-dom-to-image",function(event) {
+			var self=this,
+				params = event.paramObject || {},
+				domToImage = require("$:/plugins/tiddlywiki/dom-to-image/dom-to-image-more.js"),
+				domNode = document.querySelector(params.selector || "body.tc-body"),
+				oncompletion = params.oncompletion,
+				variables = getPropertiesWithPrefix(params,"var-");
+			if(domNode) {
+				var method = "toPng";
+				switch(params.format) {
+					case "jpeg":
+						// Intentional fallthrough
+					case "jpg":
+						method = "toJpeg";
+						break;
+					case "svg":
+						method = "toSvg";
+						break;
+				}
+				domToImage[method](domNode,{
+					height: $tw.utils.parseInt(params.height) || domNode.offsetHeight,
+					width: $tw.utils.parseInt(params.width) || domNode.offsetWidth,
+					quality: $tw.utils.parseNumber(params.quality),
+					scale: $tw.utils.parseNumber(params.scale) || 1
+				})
+					.then(function(dataUrl) {
+					// Save the image
+						if(params["save-file"]) {
+							var link = document.createElement("a");
+							link.download = params["save-file"];
+							link.href = dataUrl;
+							link.click();
+						}
+						// Save the tiddler
+						if(params["save-title"]) {
+							if(dataUrl.indexOf("data:image/svg+xml;") === 0) {
+								var commaIndex = dataUrl.indexOf(",");
+								$tw.wiki.addTiddler(new $tw.Tiddler({
+									title: params["save-title"],
+									type: "image/svg+xml",
+									"text": decodeURIComponent(dataUrl.substring(commaIndex + 1))
+								}));
+							} else {
+								var parts = dataUrl.split(";base64,");
+								$tw.wiki.addTiddler(new $tw.Tiddler({
+									title: params["save-title"],
+									type: parts[0].split(":")[1],
+									"text": parts[1]
+								}));
+							}
+						}
+						self.wiki.invokeActionString(oncompletion,self,variables,{parentWidget: $tw.rootWidget});
+					})
+					.catch(function(error) {
+						console.error("oops, something went wrong!", error);
+					});
 			}
 		});
-		return result;
 	};
-	$tw.rootWidget.addEventListener("tm-save-dom-to-image",function(event) {
-		var self=this,
-			params = event.paramObject || {},
-			domToImage = require("$:/plugins/tiddlywiki/dom-to-image/dom-to-image-more.js"),
-			domNode = document.querySelector(params.selector || "body.tc-body"),
-			oncompletion = params.oncompletion,
-			variables = getPropertiesWithPrefix(params,"var-");
-		if(domNode) {
-			var method = "toPng";
-			switch(params.format) {
-				case "jpeg":
-				// Intentional fallthrough
-				case "jpg":
-					method = "toJpeg";
-					break;
-				case "svg":
-					method = "toSvg";
-					break;
-			}
-			domToImage[method](domNode,{
-				height: $tw.utils.parseInt(params.height) || domNode.offsetHeight,
-				width: $tw.utils.parseInt(params.width) || domNode.offsetWidth,
-				quality: $tw.utils.parseNumber(params.quality),
-				scale: $tw.utils.parseNumber(params.scale) || 1
-			})
-				.then(function(dataUrl) {
-					// Save the image
-					if(params["save-file"]) {
-						var link = document.createElement("a");
-						link.download = params["save-file"];
-						link.href = dataUrl;
-						link.click();
-					}
-					// Save the tiddler
-					if(params["save-title"]) {
-						if(dataUrl.indexOf("data:image/svg+xml;") === 0) {
-							var commaIndex = dataUrl.indexOf(",");
-							$tw.wiki.addTiddler(new $tw.Tiddler({
-								title: params["save-title"],
-								type: "image/svg+xml",
-								"text": decodeURIComponent(dataUrl.substring(commaIndex + 1))
-							}));	
-						} else {
-							var parts = dataUrl.split(";base64,");
-							$tw.wiki.addTiddler(new $tw.Tiddler({
-								title: params["save-title"],
-								type: parts[0].split(":")[1],
-								"text": parts[1]
-							}));	
-						}
-					}
-					self.wiki.invokeActionString(oncompletion,self,variables,{parentWidget: $tw.rootWidget});
-				})
-				.catch(function(error) {
-					console.error("oops, something went wrong!", error);
-				});
-		}
-	});
-};
 
 })();
-	


### PR DESCRIPTION
In TidGi we sometimes need to boot a wiki folder without a `tiddlywiki.info` on disk (and we do not want to write one, so folder could looks very clean, as a LLM wiki fewer noise is better). This adds `options.wikiInfo` so callers can pass the config in memory; if it is set, the file is not required.

Also, loading currently always uses `$tw.config.wikiTiddlersSubDir`, while saving already respects `config["default-tiddler-location"]`. That mismatch makes `default-tiddler-location` only half-useful. I let loading now uses the same resolution as saving.
