### PR TITLE
[DOCS] Update [[Custom Widgets]] with new example for overriding LinkWidget

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
@@ -99,7 +99,7 @@ In this example, we override the <<.wlink "LinkWidget">> widget to automatically
 	>
 		<%if [<link.icon>]%>
 			<span class="tc-tiddler-title-icon tc-titlebar" style="fill:currentColor;font-size:11pt!important">
-				<$transclude $tiddler=<<link.icon>> height="11pt"/>
+				<$transclude $tiddler=<<link.icon>> size="11pt"/>
 			</span>
 		<%endif%>
 		<$slot $name="ts-raw">

--- a/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
@@ -92,9 +92,11 @@ In this example, we override the <<.wlink "LinkWidget">> widget to automatically
 		$values="[<params-var>jsonindexes[]] :map[<params-var>jsonget<currentTiddler>]"
 	>
 		<span class="tc-tiddler-title-icon tc-titlebar tc-tiny-gap-right" style="fill:currentColor;font-size:11pt!important">
-			<$transclude $tiddler={{{ [<params-var>jsonget[to]get[icon]] }}} height="11pt"/>
+			<$transclude $tiddler={{{ [<params-var>jsonget[to]else<currentTiddler>get[icon]] }}} height="11pt"/>
 		</span>
-		<$slot $name="ts-raw"/>
+		<$slot $name="ts-raw">
+			<$text text={{{ [<params-var>jsonget[to]else<currentTiddler>] }}}/>
+		</$slot>
 	</$genesis>
 </$parameters>
 \end

--- a/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
@@ -83,6 +83,12 @@ Python
 In this example, we override the <<.wlink "LinkWidget">> widget to automatically display an icon next to the link if the target tiddler has an `icon` field. We use the <<.wlink "ParametersWidget">> widget to capture all attributes passed to the original link and forward them to the underlying widget via <<.wlink "GenesisWidget">>:
 
 <<wikitext-example-without-html """\widget $link()
+\function link.icon()
+[<params-var>jsonget[to]else<currentTiddler>get[icon]]
+\end link.icon
+\function link.text()
+[<params-var>jsonget[to]else<currentTiddler>]
+\end link.text
 \whitespace trim
 <$parameters $params="params-var">
 	<$genesis
@@ -91,11 +97,13 @@ In this example, we override the <<.wlink "LinkWidget">> widget to automatically
 		$names="[<params-var>jsonindexes[]]"
 		$values="[<params-var>jsonindexes[]] :map[<params-var>jsonget<currentTiddler>]"
 	>
-		<span class="tc-tiddler-title-icon tc-titlebar tc-tiny-gap-right" style="fill:currentColor;font-size:11pt!important">
-			<$transclude $tiddler={{{ [<params-var>jsonget[to]else<currentTiddler>get[icon]] }}} height="11pt"/>
-		</span>
+		<%if [<link.icon>]%>
+			<span class="tc-tiddler-title-icon tc-titlebar" style="fill:currentColor;font-size:11pt!important">
+				<$transclude $tiddler=<<link.icon>> height="11pt"/>
+			</span>
+		<%endif%>
 		<$slot $name="ts-raw">
-			<$text text={{{ [<params-var>jsonget[to]else<currentTiddler>] }}}/>
+			<$text text=<<link.text>> />
 		</$slot>
 	</$genesis>
 </$parameters>

--- a/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
@@ -80,7 +80,7 @@ Python
 <$codeblock code=<<test>>/>
 </$let>""">>
 
-In this example, we override the <<.wlink LinkWidget>> to automatically display an icon next to the link if the target tiddler has an `icon` field. We use the `<$parameters>` widget to capture all attributes passed to the original link and forward them to the underlying widget via `<$genesis>`:
+In this example, we override the <<.wlink LinkWidget>> widget to automatically display an icon next to the link if the target tiddler has an `icon` field. We use the `<$parameters>` widget to capture all attributes passed to the original link and forward them to the underlying widget via `<$genesis>`:
 
 <<wikitext-example-without-html """\widget $link()
 \whitespace trim

--- a/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
@@ -1,5 +1,5 @@
 created: 20221007144237585
-modified: 20240422084734129
+modified: 20260807190532419
 tags: Concepts
 title: Custom Widgets
 type: text/vnd.tiddlywiki
@@ -79,3 +79,24 @@ Python
 <$let test="Tiger">
 <$codeblock code=<<test>>/>
 </$let>""">>
