### PR TITLE
feat: conditionally hide editor preview types

### DIFF
--- a/core/palettes/Vanilla.tid
+++ b/core/palettes/Vanilla.tid
@@ -117,7 +117,7 @@ tiddler-info-background: #f8f8f8
 tiddler-info-border: #dddddd
 tiddler-info-tab-background: #f8f8f8
 tiddler-link-background: <<colour background>>
-tiddler-link-foreground: #7f96e4
+tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: #c0c0c0
 tiddler-title-foreground: #182955
 toolbar-new-button:

--- a/core/palettes/Vanilla.tid
+++ b/core/palettes/Vanilla.tid
@@ -117,7 +117,7 @@ tiddler-info-background: #f8f8f8
 tiddler-info-border: #dddddd
 tiddler-info-tab-background: #f8f8f8
 tiddler-link-background: <<colour background>>
-tiddler-link-foreground: <<colour primary>>
+tiddler-link-foreground: #7f96e4
 tiddler-subtitle-foreground: #c0c0c0
 tiddler-title-foreground: #182955
 toolbar-new-button:

--- a/core/ui/EditTemplate/body-toolbar-button.tid
+++ b/core/ui/EditTemplate/body-toolbar-button.tid
@@ -96,7 +96,7 @@ title: $:/core/ui/EditTemplate/body/toolbar/button
 ><$transclude
 
   tiddler={{!!dropdown}}
-  mode="block"
+  mode="inline"
 
 /></div></$reveal></$set></$list></$wikify></$list>
 \end

--- a/core/ui/EditorToolbar/preview-type-dropdown.tid
+++ b/core/ui/EditorToolbar/preview-type-dropdown.tid
@@ -1,41 +1,25 @@
 title: $:/core/ui/EditorToolbar/preview-type-dropdown
 
 \procedure preview-type-button()
-<$button tag="a" class="tc-btn-invisible">
-
+\whitespace trim
+<$button tag="a" class="tc-btn-invisible tc-preview-type-button">
 	<$action-setfield $tiddler="$:/state/editpreviewtype" $value=<<previewType>>/>
-
 	<$action-deletetiddler $tiddler=<<dropdown-state>>/>
-
-	<$transclude tiddler=<<previewType>> field="caption" mode="inline">
-
-		<$view tiddler=<<previewType>> field="title" mode="inline"/>
-
-	</$transclude>
-
-	<% if [{$:/state/editpreviewtype}!match[]else[$:/core/ui/EditTemplate/body/preview/output]match<previewType>] %>
-
-		<span class="tc-tiny-gap-left">
-
+	<span class="tc-drop-down-checkmark">
+		<% if [{$:/state/editpreviewtype}!match[]else[$:/core/ui/EditTemplate/body/preview/output]match<previewType>] %>
 			<$entity entity="&#x2713;"/>
-
-		</span>
-
-	<% endif %>
-
+		<% endif %>
+	</span>
+	<$transclude tiddler=<<previewType>> field="caption" mode="inline">
+		<$view tiddler=<<previewType>> field="title" mode="inline"/>
+	</$transclude>
 </$button>
 \end
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/EditPreview]!has[draft.of]]" variable="previewType">
-
 	<$let previewCondition={{{ [<previewType>get[condition]else[yes]] }}}>
-
 		<% if [<tv-editor-type>] +[subfilter<previewCondition>] %>
-
 			<<preview-type-button>>
-
 		<% endif %>
-
 	</$let>
-
 </$list>

--- a/core/ui/EditorToolbar/preview-type-dropdown.tid
+++ b/core/ui/EditorToolbar/preview-type-dropdown.tid
@@ -1,22 +1,41 @@
 title: $:/core/ui/EditorToolbar/preview-type-dropdown
 
-\whitespace trim
 \procedure preview-type-button()
