### PR TITLE
[DOCS] Update Custom Widgets documentation with new example for overriding LinkWidget

### DIFF
--- a/editions/tw5.com/tiddlers/saving/Saving on iPad_iPhone.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on iPad_iPhone.tid
@@ -5,25 +5,27 @@ created: 20131129101027725
 delivery: App
 description: iPad/iPhone app for working with TiddlyWiki
 method: save
-modified: 20201007205336209
+modified: 20260421210013537
 tags: Saving iOS [[Standalone App]]
 title: Saving on iPad/iPhone
 type: text/vnd.tiddlywiki
 
-The iPad/iPhone app ''Quine 2'' makes it possible to view, edit and then save changes to TiddlyWiki5 on iOS. [[Download it here|https://apps.apple.com/us/app/quine-2/id1450128957]].
+The iPad/iPhone app ''Quine'' makes it possible to view, edit and then save changes to TiddlyWiki5 on iOS.
+
+Currently in its third major version, rewritten for iOS and iPadOS 26.0.
+
+[[Download it here|https://apps.apple.com/us/app/TiddlyWiki51664603]].
 
 Instructions for use:
 
-# Open Quine 2
-# Tap the + toolbar button to create and open a new TiddlyWiki
+# Open Quine
+# From the file list tap the + toolbar button, or the "New Wiki" button, to create and open a new TiddlyWiki
 # From the file list tap an existing TiddlyWiki file to open it
 # Edit the TiddlyWiki as normal, and save as normal using either Autosave or the TiddlyWiki save button <<.icon $:/core/images/save-button-dynamic>>
-# Tap the left hand "Documents" toolbar button to close an open TiddlyWiki
+# Tap the left hand "<" toolbar button to close an open TiddlyWiki, returning to the file list
 
-*Quine 2 works natively in iOS with the local file system and the iCloud file system
-*Quine 2 also allows you to open, edit and save TiddlyWiki files stored with cloud file providers
-*Quine 2 allows you to follow embedded WikiText links and canonical links to external files for cloud-like file providers which support "folder level sharing". 
-**This includes the apps "Secure Shellfish" and "Working Copy". Most providers, though, do not allow apps like Quine 2 to access linked files this way.
-** If you wish to enable such links for "well behaved" file providers, toggle "on" the "Enable folder selection for out-of-sandbox links" setting in iOS Settings for Quine 2
+*Quine works natively in iOS with the local file system and the iCloud file system
+*Quine also allows you to open, edit and save TiddlyWiki files stored with other cloud file providers
+*Quine allows you to follow embedded WikiText links and canonical links to external files on cloud-like file providers which support "folder level sharing". 
 
 //Note that Quine is published independently of TiddlyWiki//

--- a/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
@@ -1,5 +1,5 @@
 created: 20221007144237585
-modified: 20240422084734129
+modified: 20260807181514194
 tags: Concepts
 title: Custom Widgets
 type: text/vnd.tiddlywiki
@@ -79,3 +79,24 @@ Python
 <$let test="Tiger">
 <$codeblock code=<<test>>/>
 </$let>""">>
+
+In this example, we override the <<.wlink LinkWidget>> to automatically display an icon next to the link if the target tiddler has an `icon` field. We use the `<$parameters>` widget to capture all attributes passed to the original link and forward them to the underlying widget via `<$genesis>`:
+
+<<wikitext-example-without-html """\widget $link()
+\whitespace trim
+<$parameters $params="params-var">
+	<$genesis
+		$type="$link"
+		$remappable="no"
+		$names="[<params-var>jsonindexes[]]"
+		$values="[<params-var>jsonindexes[]] :map[<params-var>jsonget<currentTiddler>]"
+	>
+		<span class="tc-tiddler-title-icon" style="fill:currentColor">
+			<$transclude $tiddler={{{ [<params-var>jsonget[to]get[icon]] }}} height="11pt"/>
+		</span>
+		<$slot $name="ts-raw"/>
+	</$genesis>
+</$parameters>
+\end
+
+[[HelloThere]]""">>


### PR DESCRIPTION
about: Propose a change to TiddlyWiki 5

title: "Update Quine instructions and Custom Widgets documentation"

labels: ''

assignees: ''



---



**Is your PR related to a problem? Please describe.**

The existing documentation for Quine and Custom Widgets lacks clarity and updated examples, which can lead to confusion for users.



**Describe the solution you are proposing**

Update the Quine instructions for clarity and accuracy, including the latest version details and usage steps. Enhance the Custom Widgets documentation with a new example demonstrating how to override the LinkWidget to display an icon based on the target tiddler's `icon` field.



**Describe alternatives you've considered**

Considered leaving the documentation as is, but clarity and updated examples are essential for user understanding and effective usage.



**Additional context**

No additional context at this time.



## Checklist before requesting a review



- [ ] Illustrate any visual changes (however minor) with before/after screenshots

- [ ] Self-review of code

- [ ] Documentation updates (for user-visible changes)

- [ ] Tests (for core code changes)

- [ ] Complies with coding style guidelines (for JavaScript code)

