### PR TITLE
Freelinks: support `~` for local link suppression

### DIFF
--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9969-Freelinks_suppressing.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9969-Freelinks_suppressing.tid
@@ -7,6 +7,8 @@ release: 5.5.0
 tags: $:/tags/ChangeNote
 title: $:/changenotes/5.5.0/#9969
 type: text/vnd.tiddlywiki
+change-category: plugin
+change-type: feature
 
 Freelinks now supports local suppression of recognised automatic links.
 

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9969-Freelinks_suppressing.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9969-Freelinks_suppressing.tid
@@ -1,0 +1,27 @@
+created: 20260816103900000
+description: Freelinks: Allow locally suppressing recognised links with `~`
+github-contributors: s793016
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9969
+modified: 20260816103900000
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9969
+type: text/vnd.tiddlywiki
+
+Freelinks now supports local suppression of recognised automatic links.
+
+Prefix a recognised Freelink title with `~` to render it as plain text without
+displaying the `~` character:
+
+```text
+~Homer → Homer
+~1984 → 1984
+~中文標題 → 中文標題
+```
+
+This applies when Freelinks is enabled and the `~` prefix remains available to
+the Freelinks text widget. It supports non-CamelCase titles, including titles
+with spaces, numbers, and non-Latin characters.
+
+Unrecognised text is unchanged; for example, `~UnknownTitle` remains visible as
+written.

--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -8,6 +8,7 @@
 		"tiddlywiki/menubar",
 		"tiddlywiki/railroad",
 		"tiddlywiki/tour",
