### PR TITLE
Add class assignment to DOM node in editors

### DIFF
--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -230,7 +230,8 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		} else if(changedTiddlers[this.editTitle]) {
 			var editInfo = this.getEditInfo();
 			this.updateEditor(editInfo.value,editInfo.type);
-		} else if(changedAttributes["class"]) {
+		}
+		if(changedAttributes["class"]) {
 			this.assignDomNodeClasses();
 		}
 		this.engine.fixHeight();

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -210,15 +210,31 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		this.editShowToolbar = this.wiki.getTiddlerText(ENABLE_TOOLBAR_TITLE,"yes");
 		this.editShowToolbar = (this.editShowToolbar === "yes") && !!(this.children && this.children.length > 0) && (!this.document.isTiddlyWikiFakeDom);
 	};
-
-	EditTextWidget.prototype.assignDomNodeClasses = function() {
-		var classes = this.getAttribute("class","").split(/\s+/).filter(Boolean);
-		var origClasses = this.engine.domNode.className.split(/\s+/).filter(Boolean);
-		var newClasses = classes.filter(function(className, index) {
-			return origClasses.indexOf(className) === -1 &&
-				classes.indexOf(className) === index;
+	
+	EditTextWidget.prototype.updateDomNodeClasses = function() {
+		var domNodeClasses = this.engine.domNode.className.split(/\s+/).filter(Boolean);
+		var oldClasses = this.editClass.split(/\s+/).filter(Boolean);
+		var newClasses;
+	
+		this.editClass = this.getAttribute("class","");
+		newClasses = this.editClass.split(/\s+/).filter(Boolean);
+	
+		// Remove classes assigned from the old value of the class attribute
+		$tw.utils.each(oldClasses,function(oldClass) {
+			var i = domNodeClasses.indexOf(oldClass);
+			if(i !== -1) {
+				domNodeClasses.splice(i,1);
+			}
 		});
-		this.engine.domNode.className = origClasses.concat(newClasses).join(" ");
+	
+		// Add new classes from the updated class attribute
+		$tw.utils.each(newClasses,function(newClass) {
+			if(domNodeClasses.indexOf(newClass) === -1) {
+				domNodeClasses.push(newClass);
+			}
+		});
+	
+		this.engine.domNode.className = domNodeClasses.join(" ");
 	};
 
 	/*
@@ -237,7 +253,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 			this.updateEditor(editInfo.value,editInfo.type);
 		}
 		if(changedAttributes["class"]) {
-			this.assignDomNodeClasses();
+			this.updateDomNodeClasses();
 		}
 		this.engine.fixHeight();
 		if(this.editShowToolbar) {

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -212,8 +212,13 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 	};
 
 	EditTextWidget.prototype.assignDomNodeClasses = function() {
-		var classes = this.getAttribute("class","").split(" ");
-		this.engine.domNode.className = classes.join(" ").trim();
+		var classes = this.getAttribute("class","").split(/\s+/).filter(Boolean);
+		var origClasses = this.engine.domNode.className.split(/\s+/).filter(Boolean);
+		var newClasses = classes.filter(function(className, index) {
+			return origClasses.indexOf(className) === -1 &&
+				classes.indexOf(className) === index;
+		});
+		this.engine.domNode.className = origClasses.concat(newClasses).join(" ");
 	};
 
 	/*

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -212,27 +212,24 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 	};
 	
 	EditTextWidget.prototype.updateDomNodeClasses = function() {
-		var domNodeClasses = this.engine.domNode.className.split(/\s+/).filter(Boolean);
-		var oldClasses = this.editClass.split(/\s+/).filter(Boolean);
-		var newClasses;
+		var domNodeClasses = this.engine.domNode.className.split(/\s+/).filter(Boolean),
+			oldClasses = this.editClass.split(/\s+/).filter(Boolean),
+			newClasses;
 	
 		this.editClass = this.getAttribute("class","");
 		newClasses = this.editClass.split(/\s+/).filter(Boolean);
 	
 		// Remove classes assigned from the old value of the class attribute
-		$tw.utils.each(oldClasses,function(oldClass) {
-			var i = domNodeClasses.indexOf(oldClass);
-			if(i !== -1) {
-				domNodeClasses.splice(i,1);
-			}
+		domNodeClasses = domNodeClasses.filter(function(className) {
+			return !oldClasses.includes(className);
 		});
 	
 		// Add new classes from the updated class attribute
-		$tw.utils.each(newClasses,function(newClass) {
-			if(domNodeClasses.indexOf(newClass) === -1) {
-				domNodeClasses.push(newClass);
-			}
-		});
+		domNodeClasses = domNodeClasses.concat(
+			newClasses.filter(function(className) {
+				return !domNodeClasses.includes(className);
+			})
+		);
 	
 		this.engine.domNode.className = domNodeClasses.join(" ");
 	};

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -211,10 +211,10 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		this.editShowToolbar = (this.editShowToolbar === "yes") && !!(this.children && this.children.length > 0) && (!this.document.isTiddlyWikiFakeDom);
 	};
 
-EditTextWidget.prototype.assignDomNodeClasses = function() {
-	var classes = this.getAttribute("class","").split(" ");
-	this.engine.domNode.className = classes.join(" ").trim();
-};
+	EditTextWidget.prototype.assignDomNodeClasses = function() {
+		var classes = this.getAttribute("class","").split(" ");
+		this.engine.domNode.className = classes.join(" ").trim();
+	};
 
 	/*
 	Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -211,13 +211,18 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		this.editShowToolbar = (this.editShowToolbar === "yes") && !!(this.children && this.children.length > 0) && (!this.document.isTiddlyWikiFakeDom);
 	};
 
+EditTextWidget.prototype.assignDomNodeClasses = function() {
+	var classes = this.getAttribute("class","").split(" ");
+	this.engine.domNode.className = classes.join(" ").trim();
+};
+
 	/*
 	Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
 	*/
 	EditTextWidget.prototype.refresh = function(changedTiddlers) {
 		var changedAttributes = this.computeAttributes();
 		// Completely rerender if any of our attributes have changed
-		if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes["default"] || changedAttributes["class"] || changedAttributes.placeholder || changedAttributes.size || changedAttributes.autoHeight || changedAttributes.minHeight || changedAttributes.focusPopup ||  changedAttributes.rows || changedAttributes.tabindex || changedAttributes.cancelPopups || changedAttributes.inputActions || changedAttributes.refreshTitle || changedAttributes.autocomplete || changedTiddlers[HEIGHT_MODE_TITLE] || changedTiddlers[ENABLE_TOOLBAR_TITLE] || changedTiddlers["$:/palette"] || changedAttributes.disabled || changedAttributes.fileDrop) {
+		if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes["default"] || changedAttributes.placeholder || changedAttributes.size || changedAttributes.autoHeight || changedAttributes.minHeight || changedAttributes.focusPopup ||  changedAttributes.rows || changedAttributes.tabindex || changedAttributes.cancelPopups || changedAttributes.inputActions || changedAttributes.refreshTitle || changedAttributes.autocomplete || changedTiddlers[HEIGHT_MODE_TITLE] || changedTiddlers[ENABLE_TOOLBAR_TITLE] || changedTiddlers["$:/palette"] || changedAttributes.disabled || changedAttributes.fileDrop) {
 			this.refreshSelf();
 			return true;
 		} else if(changedTiddlers[this.editRefreshTitle]) {
@@ -225,6 +230,8 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		} else if(changedTiddlers[this.editTitle]) {
 			var editInfo = this.getEditInfo();
 			this.updateEditor(editInfo.value,editInfo.type);
+		} else if(changedAttributes["class"]) {
+			this.assignDomNodeClasses();
 		}
 		this.engine.fixHeight();
 		if(this.editShowToolbar) {

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9965.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9965.tid
@@ -1,0 +1,14 @@
+title: $:/changenotes/5.5.0/#9965
+created: 20260812171534862
+modified: 20260812171534862
+tags: $:/tags/ChangeNote
+change-type: enhancement
+change-category: usability
+description: Change of the class attribute of editors does no more completely refresh the widget
+release: 5.5.0
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9965
+github-contributors: BurningTreeC
+type: text/vnd.tiddlywiki
+
+This pull request changes the way editors refresh when their `class` attribute changes.
+They did refresh the widget completely. Now they just assign the new classes.


### PR DESCRIPTION
This PR changes the way how editors refresh when the class attribute changes.
They don't refresh completely anymore, but just assign the new classes.

See #9879