### PR TITLE
[docs] Add ButtonWidget examples and execution order

### DIFF
--- a/editions/tw5.com/tiddlers/examples/ButtonWidget/Accessibility.tid
+++ b/editions/tw5.com/tiddlers/examples/ButtonWidget/Accessibility.tid
@@ -1,0 +1,31 @@
+title: ButtonWidget/Example/Accessibility
+description: Add accessibility and metadata attributes such as aria-label, role, tabindex and data
+modified: 20260724235815000
+tags: [[$:/tags/wiki-test-spec]]
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+A button can carry accessibility and metadata attributes that pass straight through to the HTML element. They have no visible effect, so this example shows the markup rather than a result:
+
+* `aria-label` gives an accessible name when the label is only an icon
+* `role` overrides the implied ARIA role
+* `tabindex` sets the keyboard focus order
+* `data-*` attaches custom data attributes for scripts
+* `selectedAria` chooses which ARIA state `selectedClass` toggles
+
+Inspect the button in your browser to see the attributes on the element.
++
+title: Output
+
+<$wikify name="button-accessibility" mode="inline" output="html"
+text="""<$button aria-label="Close"
+	role="button"
+	tabindex="0"
+	data-action="close"
+>
+	×
+</$button>
+""">
+<$text text=<<button-accessibility>>/>
+</$wikify>

--- a/editions/tw5.com/tiddlers/examples/ButtonWidget/Actions.tid
+++ b/editions/tw5.com/tiddlers/examples/ButtonWidget/Actions.tid
@@ -1,0 +1,33 @@
+title: ButtonWidget/Example/Actions
+description: Run one or more ActionWidgets when the button is clicked, using the preferred actions attribute
+modified: 20260725015330000
+tags: [[$:/tags/wiki-test-spec]]
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+The `actions` attribute holds one or more ActionWidgets that run when the button is clicked. This is the preferred way to give a button its behaviour, because the whole behaviour sits in one place instead of being spread over several attributes.
+
+A button runs `actions` last, after `to`, `message`, `popup` and `set`. ButtonWidget lists the full order. A single `<$button to="HelloThere">Click Me</$button>` still needs no action string.
+
+The procedure below runs //two// actions in a single click:
+
+* one sets a message
+* the other bumps a counter
+
+Click ''Greet'' a few times to watch both update.
++
+title: Output
+
+\procedure greetActions()
+<$action-setfield $tiddler="$:/state/greeting" text="Hello!"/>
+<$action-setfield $tiddler="$:/state/greeting-count"
+	text={{{ [[$:/state/greeting-count]get[text]] :else[[0]] +[add[1]] }}}
+/>
+\end
+
+<$button actions=<<greetActions>>>
+Greet
+</$button>
+
+Message: <$text text={{$:/state/greeting}}/> (clicked <$text text={{{ [[$:/state/greeting-count]get[text]] :else[[0]] }}}/> times)

--- a/editions/tw5.com/tiddlers/examples/ButtonWidget/DragAndDrop.tid
+++ b/editions/tw5.com/tiddlers/examples/ButtonWidget/DragAndDrop.tid
@@ -1,0 +1,34 @@
+title: ButtonWidget/Example/DragAndDrop
+description: Make a button draggable with dragTiddler or dragFilter
+modified: 20260724235815000
+tags: [[$:/tags/wiki-test-spec]]
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+`dragTiddler` makes the button draggable and sets the single tiddler it carries. `dragFilter` carries a list of tiddlers produced by a filter instead.
+
+Choose one of the two:
+
+* `dragTiddler` is a single tiddler title to drag
+* `dragFilter` is a filter whose results are dragged as a list
+
+Drag the button onto the drop area to see the title it carries. Drag and drop needs a desktop browser.
++
+title: Output
+
+\procedure recordDrop()
+<$action-setfield $tiddler="$:/state/dropped" text=<<actionTiddler>>/>
+\end
+
+<$button dragTiddler="HelloThere" class="tc-btn-invisible tc-tiddlylink">
+Drag me
+</$button>
+
+<$droppable actions=<<recordDrop>>>
+<div style="border: 1px dashed #999; padding: 0.5em; margin-top: 0.5em;">
+Drop the button here
+</div>
+</$droppable>
+
+Dropped title: <$text text={{$:/state/dropped}}/>