-<$let selectedClass={{{ [{$:/state/editpreviewtype}!match[]else[$:/core/ui/EditTemplate/body/preview/output]match<previewType>then[tc-list-item-selected]else[]] }}}>
-	<$button tag="a" class=`tc-btn-invisible $(selectedClass)$`>
-		<$action-setfield $tiddler="$:/state/editpreviewtype" $value=<<previewType>>/>
-		<$action-deletetiddler $tiddler=<<dropdown-state>>/>
-		<$transclude tiddler=<<previewType>> field="caption" mode="inline">
-			<$view tiddler=<<previewType>> field="title" mode="inline"/>
-		</$transclude>
-	</$button>
-</$let>
+<$button tag="a" class="tc-btn-invisible">
+
+	<$action-setfield $tiddler="$:/state/editpreviewtype" $value=<<previewType>>/>
+
+	<$action-deletetiddler $tiddler=<<dropdown-state>>/>
+
+	<$transclude tiddler=<<previewType>> field="caption" mode="inline">
+
+		<$view tiddler=<<previewType>> field="title" mode="inline"/>
+
+	</$transclude>
+
+	<% if [{$:/state/editpreviewtype}!match[]else[$:/core/ui/EditTemplate/body/preview/output]match<previewType>] %>
+
+		<span class="tc-tiny-gap-left">
+
+			<$entity entity="&#x2713;"/>
+
+		</span>
+
+	<% endif %>
+
+</$button>
 \end
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/EditPreview]!has[draft.of]]" variable="previewType">
+
 	<$let previewCondition={{{ [<previewType>get[condition]else[yes]] }}}>
+
 		<% if [<tv-editor-type>] +[subfilter<previewCondition>] %>
+
 			<<preview-type-button>>
+
 		<% endif %>
+
 	</$let>
+
 </$list>

--- a/core/ui/EditorToolbar/preview-type-dropdown.tid
+++ b/core/ui/EditorToolbar/preview-type-dropdown.tid
@@ -2,18 +2,20 @@ title: $:/core/ui/EditorToolbar/preview-type-dropdown
 
 \procedure preview-type-button()
 \whitespace trim
-<$button tag="a" class="tc-btn-invisible tc-preview-type-button">
-	<$action-setfield $tiddler="$:/state/editpreviewtype" $value=<<previewType>>/>
-	<$action-deletetiddler $tiddler=<<dropdown-state>>/>
-	<span class="tc-drop-down-checkmark">
-		<% if [{$:/state/editpreviewtype}!match[]else[$:/core/ui/EditTemplate/body/preview/output]match<previewType>] %>
-			<$entity entity="&#x2713;"/>
-		<% endif %>
-	</span>
-	<$transclude tiddler=<<previewType>> field="caption" mode="inline">
-		<$view tiddler=<<previewType>> field="title" mode="inline"/>
-	</$transclude>
-</$button>
+<span class={{{ [{$:/state/editpreviewtype}!match[]else[$:/core/ui/EditTemplate/body/preview/output]match<previewType>then[tc-list-item-selected]else[]] }}}>
+	<$button tag="a" class="tc-btn-invisible tc-tiddlylink tc-preview-type-button">
+		<$action-setfield $tiddler="$:/state/editpreviewtype" $value=<<previewType>>/>
+		<$action-deletetiddler $tiddler=<<dropdown-state>>/>
+		<span class="tc-drop-down-checkmark">
+			<% if [{$:/state/editpreviewtype}!match[]else[$:/core/ui/EditTemplate/body/preview/output]match<previewType>] %>
+				<$entity entity="&#x2713;"/>
+			<% endif %>
+		</span>
+		<$transclude tiddler=<<previewType>> field="caption" mode="inline">
+			<$view tiddler=<<previewType>> field="title" mode="inline"/>
+		</$transclude>
+	</$button>
+</span>
 \end
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/EditPreview]!has[draft.of]]" variable="previewType">

--- a/core/ui/EditorToolbar/preview-type-dropdown.tid
+++ b/core/ui/EditorToolbar/preview-type-dropdown.tid
@@ -1,33 +1,22 @@
 title: $:/core/ui/EditorToolbar/preview-type-dropdown
 
-\define preview-type-button()
-<$button tag="a">
-
-<$action-setfield $tiddler="$:/state/editpreviewtype" $value="$(previewType)$"/>
-
-<$action-deletetiddler
-	$tiddler=<<dropdown-state>>
-/>
-
-<$transclude tiddler=<<previewType>> field="caption" mode="inline">
-
-<$view tiddler=<<previewType>> field="title" mode="inline"/>
-
-</$transclude> 
-
-<$reveal tag="span" state="$:/state/editpreviewtype" type="match" text=<<previewType>> default="$:/core/ui/EditTemplate/body/preview/output">
-
-<$entity entity="&nbsp;"/>
-
-<$entity entity="&#x2713;"/>
-
-</$reveal>
-
-</$button>
+\whitespace trim
+\procedure preview-type-button()
+<$let selectedClass={{{ [{$:/state/editpreviewtype}!match[]else[$:/core/ui/EditTemplate/body/preview/output]match<previewType>then[tc-list-item-selected]else[]] }}}>
+	<$button tag="a" class=`tc-btn-invisible $(selectedClass)$`>
+		<$action-setfield $tiddler="$:/state/editpreviewtype" $value=<<previewType>>/>
+		<$action-deletetiddler $tiddler=<<dropdown-state>>/>
+		<$transclude tiddler=<<previewType>> field="caption" mode="inline">
+			<$view tiddler=<<previewType>> field="title" mode="inline"/>
+		</$transclude>
+	</$button>
+</$let>
 \end
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/EditPreview]!has[draft.of]]" variable="previewType">
-
-<<preview-type-button>>
-
+	<$let previewCondition={{{ [<previewType>get[condition]else[yes]] }}}>
+		<% if [<tv-editor-type>] +[subfilter<previewCondition>] %>
+			<<preview-type-button>>
+		<% endif %>
+	</$let>
 </$list>

