### PR TITLE
Dimensiontracker - a generic solution to track dimensions of elements by selector

### DIFF
--- a/core/modules/info/dimensiontracker.js
+++ b/core/modules/info/dimensiontracker.js
@@ -1,0 +1,278 @@
+/*\
+title: $:/core/modules/info/dimensiontracker.js
+type: application/javascript
+module-type: info
+
+Initialise $:/info/ tiddlers derived from the measured geometry of DOM elements.
+
+Each info tiddler receives unitless CSS-pixel values in the fields `width`,
+`height`, `x`, `y`, `top`, `left`, `right` and `bottom`, plus `found` (yes/no)
+so a consumer can distinguish "not present" from "present but zero-sized".
+
+Stylesheets can select the right one with the tv-window-id variable, which
+$:/core/modules/startup/windows.js passes to the stylesheet it renders into
+each new window:
+
+	{{{ [<tv-window-id>!is[blank]addprefix[user/]] ~[[system/main]]
+	    +[addprefix[$:/info/browser/menubar/]get[height]] ~[[0]] +[addsuffix[px]] }}}
+
+Note x/y/top/left are viewport-relative and are NOT recomputed on scroll. That
+is deliberate: scroll would produce a write on every frame, and the intended
+use is measuring the size and resting position of page furniture.
+
+\*/
+
+"use strict";
+
+exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
+	if(!$tw.browser) {
+		return [];
+	}
+
+	class ElementDimensionsTracker {
+		constructor(updateCallback) {
+			this.updateCallback = updateCallback;
+			this.windows = new Map();     // windowId -> {win, observer, nodes: Map<configTitle,element>}
+			this.configs = new Map();     // configTitle -> {selector, infoTiddler}
+			this.signatures = new Map();  // infoTitle -> last written signature
+			this.scheduled = false;
+		}
+
+		infoTitle(config,windowId) {
+			return config.infoTiddler + "/" + windowId;
+		}
+
+		round(value) {
+			return Math.round(value * 100) / 100;
+		}
+
+		measureOne(entry,configTitle,config) {
+			var element = null;
+			try {
+				element = entry.win.document.querySelector(config.selector) || null;
+			} catch(e) {
+				// A malformed selector must not take the whole tracker down
+				element = null;
+			}
+			// Re-point the observer if a re-render replaced the node
+			var previous = entry.nodes.get(configTitle) || null;
+			if(element !== previous) {
+				if(entry.observer) {
+					if(previous) {
+						entry.observer.unobserve(previous);
+					}
+					if(element) {
+						entry.observer.observe(element);
+					}
+				}
+				entry.nodes.set(configTitle,element);
+			}
+			var title = this.infoTitle(config,entry.windowId),
+				fields = {title: title};
+			if(element) {
+				var rect = element.getBoundingClientRect();
+				fields.found = "yes";
+				fields.width = "" + this.round(rect.width);
+				fields.height = "" + this.round(rect.height);
+				fields.x = "" + this.round(rect.left);
+				fields.y = "" + this.round(rect.top);
+				fields.top = "" + this.round(rect.top);
+				fields.left = "" + this.round(rect.left);
+				fields.right = "" + this.round(rect.right);
+				fields.bottom = "" + this.round(rect.bottom);
+				fields.text = "" + this.round(rect.width) + " " + this.round(rect.height);
+			} else {
+				fields.found = "no";
+				$tw.utils.each(["width","height","x","y","top","left","right","bottom"],function(name) {
+					fields[name] = "0";
+				});
+				fields.text = "";
+			}
+			var signature = JSON.stringify(fields);
+			if(signature === this.signatures.get(title)) {
+				return null;
+			}
+			this.signatures.set(title,signature);
+			return fields;
+		}
+
+		measureAll() {
+			var self = this,
+				additions = [];
+			this.windows.forEach(function(entry) {
+				// A window can be closed between scheduling and running
+				if(entry.win.closed) {
+					return;
+				}
+				self.configs.forEach(function(config,configTitle) {
+					var fields = self.measureOne(entry,configTitle,config);
+					if(fields) {
+						additions.push(fields);
+					}
+				});
+			});
+			// One callback for the whole batch, so N trackers cost one refresh
+			if(additions.length > 0) {
+				this.updateCallback(additions,[]);
+			}
+		}
+
+		/*
+		Coalesce every trigger into at most one measurement.
+		*/
+		schedule() {
+			var self = this;
+			if(this.scheduled) {
+				return;
+			}
+			this.scheduled = true;
+			var run = function() {
+				if(!self.scheduled) {
+					return;
+				}
+				self.scheduled = false;
+				self.measureAll();
+			};
+			window.requestAnimationFrame(run);
+			window.setTimeout(run,250);
+		}
+
+		trackWindow(win,windowId) {
+			var self = this;
+			if(this.windows.has(windowId)) {
+				return;
+			}
+			var entry = {win: win, windowId: windowId, observer: null, nodes: new Map()};
+			// ResizeObserver must come from the window whose nodes it watches
+			if(typeof win.ResizeObserver === "function") {
+				entry.observer = new win.ResizeObserver(function() {
+					self.schedule();
+				});
+			}
+			entry.resizeHandler = function() {
+				self.schedule();
+			};
+			win.addEventListener("resize",entry.resizeHandler,{passive: true});
+			this.windows.set(windowId,entry);
+			this.schedule();
+		}
+
+		untrackWindow(windowId) {
+			var entry = this.windows.get(windowId);
+			if(!entry) {
+				return;
+			}
+			if(entry.observer) {
+				entry.observer.disconnect();
+			}
+			try {
+				entry.win.removeEventListener("resize",entry.resizeHandler);
+			} catch(e) {
+				// The window may already be gone
+			}
+			this.windows.delete(windowId);
+			this.clearWindow(windowId);
+		}
+
+		// Drop every info tiddler belonging to one window
+		clearWindow(windowId) {
+			var self = this,
+				deletions = [];
+			this.configs.forEach(function(config) {
+				var title = self.infoTitle(config,windowId);
+				deletions.push(title);
+				self.signatures.delete(title);
+			});
+			if(deletions.length > 0) {
+				this.updateCallback([],deletions);
+			}
+		}
+
+		addConfig(configTitle,config) {
+			this.configs.set(configTitle,config);
+			this.schedule();
+		}
+
+		// Drop one config, and its info tiddler in every window
+		removeConfig(configTitle) {
+			var self = this,
+				config = this.configs.get(configTitle);
+			if(!config) {
+				return;
+			}
+			var deletions = [];
+			this.windows.forEach(function(entry) {
+				var title = self.infoTitle(config,entry.windowId),
+					node = entry.nodes.get(configTitle);
+				if(node && entry.observer) {
+					entry.observer.unobserve(node);
+				}
+				entry.nodes.delete(configTitle);
+				deletions.push(title);
+				self.signatures.delete(title);
+			});
+			this.configs.delete(configTitle);
+			if(deletions.length > 0) {
+				this.updateCallback([],deletions);
+			}
+		}
+	}
+
+	var tracker = new ElementDimensionsTracker(updateInfoTiddlersCallback);
+
+	// Exposed for debugging and for plugins that need to force a re-measure
+	$tw.elementDimensionsTracker = tracker;
+
+	// Track the main window, using the same key as windowdimensions.js
+	tracker.trackWindow(window,"system/main");
+
+	if($tw.eventBus) {
+		$tw.eventBus.on("window:opened",function(event) {
+			tracker.trackWindow(event.window,"user/" + event.windowID);
+		});
+		$tw.eventBus.on("window:closed",function(event) {
+			tracker.untrackWindow("user/" + event.windowID);
+		});
+	}
+
+	// Watch the tracker configuration tiddlers
+	$tw.filterTracker.track({
+		filterString: "[all[tiddlers+shadows]tag[$:/tags/DimensionTracker]!is[draft]]",
+		fnEnter: function(title) {
+			var tiddler = $tw.wiki.getTiddler(title);
+			if(tiddler) {
+				var selector = tiddler.fields["selector"],
+					infoTiddler = tiddler.fields["info-tiddler"];
+				if(selector && infoTiddler) {
+					tracker.addConfig(title,{selector: selector, infoTiddler: infoTiddler});
+				}
+			}
+			return title;
+		},
+		fnLeave: function(title) {
+			tracker.removeConfig(title);
+		},
+		fnChange: function(title) {
+			tracker.removeConfig(title);
+			var tiddler = $tw.wiki.getTiddler(title);
+			if(tiddler) {
+				var selector = tiddler.fields["selector"],
+					infoTiddler = tiddler.fields["info-tiddler"];
+				if(selector && infoTiddler) {
+					tracker.addConfig(title,{selector: selector, infoTiddler: infoTiddler});
+				}
+			}
+			return title;
+		}
+	});
+
+	$tw.hooks.addHook("th-page-refreshed",function() {
+		tracker.schedule();
+	});
+
+	$tw.wiki.addEventListener("change",function() {
+		tracker.schedule();
+	});
+
+	return [];
+};