+
+In this example, we override the <<.wlink LinkWidget>> to automatically display an icon next to the link if the target tiddler has an `icon` field. We use the `<$parameters>` widget to capture all attributes passed to the original link and forward them to the underlying widget via `<$genesis>`:
+
+<<wikitext-example-without-html """\widget $link()
+\whitespace trim
+<$parameters $params="params-var">
+	<$genesis
+		$type="$link"
+		$remappable="no"
+		$names="[<params-var>jsonindexes[]]"
+		$values="[<params-var>jsonindexes[]] :map[<params-var>jsonget<currentTiddler>]"
+	>
+		<span class="tc-tiddler-title-icon" style="fill:currentColor">
+			<$transclude $tiddler={{{ [<params-var>jsonget[to]get[icon]] }}} height="11pt"/>
+		</span>
+		<$slot $name="ts-raw"/>
+	</$genesis>
+</$parameters>
+\end
+
+[[HelloThere]]""">>

--- a/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
@@ -91,7 +91,7 @@ In this example, we override the <<.wlink LinkWidget>> to automatically display 
 		$names="[<params-var>jsonindexes[]]"
 		$values="[<params-var>jsonindexes[]] :map[<params-var>jsonget<currentTiddler>]"
 	>
-		<span class="tc-tiddler-title-icon" style="fill:currentColor">
+		<span class="tc-tiddler-title-icon tc-titlebar" style="fill:currentColor;font-size:11pt">
 			<$transclude $tiddler={{{ [<params-var>jsonget[to]get[icon]] }}} height="11pt"/>
 		</span>
 		<$slot $name="ts-raw"/>

--- a/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
@@ -91,7 +91,7 @@ In this example, we override the <<.wlink LinkWidget>> to automatically display 
 		$names="[<params-var>jsonindexes[]]"
 		$values="[<params-var>jsonindexes[]] :map[<params-var>jsonget<currentTiddler>]"
 	>
-		<span class="tc-tiddler-title-icon tc-titlebar" style="fill:currentColor;font-size:11pt">
+		<span class="tc-tiddler-title-icon tc-titlebar tc-tiny-gap-right" style="fill:currentColor;font-size:11pt">
 			<$transclude $tiddler={{{ [<params-var>jsonget[to]get[icon]] }}} height="11pt"/>
 		</span>
 		<$slot $name="ts-raw"/>

--- a/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
@@ -91,7 +91,7 @@ In this example, we override the <<.wlink "LinkWidget">> widget to automatically
 		$names="[<params-var>jsonindexes[]]"
 		$values="[<params-var>jsonindexes[]] :map[<params-var>jsonget<currentTiddler>]"
 	>
-		<span class="tc-tiddler-title-icon tc-titlebar tc-tiny-gap-right" style="fill:currentColor;font-size:11pt">
+		<span class="tc-tiddler-title-icon tc-titlebar tc-tiny-gap-right" style="fill:currentColor;font-size:11pt!important">
 			<$transclude $tiddler={{{ [<params-var>jsonget[to]get[icon]] }}} height="11pt"/>
 		</span>
 		<$slot $name="ts-raw"/>

--- a/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
@@ -99,4 +99,4 @@ In this example, we override the <<.wlink LinkWidget>> to automatically display 
 </$parameters>
 \end
 
-[[HelloThere]]""">>
+<<list-links "[has[icon]]">>""">>

--- a/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/Custom Widgets.tid
@@ -80,7 +80,7 @@ Python
 <$codeblock code=<<test>>/>
 </$let>""">>
 
-In this example, we override the <<.wlink LinkWidget>> widget to automatically display an icon next to the link if the target tiddler has an `icon` field. We use the `<$parameters>` widget to capture all attributes passed to the original link and forward them to the underlying widget via `<$genesis>`:
+In this example, we override the <<.wlink "LinkWidget">> widget to automatically display an icon next to the link if the target tiddler has an `icon` field. We use the <<.wlink "ParametersWidget">> widget to capture all attributes passed to the original link and forward them to the underlying widget via <<.wlink "GenesisWidget">>:
 
 <<wikitext-example-without-html """\widget $link()
 \whitespace trim


### PR DESCRIPTION
Addition of a new example to [[Custom Widgets]] demonstrating how to override the `LinkWidget` to display an icon next to links if the target tiddler has an `icon` field.

<img width="1808" height="1013" alt="image" src="https://github.com/user-attachments/assets/bad07709-0a93-435b-9e2b-48ddee9c7a9d" />