--- a/core/ui/EditorToolbar/preview-type-dropdown.tid
+++ b/core/ui/EditorToolbar/preview-type-dropdown.tid
@@ -2,20 +2,18 @@ title: $:/core/ui/EditorToolbar/preview-type-dropdown
 
 \procedure preview-type-button()
 \whitespace trim
-<span class={{{ [{$:/state/editpreviewtype}!match[]else[$:/core/ui/EditTemplate/body/preview/output]match<previewType>then[tc-list-item-selected]else[]] }}}>
-	<$button tag="a" class="tc-btn-invisible tc-tiddlylink tc-preview-type-button">
-		<$action-setfield $tiddler="$:/state/editpreviewtype" $value=<<previewType>>/>
-		<$action-deletetiddler $tiddler=<<dropdown-state>>/>
-		<span class="tc-drop-down-checkmark">
-			<% if [{$:/state/editpreviewtype}!match[]else[$:/core/ui/EditTemplate/body/preview/output]match<previewType>] %>
-				<$entity entity="&#x2713;"/>
-			<% endif %>
-		</span>
-		<$transclude tiddler=<<previewType>> field="caption" mode="inline">
-			<$view tiddler=<<previewType>> field="title" mode="inline"/>
-		</$transclude>
-	</$button>
-</span>
+<$button tag="a" class="tc-btn-invisible tc-preview-type-button">
+	<$action-setfield $tiddler="$:/state/editpreviewtype" $value=<<previewType>>/>
+	<$action-deletetiddler $tiddler=<<dropdown-state>>/>
+	<span class="tc-drop-down-checkmark">
+		<% if [{$:/state/editpreviewtype}!match[]else[$:/core/ui/EditTemplate/body/preview/output]match<previewType>] %>
+			<$entity entity="&#x2713;"/>
+		<% endif %>
+	</span>
+	<$transclude tiddler=<<previewType>> field="caption" mode="inline">
+		<$view tiddler=<<previewType>> field="title" mode="inline"/>
+	</$transclude>
+</$button>
 \end
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/EditPreview]!has[draft.of]]" variable="previewType">

