### PR TITLE
[DOCS] Correct 5.4.0 release note for configuration updates

### DIFF
--- a/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9107 - update-configuration-defaults.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9107 - update-configuration-defaults.tid
@@ -1,11 +1,10 @@
 title: $:/changenotes/5.4.0/#9107
-description: Update configuration defaults
+description: Update default sidebar layout
 release: 5.4.0
 tags: $:/tags/ChangeNote
 change-type: enhancement
 change-category: usability
-github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9107
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9107 https://github.com/TiddlyWiki/TiddlyWiki5/issues/9757
 github-contributors: Jermolene
 
-* Changed default sidebar layout from ''fixed-fluid'' to ''fluid-fixed''
-* Changed ''Wrap long lines in code blocks'' default to ''No''
+Changed default sidebar layout from ''fixed-fluid'' to ''fluid-fixed''


### PR DESCRIPTION
The change to the code wrapping was ultimately reverted before 5.4.0's release, so I took it off the release notes.