### PR TITLE
Fix typo in story width variable name

### DIFF
--- a/core/stylesheets/custom-properties.tid
+++ b/core/stylesheets/custom-properties.tid
@@ -1,6 +1,6 @@
 title: $:/core/stylesheets/custom-properties
 
-\rules only transcludeinline macrocallinline html transcludeblock
+\rules only transcludeinline macrocallinline html transcludeblock filteredtranscludeinline
 
 /* Tiddlywiki's CSS properties */
 
@@ -21,7 +21,7 @@ title: $:/core/stylesheets/custom-properties
 	--tp-story-left: {{$:/themes/tiddlywiki/vanilla/metrics/storyleft}};
 	--tp-story-top: {{$:/themes/tiddlywiki/vanilla/metrics/storytop}};
 	--tp-story-right: {{$:/themes/tiddlywiki/vanilla/metrics/storyright}};
-	--tp-story-width: {{$:/themes/tiddlywiki/vanilla/metrics/storyrwidth}};
+	--tp-story-width: {{$:/themes/tiddlywiki/vanilla/metrics/storywidth}};
 	--tp-tiddler-width: {{$:/themes/tiddlywiki/vanilla/metrics/tiddlerwidth}};
 	--tp-sidebar-breakpoint: {{$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint}};
 	--tp-sidebar-width: {{$:/themes/tiddlywiki/vanilla/metrics/sidebarwidth}};

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9958.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9958.tid
@@ -1,0 +1,10 @@
+title: $:/changenotes/5.4.1/#9958
+description: Fix typo in CSS custom properties
+tags: $:/tags/ChangeNote
+release: 5.5.0
+change-type: bugfix
+change-category: usability
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9958
+github-contributors: BurningTreeC
+
+Fixes a typo in the CSS custom properties


### PR DESCRIPTION
This fixes a typo in custom-properties storyrwidth -> storywidth and adds filteredtranscludeinline for the --tp-animation-duration