--- a/editions/test/tiddlers/tests/test-editor-preview-condition.js
+++ b/editions/test/tiddlers/tests/test-editor-preview-condition.js
@@ -1,0 +1,69 @@
+/*\\
+title: test-editor-preview-condition.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Tests that the preview-type dropdown respects the condition field on $:/tags/EditPreview tiddlers.
+
+\\*/
+"use strict";
+
+describe("Preview type dropdown condition field", function() {
+
+	function setupWiki() {
+		var wiki = new $tw.Wiki({});
+		wiki.addTiddlers([
+			{ title: "AlwaysPreview", tags: "$:/tags/EditPreview", caption: "Always" },
+			{ title: "CustomEditorOnlyPreview", tags: "$:/tags/EditPreview", caption: "Custom", condition: "[<tv-editor-type>match[custom]]" }
+		]);
+		wiki.addIndexersToWiki();
+		return wiki;
+	}
+
+	function renderDropdown(wiki, editorType) {
+		var parser = wiki.parseText("text/vnd.tiddlywiki",
+			"<$set name=\"tv-editor-type\" value=\"" + editorType + "\"><$transclude tiddler=\"$:/core/ui/EditorToolbar/preview-type-dropdown\"/></$set>");
+		var widget = wiki.makeWidget(parser, { document: $tw.fakeDocument });
+		var container = $tw.fakeDocument.createElement("div");
+		widget.render(container, null);
+		return container;
+	}
+
+	function textContent(container) {
+		return (container.textContent || "").replace(/\s+/g, " ").trim();
+	}
+
+	function dropdownContainer(wiki, editorType) {
+		var parser = wiki.parseText("text/vnd.tiddlywiki",
+			"<$set name=\"tv-editor-type\" value=\"" + editorType + "\"><div class=\"tc-drop-down\"><$transclude tiddler=\"$:/core/ui/EditorToolbar/preview-type-dropdown\"/></div></$set>");
+		var widget = wiki.makeWidget(parser, { document: $tw.fakeDocument });
+		var container = $tw.fakeDocument.createElement("div");
+		widget.render(container, null);
+		return container.querySelector(".tc-drop-down");
+	}
+
+	it("should show all preview types when no condition is set", function() {
+		var wiki = setupWiki();
+		var container = renderDropdown(wiki, "text");
+		var text = textContent(container);
+		expect(text).toContain("Always");
+		expect(text).not.toContain("Custom");
+	});
+
+	it("should show conditional preview types when the condition matches", function() {
+		var wiki = setupWiki();
+		var container = renderDropdown(wiki, "custom");
+		var text = textContent(container);
+		expect(text).toContain("Always");
+		expect(text).toContain("Custom");
+	});
+
+	it("should not wrap preview type entries in extra paragraph elements", function() {
+		var wiki = setupWiki();
+		var dropdown = dropdownContainer(wiki, "text");
+		expect(dropdown).toBeTruthy();
+		expect(dropdown.querySelector("p")).toBeNull();
+		expect(dropdown.firstElementChild && dropdown.firstElementChild.tagName).toBe("A");
+	});
+
+});

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9938.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9938.tid
@@ -1,0 +1,10 @@
+title: $:/changenotes/5.5.0/#9938
+description: Support conditional editor preview types
+release: 5.5.0
+tags: $:/tags/ChangeNote
+change-type: feature
+change-category: editor
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9938
+github-contributors: linonetwo
+
+Editor preview types can now specify a `condition` field to control their visibility. A new "Source" preview is added for the ProseMirror editor.

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9938.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9938.tid
@@ -1,5 +1,5 @@
 title: $:/changenotes/5.5.0/#9938
-description: Support conditional editor preview types
+description: Conditionally hide editor preview types
 release: 5.5.0
 tags: $:/tags/ChangeNote
 change-type: feature

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9938.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9938.tid
@@ -3,7 +3,7 @@ description: Conditionally hide editor preview types
 release: 5.5.0
 tags: $:/tags/ChangeNote
 change-type: feature
-change-category: editor
+change-category: widget
 github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9938
 github-contributors: linonetwo
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -888,6 +888,12 @@ button.tc-btn-invisible.tc-remove-tag-button {
 	color: <<colour tiddler-background>>;
 }
 
+.tc-drop-down a.tc-list-item-selected,
+.tc-drop-down a.tc-list-item-selected:hover {
+	background-color: <<colour primary>>;
+	color: <<colour tiddler-background>>;
+}
+
 /*
 ** Page layout
 */

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1898,6 +1898,11 @@ html body.tc-body.tc-single-tiddler-window {
 	line-height: 1.4;
 }
 
+/* The checkmark column already indents the caption, so the entry needs less start padding */
+.tc-drop-down a.tc-preview-type-button {
+	<<padding-start 9px>>
+}
+
 .tc-drop-down .tc-tab-set .tc-tab-buttons button {
 	display: inline-block;
 	width: auto;
@@ -1945,6 +1950,12 @@ html body.tc-body.tc-single-tiddler-window {
 .tc-drop-down-bullet {
 	display: inline-block;
 	width: 0.5em;
+}
+
+/* Fixed width column, so entries without a checkmark start at the same x position */
+.tc-drop-down-checkmark {
+	display: inline-block;
+	width: 1.1em;
 }
 
 .tc-drop-down .tc-tab-contents a {

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -888,12 +888,6 @@ button.tc-btn-invisible.tc-remove-tag-button {
 	color: <<colour tiddler-background>>;
 }
 
-.tc-drop-down a.tc-list-item-selected,
-.tc-drop-down a.tc-list-item-selected:hover {
-	background-color: <<colour primary>>;
-	color: <<colour tiddler-background>>;
-}
-
 /*
 ** Page layout
 */


### PR DESCRIPTION
I'd like to register a ProseMirror-only source preview:

```tid
condition: [<tv-editor-type>match[prosemirror]]
```

Split from #8991 so it can be reviewed and merged independently.