### PR TITLE
Workaround for LinkWidget tooltip transclusion recursion error

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/LinkWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/LinkWidget.tid
@@ -36,38 +36,29 @@ The default value of the tooltip attribute is supplied by the <<.vlink tv-wikili
 
 This means that you can control the text of a link tooltip in several ways:
 
-```
-<$link to="HelloThere" tooltip="Custom tooltip">Link 1</$link>
+<<wikitext-example-without-html """<$link to="HelloThere" tooltip="Custom tooltip">Link 1</$link>""">>
 
-<$link to="HelloThere" tooltip="Another tooltip">{{$:/core/icon}}</$link>
+<<wikitext-example-without-html """<$link to="HelloThere" tooltip="Another tooltip">{{$:/core/icon}}</$link>""">>
 
-<$set name="tv-wikilink-tooltip" value="I'm a link to {{!!title}}">
+<<wikitext-example """<$set name="tv-wikilink-tooltip" value="I'm a link to <$text text={{!!title}}/>">
 <$link to="HelloThere">Link 2</$link>
-</$set>
-
-```
-
-Renders as:
-
-<$link to="HelloThere" tooltip="Custom tooltip">Link 1</$link>
-
-<$link to="HelloThere" tooltip="Another tooltip">{{$:/core/icon}}</$link>
-
-<$set name="tv-wikilink-tooltip" value="I'm a link to {{!!title}}">
-<$link to="HelloThere">Link 2</$link>
-</$set>
+</$set>""">>
 
 Note that the tooltip is rendered with the current tiddler set to the target of the link.
 
 A useful convention is to set the tooltip like this:
 
-```
-\define tv-wikilink-tooltip()
-<$transclude field="tooltip"><$transclude field="title"/></$transclude>
+<<wikitext-example-without-html """\procedure tv-wikilink-tooltip()
+<$let tv-wikilinks="no"><$transclude $field="tooltip"><$transclude $field="title"/></$transclude></$let>
 \end
-```
+
+<$link to="SampleTabThree">Link 3</$link> has a ''tooltip'' field, so the tooltip is its content.
+
+<$link to="HelloThere">Link 4</$link> has none, so the title is used instead.""">>
 
 This causes the tooltip to be the ''tooltip'' field of the target tiddler. If the field isn't present, then the title is used instead.
+
+Setting <<.vlink tv-wikilinks>> to `no` keeps the tooltip from generating links of its own.
 
 ! Action Variables
 


### PR DESCRIPTION
This PR contains a workaround for LinkWidget tooltip transclusion recursion error. See issue #9976

**This is a workaround no full fix** - A new PR with full tests, covering all code paths is on the way. 
 

---
<small>Submitted using https://edit.tiddlywiki.com/.</small>