--- a/editions/tw5.com/tiddlers/examples/ButtonWidget/DragFilter.tid
+++ b/editions/tw5.com/tiddlers/examples/ButtonWidget/DragFilter.tid
@@ -1,0 +1,54 @@
+title: ButtonWidget/Example/DragFilter
+description: Drag a list of tiddlers with dragFilter and receive it with listActions
+modified: 20260725001110000
+tags: [[$:/tags/wiki-test-spec]]
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+`dragFilter` makes the button draggable and carries every tiddler the filter returns, where `dragTiddler` carries a single title.
+
+The drop target chooses how it receives that payload:
+
+* `actions` runs once per dragged tiddler, with the title in `<<actionTiddler>>`
+* `listActions` runs once for the whole payload, with all titles in `<<actionTiddlerList>>`
+
+This test case carries four payload tiddlers tagged `Concepts`. The button drags all four, so the drop area shows the whole list at once. Drag and drop needs a desktop browser.
++
+title: Cascades
+tags: Concepts
+
+A cascade is a filter list that is evaluated in turn until one returns a result.
++
+title: ColourPalettes
+tags: Concepts
+
+A colour palette is a tiddler holding the named colours used by the user interface.
++
+title: Commands
+tags: Concepts
+
+Commands are the operations run by the Node.js server from the command line.
++
+title: Filters
+tags: Concepts
+
+A filter is an expression that selects a list of tiddler titles from the wiki.
++
+title: Output
+
+\procedure recordDropList()
+<$action-setfield $tiddler="$:/state/dropped-list" text=<<actionTiddlerList>>/>
+\end
+
+<$button dragFilter="[tag[Concepts]]" class="tc-btn-invisible tc-tiddlylink">
+Drag four tiddlers
+</$button>
+
+<$droppable listActions=<<recordDropList>>>
+<div style="border: 1px dashed #999; padding: 0.5em; margin-top: 0.5em;">
+Drop the button here
+</div>
+</$droppable>
+
+Dropped titles: <$text text={{$:/state/dropped-list}}/>

--- a/editions/tw5.com/tiddlers/examples/ButtonWidget/Message.tid
+++ b/editions/tw5.com/tiddlers/examples/ButtonWidget/Message.tid
@@ -1,0 +1,30 @@
+title: ButtonWidget/Example/Message
+description: Send a widget message with the message and param attributes
+modified: 20260724235815000
+tags: [[$:/tags/wiki-test-spec]]
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+The `message` attribute sends a widget message when the button is clicked. The `param` attribute passes a single value with it.
+
+The two attributes work together:
+
+* `message` is the message type to send
+* `param` is the value delivered with the message
+
+A `messagecatcher` receives the message here and shows the parameter. Click the button to send it.
++
+title: Output
+
+\procedure receiveMessage()
+<$action-setfield $tiddler="$:/state/received" text=<<event-param>>/>
+\end
+
+<$messagecatcher $tm-sample-message=<<receiveMessage>>>
+<$button message="tm-sample-message" param="Hello from param">
+Send message
+</$button>
+</$messagecatcher>
+
+Received param: <$text text={{$:/state/received}}/>

--- a/editions/tw5.com/tiddlers/examples/ButtonWidget/NewTiddler.tid
+++ b/editions/tw5.com/tiddlers/examples/ButtonWidget/NewTiddler.tid
@@ -1,0 +1,42 @@
+title: ButtonWidget/Example/NewTiddler
+description: Create a tiddler from a template with the tm-new-tiddler message
+modified: 20260725002340000
+tags: [[$:/tags/wiki-test-spec]]
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+`tm-new-tiddler` is a message the core already handles, so the button needs no catcher of its own.
+
+* `message` is set to `tm-new-tiddler`
+* `param` names a template tiddler, and the new tiddler starts out with that template's fields
+
+This test case carries a `TaskTemplate` payload tiddler holding `tags`, `status` and `priority`. Open the ''TaskTemplate'' tab above to see it.
+
+The message creates a draft and normally opens it for editing. A test case has no story river, so the table lists the drafts instead. Each click adds one row, and the new tiddler takes the next free title because the previous draft still exists.
++
+title: TaskTemplate
+tags: Task
+status: open
+priority: normal
+
+Describe the task here.
++
+title: Output
+
+<$button message="tm-new-tiddler" param="TaskTemplate">
+New task
+</$button>
+
+<table>
+<tr><th>Click</th><th>New tiddler</th><th>tags</th><th>status</th><th>priority</th></tr>
+<$list filter="[has[draft.title]sort[draft.title]]" counter="clickNumber">
+<tr>
+	<td><<clickNumber>></td>
+	<td><$text text={{!!draft.title}}/></td>
+	<td><$text text={{!!tags}}/></td>
+	<td><$text text={{!!status}}/></td>
+	<td><$text text={{!!priority}}/></td>
+</tr>
+</$list>
+</table>