--- a/core/modules/info/dimensiontracker.js
+++ b/core/modules/info/dimensiontracker.js
@@ -117,14 +117,6 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 			}
 		}
 
-		/*
-		Coalesce every trigger into at most one measurement.
-
-		If a specific window is supplied, use that window's animation frame
-		and timer mechanisms. This is important when tracking multiple
-		TiddlyWiki windows. Calls without a window fall back to the main
-		window.
-		*/
 		schedule(win) {
 			var self = this;
 			if(this.scheduled) {

--- a/core/modules/info/dimensiontracker.js
+++ b/core/modules/info/dimensiontracker.js
@@ -29,11 +29,6 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 		return [];
 	}
 
-	/*
-	Pure helpers. They depend only on their arguments, so they live here rather
-	than on the class — a method that never touches instance state is not a
-	method, and eslint's class-methods-use-this rule says so.
-	*/
 	function infoTitle(config,windowId) {
 		return config.infoTiddler + "/" + windowId;
 	}

--- a/core/modules/info/dimensiontracker.js
+++ b/core/modules/info/dimensiontracker.js
@@ -119,13 +119,21 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 
 		/*
 		Coalesce every trigger into at most one measurement.
+
+		If a specific window is supplied, use that window's animation frame
+		and timer mechanisms. This is important when tracking multiple
+		TiddlyWiki windows. Calls without a window fall back to the main
+		window.
 		*/
-		schedule() {
+		schedule(win) {
 			var self = this;
 			if(this.scheduled) {
 				return;
 			}
 			this.scheduled = true;
+
+			var schedulingWindow = win || window;
+
 			var run = function() {
 				if(!self.scheduled) {
 					return;
@@ -133,8 +141,9 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 				self.scheduled = false;
 				self.measureAll();
 			};
-			window.requestAnimationFrame(run);
-			window.setTimeout(run,250);
+
+			schedulingWindow.requestAnimationFrame(run);
+			schedulingWindow.setTimeout(run,250);
 		}
 
 		trackWindow(win,windowId) {
@@ -143,18 +152,21 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 				return;
 			}
 			var entry = {win: win, windowId: windowId, observer: null, nodes: new Map()};
+
 			// ResizeObserver must come from the window whose nodes it watches
 			if(typeof win.ResizeObserver === "function") {
 				entry.observer = new win.ResizeObserver(function() {
-					self.schedule();
+					self.schedule(win);
 				});
 			}
+
 			entry.resizeHandler = function() {
-				self.schedule();
+				self.schedule(win);
 			};
+
 			win.addEventListener("resize",entry.resizeHandler,{passive: true});
 			this.windows.set(windowId,entry);
-			this.schedule();
+			this.schedule(win);
 		}
 
 		untrackWindow(windowId) {

--- a/core/modules/info/dimensiontracker.js
+++ b/core/modules/info/dimensiontracker.js
@@ -29,6 +29,14 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 		return [];
 	}
 
+	function infoTitle(config,windowId) {
+		return config.infoTiddler + "/" + windowId;
+	}
+
+	function round(value) {
+		return Math.round(value * 100) / 100;
+	}
+
 	class ElementDimensionsTracker {
 		constructor(updateCallback) {
 			this.updateCallback = updateCallback;
@@ -36,14 +44,6 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 			this.configs = new Map();     // configTitle -> {selector, infoTiddler}
 			this.signatures = new Map();  // infoTitle -> last written signature
 			this.scheduled = false;
-		}
-
-		infoTitle(config,windowId) {
-			return config.infoTiddler + "/" + windowId;
-		}
-
-		round(value) {
-			return Math.round(value * 100) / 100;
 		}
 
 		measureOne(entry,configTitle,config) {

--- a/core/modules/info/dimensiontracker.js
+++ b/core/modules/info/dimensiontracker.js
@@ -29,6 +29,11 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 		return [];
 	}
 
+	/*
+	Pure helpers. They depend only on their arguments, so they live here rather
+	than on the class — a method that never touches instance state is not a
+	method, and eslint's class-methods-use-this rule says so.
+	*/
 	function infoTitle(config,windowId) {
 		return config.infoTiddler + "/" + windowId;
 	}
@@ -67,20 +72,20 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 				}
 				entry.nodes.set(configTitle,element);
 			}
-			var title = this.infoTitle(config,entry.windowId),
+			var title = infoTitle(config,entry.windowId),
 				fields = {title: title};
 			if(element) {
 				var rect = element.getBoundingClientRect();
 				fields.found = "yes";
-				fields.width = "" + this.round(rect.width);
-				fields.height = "" + this.round(rect.height);
-				fields.x = "" + this.round(rect.left);
-				fields.y = "" + this.round(rect.top);
-				fields.top = "" + this.round(rect.top);
-				fields.left = "" + this.round(rect.left);
-				fields.right = "" + this.round(rect.right);
-				fields.bottom = "" + this.round(rect.bottom);
-				fields.text = "" + this.round(rect.width) + " " + this.round(rect.height);
+				fields.width = "" + round(rect.width);
+				fields.height = "" + round(rect.height);
+				fields.x = "" + round(rect.left);
+				fields.y = "" + round(rect.top);
+				fields.top = "" + round(rect.top);
+				fields.left = "" + round(rect.left);
+				fields.right = "" + round(rect.right);
+				fields.bottom = "" + round(rect.bottom);
+				fields.text = "" + round(rect.width) + " " + round(rect.height);
 			} else {
 				fields.found = "no";
 				$tw.utils.each(["width","height","x","y","top","left","right","bottom"],function(name) {
@@ -179,7 +184,7 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 			var self = this,
 				deletions = [];
 			this.configs.forEach(function(config) {
-				var title = self.infoTitle(config,windowId);
+				var title = infoTitle(config,windowId);
 				deletions.push(title);
 				self.signatures.delete(title);
 			});
@@ -202,7 +207,7 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 			}
 			var deletions = [];
 			this.windows.forEach(function(entry) {
-				var title = self.infoTitle(config,entry.windowId),
+				var title = infoTitle(config,entry.windowId),
 					node = entry.nodes.get(configTitle);
 				if(node && entry.observer) {
 					entry.observer.unobserve(node);

--- a/editions/tw5.com/tiddlers/mechanisms/DimensionTrackerMechanism.tid
+++ b/editions/tw5.com/tiddlers/mechanisms/DimensionTrackerMechanism.tid
@@ -1,0 +1,13 @@
+title: Dimension Tracker Mechanism
+tags: Mechanisms
+created: 20260814084235646
+modified: 20260814084235646
+
+
+<<.from-version "5.5.0">> The dimension tracker mechanism allows you to define elements by [ext[CSS selectors|https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Selectors]] to be bound to a specified [[info|InfoMechanism]] tiddler. The info tiddler will be dynamically update to reflect the current dimensions of the selected element.
+
+Adding or modifying a tiddler tagged $:/tags/DimensionTracker takes effect immediately.
+
+The dimension queries are always applied by window. Therefore the info tiddlers get a suffix by window-id. The main window has the suffix `system/main`. Other windows have the suffix `user/<window-id>`. See [[WidgetMessage: tm-open-window]] for informations about the `window ID`.
+
+The menubar plugin includes a dimension tracker that is used for tracking the menubar height and applying that height to the top offset of sticky tiddler titles. See $:/plugins/tiddlywiki/menubar/trackers/menubar for details.

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9959.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9959.tid
@@ -1,0 +1,16 @@
+title: $:/changenotes/5.5.0/#9959
+created: 20260814084235746
+modified: 20260814084235746
+description: Dimension Tracker Mechanism
+release: 5.5.0
+tags: $:/tags/ChangeNote
+change-type: enhancement
+change-category: hackability
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9959
+github-contributors: BurningTreeC
+
+The Dimension Tracker Mechanism allows tracking the dimensions like `width` and `height` of elements specified by a `CSS selector`.
+
+This is internally used by the `menubar` plugin to track the height of the bar and to apply its height as a top offset to sticky tiddler titles.
+
+It creates info tiddlers and listens for size changes on the tracked element(s). If the size changes, the info tiddler gets updated with the new size.

--- a/plugins/tiddlywiki/menubar/styles.tid
+++ b/plugins/tiddlywiki/menubar/styles.tid
@@ -40,7 +40,19 @@ tags: [[$:/tags/Stylesheet]]
 </$reveal>
 \end
 
-\rules only filteredtranscludeinline transcludeinline macrodef macrocallinline
+\rules only filteredtranscludeinline transcludeinline macrodef macrocallinline conditional
+
+.tc-page-container {
+	--nb-menubar-h: {{{ [<tv-window-id>!is[blank]addprefix[user/]] ~[[system/main]] +[addprefix[$:/info/browser/menubar/]get[height]] ~[[0]] +[addsuffix[px]] }}};
+}
+
+<%if [{$:/themes/tiddlywiki/vanilla/options/stickytitles}match[yes]] %>
+
+	.tc-tiddler-title {
+		inset-block-start: var(--nb-menubar-h, 0px);
+	}
+
+<% endif %>
 
 nav.tc-menubar {
 	position: fixed;

--- a/plugins/tiddlywiki/menubar/trackers-menubar.tid
+++ b/plugins/tiddlywiki/menubar/trackers-menubar.tid
@@ -1,0 +1,4 @@
+title: $:/plugins/tiddlywiki/menubar/trackers/menubar
+tags: $:/tags/DimensionTracker
+selector: nav.tc-menubar
+info-tiddler: $:/info/browser/menubar


### PR DESCRIPTION
This PR adds `dimensiontracker.js` which uses the `filterTracker` mechanism to track tiddlers tagged `$:/tags/DimensionTracker` , creating info tiddlers containing the information about the dimensions of the selected element by a CSS selector.

It's used in the menubar plugin to add a top offset to sticky titles matching the height of the menubar.

Docs are missing, will be added, so will the changenote.