### PR TITLE
Improve discoverability of the style attribute feature

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
@@ -1,6 +1,6 @@
 caption: HTML
 created: 20131205160816081
-modified: 20241025073517909
+modified: 20260821065251883
 tags: WikiText
 title: HTML in WikiText
 type: text/vnd.tiddlywiki
@@ -68,26 +68,4 @@ In an extension of conventional HTML syntax, attributes of elements and widgets 
 
 !! Style Attributes
 
-TiddlyWiki supports the usual HTML ''style'' attribute for assigning CSS styles to elements:
-
-```
-<div style="color:red;">Hello</div>
-```
-
-<<.from-version "5.2.2">> In an extension to HTML, TiddlyWiki also supports accessing individual CSS styles as independent attributes. For example:
-
-```
-<div style.color="red">Hello</div>
-```
-
-The advantage of this syntax is that it simplifies assigning computed values to CSS styles. For example:
-
-```
-<div style.color={{!!color}}>Hello</div>
-```
-
-<<.from-version "5.3.6">> TiddlyWiki also supports setting [[CSS custom properties|https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties]] as independent attributes. For example:
-
-```
-<div --bg-color={{{ [[red]] }}}>Hello</div>
-```
+{{Style Attributes}}

--- a/editions/tw5.com/tiddlers/wikitext/Style Attributes.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Style Attributes.tid
@@ -1,0 +1,29 @@
+created: 20260821065249926
+modified: 20260821065326363
+tags: [[HTML in WikiText]] [[How to apply custom styles]]
+title: Style Attributes
+type: text/vnd.tiddlywiki
+
+TiddlyWiki supports the usual HTML ''style'' attribute for assigning CSS styles to elements:
+
+```
+<div style="color:red;">Hello</div>
+```
+
+<<.from-version "5.2.2">> In an extension to HTML, TiddlyWiki also supports accessing individual CSS styles as independent attributes. For example:
+
+```
+<div style.color="red">Hello</div>
+```
+
+The advantage of this syntax is that it simplifies assigning computed values to CSS styles. For example:
+
+```
+<div style.color={{!!color}}>Hello</div>
+```
+
+<<.from-version "5.3.6">> TiddlyWiki also supports setting [[CSS custom properties|https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties]] as independent attributes. For example:
+
+```
+<div --bg-color={{{ [[red]] }}}>Hello</div>
+```


### PR DESCRIPTION
In response to a [discussion on talk tiddlywiki](https://talk.tiddlywiki.org/t/hm-wasnt-there-some-style-attribute-method/15595/4), this PR excise the Style Attributes section from the tiddler "HTML in Wikitext" and tag it with `[[How to apply custom styles]] [[HTML in WikiText]]` to make the style attribute feature easier to find.

---
<small>Submitted using https://edit.tiddlywiki.com/.</small>