+		"tiddlywiki/freelinks",
 		"tiddlywiki/dom-to-image"
 	],
 	"themes": [

--- a/plugins/tiddlywiki/freelinks/text.js
+++ b/plugins/tiddlywiki/freelinks/text.js
@@ -130,10 +130,6 @@ TextNodeWidget.prototype.processTextWithMatches = function(text,currentTiddlerTi
 		var matchedTitleToCompare = ignoreCase ? matchedTitle.toLowerCase() : matchedTitle;
 		if(titleToCompare && matchedTitleToCompare === titleToCompare) continue;
 
-		/*
-		A recognised title immediately preceded by "~" is escaped.
-		Hide only this successful escape prefix; do not remove unrelated tildes.
-		*/
 		if(start > 0 && text.charAt(start - 1) === "~") {
 			escapedTildes[start - 1] = 1;
 			continue;

--- a/plugins/tiddlywiki/freelinks/text.js
+++ b/plugins/tiddlywiki/freelinks/text.js
@@ -109,6 +109,7 @@ TextNodeWidget.prototype.processTextWithMatches = function(text,currentTiddlerTi
 	});
 
 	var occupied = new Uint8Array(text.length);
+	var escapedTildes = new Uint8Array(text.length);
 	var validMatches = [];
 
 	var maxLinks = parseInt(this.wiki.getTiddlerText(MAX_LINKS_TIDDLER,"500"),10);
@@ -117,11 +118,10 @@ TextNodeWidget.prototype.processTextWithMatches = function(text,currentTiddlerTi
 	}
 
 	for(var i = 0; i < matches.length; i++) {
-		if(validMatches.length >= maxLinks) break;
-
 		var m = matches[i];
 		var start = m.index;
 		var end = start + m.length;
+
 		if(start < 0 || end > text.length) continue;
 
 		var matchedTitle = this.tiddlerTitleInfo.titles[m.titleIndex];
@@ -130,11 +130,25 @@ TextNodeWidget.prototype.processTextWithMatches = function(text,currentTiddlerTi
 		var matchedTitleToCompare = ignoreCase ? matchedTitle.toLowerCase() : matchedTitle;
 		if(titleToCompare && matchedTitleToCompare === titleToCompare) continue;
 
+		/*
+		A recognised title immediately preceded by "~" is escaped.
+		Hide only this successful escape prefix; do not remove unrelated tildes.
+		*/
+		if(start > 0 && text.charAt(start - 1) === "~") {
+			escapedTildes[start - 1] = 1;
+			continue;
+		}
+
 		var overlapping = false;
 		for(var j = start; j < end; j++) {
-			if(occupied[j]) { overlapping = true; break; }
+			if(occupied[j]) {
+				overlapping = true;
+				break;
+			}
 		}
 		if(overlapping) continue;
+
+		if(validMatches.length >= maxLinks) break;
 
 		validMatches.push(m);
 		for(var k = start; k < end; k++) {
@@ -142,11 +156,36 @@ TextNodeWidget.prototype.processTextWithMatches = function(text,currentTiddlerTi
 		}
 	}
 
+	var appendPlainText = function(tree,from,to) {
+		if(to <= from) return;
+
+		var plainText = "";
+		for(var p = from; p < to; p++) {
+			if(!escapedTildes[p]) {
+				plainText += text.charAt(p);
+			}
+		}
+
+		if(plainText) {
+			tree.push({
+				type: "plain-text",
+				text: plainText
+			});
+		}
+	};
+
 	if(validMatches.length === 0) {
-		return [{type: "plain-text", text: text}];
+		var escapedOnlyTree = [];
+		appendPlainText(escapedOnlyTree,0,text.length);
+
+		return escapedOnlyTree.length > 0 ?
+			escapedOnlyTree :
+			[{type: "plain-text", text: ""}];
 	}
 
-	validMatches.sort(function(a,b){ return a.index - b.index; });
+	validMatches.sort(function(a,b) {
+		return a.index - b.index;
+	});
 
 	var newParseTree = [];
 	var curPos = 0;
@@ -156,9 +195,7 @@ TextNodeWidget.prototype.processTextWithMatches = function(text,currentTiddlerTi
 		var s = mm.index;
 		var e = s + mm.length;
 
-		if(s > curPos) {
-			newParseTree.push({ type: "plain-text", text: text.substring(curPos,s) });
-		}
+		appendPlainText(newParseTree,curPos,s);
 
 		var toTitle = this.tiddlerTitleInfo.titles[mm.titleIndex];
 		var matchedText = text.substring(s,e);
@@ -178,9 +215,7 @@ TextNodeWidget.prototype.processTextWithMatches = function(text,currentTiddlerTi
 		curPos = e;
 	}
 
-	if(curPos < text.length) {
-		newParseTree.push({ type: "plain-text", text: text.substring(curPos) });
-	}
+	appendPlainText(newParseTree,curPos,text.length);
 
 	return newParseTree;
 };

--- a/plugins/tiddlywiki/freelinks/text.js
+++ b/plugins/tiddlywiki/freelinks/text.js
@@ -74,7 +74,11 @@ TextNodeWidget.prototype.execute = function() {
 		   this.tiddlerTitleInfo.titles.length > 0 && this.tiddlerTitleInfo.ac) {
 			var newParseTree = this.processTextWithMatches(text,currentTiddlerTitle,ignoreCase,useWordBoundary);
 			if(newParseTree && newParseTree.length > 0 &&
-				(newParseTree.length > 1 || newParseTree[0].type !== "plain-text")) {
+			(
+				newParseTree.length > 1 ||
+				newParseTree[0].type !== "plain-text" ||
+				newParseTree[0].text !== text
+			)) {
 				childParseTree = newParseTree;
 			}
 		}


### PR DESCRIPTION
## Summary

Implements the first part of [#9964](https://github.com/TiddlyWiki/TiddlyWiki5/issues/9964): allow a recognised Freelink match to be locally suppressed by prefixing it with `~`.

```text
~Title → Title as plain text
```

The escaped title is not rendered as a Freelink, and the `~` escape character is not shown in the rendered output.

This covers non-CamelCase Freelink titles for which the `~` prefix remains available to the Freelinks text widget, including titles containing spaces, numbers, or non-Latin characters.

Examples:

```text
~Homer                 → Homer, plain text
~1984                  → 1984, plain text
~The Lord of the Rings → The Lord of the Rings, plain text
~中文標題                → 中文標題, plain text
```

When Freelinks is disabled, this behaviour is inactive and the source text remains unchanged.

## Implementation

The change is limited to the Freelinks text-widget override.

- During title-match selection, a recognised match immediately preceded by `~` is treated as escaped and is not added to the rendered Freelink matches.
- The escape character is recorded only when it successfully suppresses a recognised Freelink match.
- When plain-text parse-tree nodes are generated, recorded escape characters are omitted from rendered output.
- The render-path condition now also adopts a transformed single plain-text node. This is required for inputs such as `~Homer`, where the output changes from one plain-text node to another but does not contain a link node.

The implementation does not remove unrelated `~` characters:

```text
~UnknownTitle → ~UnknownTitle
~~Homer       → ~Homer
```

For `~~Homer`, the second `~` escapes the recognised `Homer` match, while the first `~` remains literal text.

## CamelCase limitation

Native CamelCase parser rules may consume the `~` prefix before the Freelinks text widget runs. Supporting escaped CamelCase titles therefore requires a follow-up core/parser-level mechanism that preserves the escape state for Freelinks to consume.

## Testing

Verified manually with Freelinks enabled:

```text
Existing title: Homer
Input:          ~Homer
Expected:       Homer as plain text, without a Freelink or visible `~`

Existing title: 1984
Input:          ~1984
Expected:       1984 as plain text, without a Freelink or visible `~`

Existing title: 中文標題
Input:          ~中文標題
Expected:       中文標題 as plain text, without a Freelink or visible `~`

Unknown title:
Input:          ~UnknownTitle
Expected:       ~UnknownTitle remains unchanged

Freelinks disabled:
Input:          ~Homer
Expected:       ~Homer remains unchanged
```