--- a/editions/tw5.com/tiddlers/examples/ButtonWidget/Popup.tid
+++ b/editions/tw5.com/tiddlers/examples/ButtonWidget/Popup.tid
@@ -1,0 +1,38 @@
+created: 20260724134149482
+description: Toggle a popup with the popup attribute and a companion reveal widget
+modified: 20260725003054000
+tags: $:/tags/wiki-test-spec
+title: ButtonWidget/Example/Popup
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+The `popup` attribute names a state tiddler that stores the popup coordinates. A companion `reveal` widget reads that state to show or hide the content.
+
+The button uses these attributes:
+
+* `popup` is the state tiddler for the popup
+* `selectedClass` highlights the button while the popup is open
+* `popupAbsCoords` writes absolute coordinates when set to `yes`, rather than relative ones
+
+Use `popupTitle` in place of `popup` when the state title should not be read as a text reference. Click the button to toggle the popup.
+
+The `reveal` widget always creates a DOM element of its own: a `div` in block mode, a `span` in inline mode. The `tag` attribute sets that element explicitly. Wrapping the popup content in a `<div>` would add a second element, so this example sets `tag="div"` and puts the `tc-drop-down` class on the widget itself. The popup is then one element instead of two.
++
+title: Output
+
+<$button popup="$:/state/popup/demo" selectedClass="tc-selected">
+Toggle popup
+</$button>
+
+<$reveal type="popup"
+  tag="div"
+  state="$:/state/popup/demo"
+  position="belowleft"
+  animate="yes"
+  class="tc-drop-down"
+>
+
+This is the popup content.
+
+</$reveal>

--- a/editions/tw5.com/tiddlers/examples/ButtonWidget/Presentation.tid
+++ b/editions/tw5.com/tiddlers/examples/ButtonWidget/Presentation.tid
@@ -1,0 +1,41 @@
+title: ButtonWidget/Example/Presentation
+description: Change the rendered element and appearance with tag, class, style and disabled
+modified: 20260725003716000
+tags: [[$:/tags/wiki-test-spec]]
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+Several attributes control how the button looks and which element it renders:
+
+* `tag` renders a different HTML element in place of `button`
+* `class` adds one or more CSS classes
+* `style` sets a full CSS style string
+* `disabled` set to `yes` disables the button
+
+Reach for `class` first and keep the rules in a stylesheet. One class restyles every button that uses it, follows the colour palette and stays under the user's control. A hardcoded `style` overrides the theme and has to be repeated at every button, so use it only when no class can do the job.
+
+`style` sets the whole style attribute and replaces anything a `style.*` attribute wrote before it, so do not mix the two.
++
+title: Output
+
+<$button tag="a" class="tc-tiddlylink">
+tag="a" renders a link element
+</$button>
+
+<$button class="tc-btn-big-green">
+class uses a rule from the stylesheet
+</$button>
+
+<$button disabled="yes">
+disabled="yes"
+</$button>
+
+<$button style.color="green">
+style is the last resort
+</$button>
+
+<$button style="font-weight: bold;">
+style is the last resort
+</$button>
+

--- a/editions/tw5.com/tiddlers/examples/ButtonWidget/SelectedState.tid
+++ b/editions/tw5.com/tiddlers/examples/ButtonWidget/SelectedState.tid
@@ -1,0 +1,52 @@
+title: ButtonWidget/Example/SelectedState
+description: Highlight the active button with selectedClass, set, setTo and default used together
+modified: 20260724235815000
+tags: [[$:/tags/wiki-test-spec]]
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+This example combines four attributes so a row of buttons can show which colour is active:
+
+* `set` and `setTo` write the chosen colour to a state tiddler
+* `selectedClass` marks the button whose `setTo` matches the current value of `set`
+* `default` gives the value to compare against while the `set` tiddler does not yet exist
+
+Because `default` is `red`, the ''Red'' button starts out selected. Click another colour to move the selection.
++
+title: Output
+
+<!-- The inline <style> below is only for this self-contained test/development example.
+For production, define styles in a tiddler tagged $:/tags/Stylesheet instead. -->
+<style>
+.demo-swatch {
+	padding: 0.2em 0.7em;
+}
+.demo-selected {
+	outline: 2px solid #1a73e8;
+}
+</style>
+
+<$button set="$:/state/colour" setTo="red"
+	default="red"
+	class="demo-swatch tc-small-gap-right"
+	selectedClass="demo-selected"
+>
+	Red
+</$button>
+<$button set="$:/state/colour" setTo="green"
+	default="red"
+	class="demo-swatch tc-small-gap-right"
+	selectedClass="demo-selected"
+>
+	Green
+</$button>
+<$button set="$:/state/colour" setTo="blue"
+	default="red"
+	class="demo-swatch tc-small-gap-right"
+	selectedClass="demo-selected"
+>
+	Blue
+</$button>
+
+Selected colour: <$text text={{{ [[$:/state/colour]get[text]] :else[[red]] }}}/>

--- a/editions/tw5.com/tiddlers/examples/ButtonWidget/SetAndSetTo.tid
+++ b/editions/tw5.com/tiddlers/examples/ButtonWidget/SetAndSetTo.tid
@@ -1,0 +1,24 @@
+title: ButtonWidget/Example/SetAndSetTo
+description: Assign a value to a tiddler with the set and setTo attributes used together
+modified: 20260724235815000
+tags: [[$:/tags/wiki-test-spec]]
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+`set` and `setTo` work as a pair to assign a value when the button is clicked:
+
+* `set` names the storage location, a TextReference
+* `setTo` is the value written to it
+
+`set` points at the location //itself//, so it takes no curly brackets, unlike an ordinary transclusion.
+
+Click a colour to write it to the state tiddler shown below.
++
+title: Output
+
+<$button set="$:/state/colour" setTo="red">Red</$button>
+<$button set="$:/state/colour" setTo="green">Green</$button>
+<$button set="$:/state/colour" setTo="blue">Blue</$button>
+
+Selected colour: <$text text={{$:/state/colour}}/>

--- a/editions/tw5.com/tiddlers/examples/ButtonWidget/SetField.tid
+++ b/editions/tw5.com/tiddlers/examples/ButtonWidget/SetField.tid
@@ -1,0 +1,37 @@
+title: ButtonWidget/Example/SetField
+description: Assign a field or index directly with setTitle, setField and setIndex
+modified: 20260724235815000
+tags: [[$:/tags/wiki-test-spec]]
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+The `set` attribute treats its value as a TextReference, which is ambiguous when a title contains `!!` or `##`. The `setTitle` group names the target directly instead.
+
+The attributes work together:
+
+* `setTitle` is the tiddler to change, with no TextReference parsing
+* `setField` is the field to write, defaulting to `text`
+* `setIndex` writes a data index instead of a field
+* `setTo` is the value to assign
+
+Click a button to set the `caption` field, then watch it update below.
++
+title: Output
+
+<$button setTitle="$:/state/demo"
+	setField="caption"
+	setTo="First"
+	class="tc-small-gap-right"
+>
+	Set caption to First
+</$button>
+<$button setTitle="$:/state/demo"
+	setField="caption"
+	setTo="Second"
+	class="tc-small-gap-right"
+>
+	Set caption to Second
+</$button>
+
+Caption is now: <$text text={{$:/state/demo!!caption}}/>

--- a/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
@@ -1,6 +1,6 @@
 caption: button
 created: 20131024141900000
-modified: 20251101091926820
+modified: 20260725015330000
 tags: Widgets TriggeringWidgets
 title: ButtonWidget
 type: text/vnd.tiddlywiki
@@ -66,4 +66,40 @@ Press me!
 </$button>
 ```
 
-''Tip:'' Set ''class'' to `tc-btn-invisible tc-tiddlylink` to have a button look like an internal link.
+! Order of execution
+
+The order of the attributes written in wikitext does ''not'' matter.
+
+A button can carry several of these attributes at once. They are not alternatives: every one that is present is used, and ''always in the order shown below''.
+
+# ActionWidgets in the button body
+# <<.attr to>>
+# <<.attr message>>, with <<.attr param>>
+# <<.attr popup>> or <<.attr popupTitle>>
+# <<.attr set>> or <<.attr setTitle>>, with <<.attr setTo>>, <<.attr setField>> and <<.attr setIndex>>
+# <<.attr actions>>
+
+<<.tip """When a button does more than one thing, put the whole behaviour in the `actions` attribute. It keeps the behaviour in one place and runs it last, after every other attribute above. A single `<$button to="HelloThere">Click Me</$button>` needs no action string.""">>
+
+Action widgets are refreshed before each one runs, so they see the results of the actions before them. Ordinary widgets wrapped around them are not. See [[ActionWidget Execution Modes]] when a value looks out of date.
+
+! Examples
+
+This button uses the <<.attr to>> attribute to navigate to the [[HelloThere]] tiddler, opening it in the story river. The optional <<.attr tooltip>> attribute sets the text shown on hover.
+
+<$macrocall $name='wikitext-example-without-html'
+src='<$button to="HelloThere" tooltip="Navigate to the HelloThere tiddler">
+Open ~HelloThere
+</$button>'/>
+
+<<.tip """Set ''class'' to `tc-btn-invisible tc-tiddlylink` to have a button look like an internal link.""">>
+
+! Interactive Examples
+
+<<<
+<$list filter="[prefix[ButtonWidget/Example/]]">
+
+; <$link/>
+: {{!!description}}
+</$list>
+<<<


### PR DESCRIPTION
Document the button widget with runnable test cases and explain how its attributes combine.

* Add eleven test case tiddlers, listed by title prefix so a new one needs no edit to the widget page
* Describe the order in which a button runs body actions, to, message, popup, set and actions, whatever order they are written in
* Prefer class over a hardcoded style