### PR TITLE
Fix link widget tooltip and href generation

### DIFF
--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -99,7 +99,9 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 		wikiLinkText = this.wiki.filterTiddlers(wikilinkTransformFilter,this,function(iterator) {
 			iterator(self.wiki.getTiddler(self.to),self.to);
 		})[0];
-	} else {
+	}
+	// No filter result leaves the href undefined, so fall back to the template. An empty string is a deliberate empty href. See #9977
+	if(wikiLinkText === undefined) {
 		// Expand the tv-wikilink-template variable to construct the href
 		var wikiLinkTemplateMacro = this.getVariable("tv-wikilink-template"),
 			wikiLinkTemplate = wikiLinkTemplateMacro ? wikiLinkTemplateMacro.trim() : "#$uri_encoded$";
@@ -123,7 +125,9 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 		var tooltipText = this.wiki.renderText("text/plain","text/vnd.tiddlywiki",tooltipWikiText,{
 			parseAsInline: true,
 			variables: {
-				currentTiddler: this.to
+				currentTiddler: this.to,
+				// A link in the tooltip would render the tooltip again, forever. See #9976
+				"tv-wikilinks": "no"
 			},
 			parentWidget: this
 		});

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/LinkWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/LinkWidget-DataAttributes.tid
@@ -1,5 +1,6 @@
 title: Widgets/DataAttributes/LinkWidget
 description: Data Attributes for LinkWidget
+related: test-link-widget.js lists every place the link widget is tested
 type: text/vnd.tiddlywiki-multiple
 tags: [[$:/tags/wiki-test-spec]]
 

--- a/editions/test/tiddlers/tests/test-link-widget-adversary.js
+++ b/editions/test/tiddlers/tests/test-link-widget-adversary.js
@@ -1,0 +1,342 @@
+/*\
+title: test-link-widget-adversary.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+FULL CODE COVERAGE
+
+This file and test-link-widget.js together cover every branch of
+core/modules/widgets/link.js. Add a spec here when a new branch handles
+input an author got wrong or an attacker chose, and one in
+test-link-widget.js when it handles input meant to work.
+
+Every spec carries the wikitext it renders, so you can replay it by hand.
+Paste the snippet into a new tiddler, then press F12 and inspect the
+generated element.
+
+The tooltip specs guard issue #9976. Before the fix, a tooltip that
+rendered a wikilink made the nested link render the same tooltip again,
+so the loop only ended when the widget tree depth limit tripped. The
+tooltip then read "Recursive transclusion error in transclude widget", or
+the whole rendering failed where no ancestor transclusion was there to
+catch the error. Hover the links in those specs to check by hand.
+
+CamelCase links are off in the core defaults and on in tw5.com, which is
+why the two specs that need them switch the parser rule on for their own
+duration.
+
+The two tv-filter-export-link specs guard issue #9977, where a filter that
+matched nothing put the string undefined into the href.
+
+Every place the link widget is tested:
+
+	test-link-widget-adversary.js: this file
+	test-link-widget.js: ordinary behaviour
+	test-widget.js: $link cleaning itself up when its children fail to render
+	test-wikitext.js: a to attribute built by a macro, and its URI encoding
+
+	data/widgets/DataAttributes/LinkWidget-DataAttributes.tid
+		data and style attributes on an anchor and on a button
+
+\*/
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+describe("Link widget adversary", function() {
+
+	var widget = require("$:/core/modules/widgets/widget.js"),
+		WikiParser = require("$:/core/modules/parsers/wikiparser/wikiparser.js")["text/vnd.tiddlywiki"];
+
+	var RECURSION_ESCAPED = "the recursion guard threw out of the render";
+
+	// The tooltip convention documented in the LinkWidget tiddler, written
+	// the naive way, with no guard against the tooltip generating links
+	var TOOLTIP_MACRO_NAIVE = `\\define tv-wikilink-tooltip()
+<$transclude field="tooltip"><$transclude field="title"/></$transclude>
+\\end
+`;
+
+	function createTestWiki() {
+		var wiki = $tw.test.wiki();
+		wiki.addTiddlers([
+			{title: "HelloThere", text: "Welcome"},
+			{title: "Community", text: "Welcome"},
+			// A tooltip that is itself a link, which is what used to loop
+			{title: "LinkingTab", tooltip: "See [[Community]] now", text: "Welcome"},
+			{title: "Blurb", text: "See [[Community]] now"}
+		]);
+		return wiki;
+	}
+
+	function renderText(wiki,text) {
+		var parser = wiki.parseText("text/vnd.tiddlywiki",text,{}),
+			widgetNode = new widget.widget({type: "widget", children: parser.tree},{
+				wiki: wiki,
+				document: $tw.fakeDocument
+			});
+		$tw.fakeDocument.setSequenceNumber(0);
+		var wrapper = $tw.fakeDocument.createElement("div");
+		try {
+			widgetNode.render(wrapper,null);
+		} catch(err) {
+			// TranscludeRecursionError carries no message, so Jasmine cannot
+			// format it. Report it as a value the expectation can name.
+			if(err instanceof $tw.utils.TranscludeRecursionError) {
+				return RECURSION_ESCAPED;
+			}
+			throw err;
+		}
+		return wrapper.innerHTML;
+	}
+
+	// The parser caches its rule classes on the WikiParser prototype, so the
+	// tooltip that the widget renders internally cannot be given a rule set
+	// of its own. Rebuild the cache from a wiki that enables CamelCase
+	// links, then rebuild it from the shared wiki so later specs are
+	// unaffected. To do the same by hand, set
+	// $:/config/WikiParserRules/Inline/wikilink to enable.
+	function withCamelCaseLinks(wiki,callback) {
+		wiki.addTiddler({title: "$:/config/WikiParserRules/Inline/wikilink", text: "enable"});
+		delete WikiParser.prototype.inlineRuleClasses;
+		try {
+			return callback();
+		} finally{
+			delete WikiParser.prototype.inlineRuleClasses;
+			$tw.wiki.parseText("text/vnd.tiddlywiki","");
+		}
+	}
+
+	/* Tooltips that render links. Issue #9976 */
+
+	it("should render a tooltip containing an explicit link", function() {
+		// Hover the link. The tooltip should read "See Community now".
+		// <$let tv-wikilink-tooltip="See [[Community]] now">
+		// <$link to="Community">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilink-tooltip="See [[Community]] now"><$link to="Community">Link</$link></$let>');
+		expect(html).toContain('title="See Community now"');
+	});
+
+	it("should render a tooltip transcluded from a tiddler containing a link", function() {
+		// Same as above, except the tooltip text arrives through a
+		// transclusion, so the recursion guard has a transclude widget to
+		// stop at and the tooltip used to read the error message instead.
+		// <$let tv-wikilink-tooltip="{{Blurb}}">
+		// <$link to="Community">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilink-tooltip="{{Blurb}}"><$link to="Community">Link</$link></$let>');
+		expect(html).toContain('title="See Community now"');
+	});
+
+	it("should render a tooltip field containing a link", function() {
+		// LinkingTab carries tooltip: See [[Community]] now
+		// \define tv-wikilink-tooltip()
+		// <$transclude field="tooltip"><$transclude field="title"/></$transclude>
+		// \end
+		// <$link to="LinkingTab">Link</$link>
+		var html = renderText(createTestWiki(),TOOLTIP_MACRO_NAIVE + '<$link to="LinkingTab">Link</$link>');
+		expect(html).toContain('title="See Community now"');
+	});
+
+	it("should render the tooltip example documented in LinkWidget", function() {
+		// This is the example that reported the bug. It needs CamelCase
+		// links, because the tooltip text is the target title HelloThere.
+		// <$let tv-wikilink-tooltip="I'm a link to {{!!title}}">
+		// <$link to="HelloThere">Link 2</$link>
+		// </$let>
+		var wiki = createTestWiki();
+		var html = withCamelCaseLinks(wiki,function() {
+			return renderText(wiki,`<$let tv-wikilink-tooltip="I'm a link to {{!!title}}">
+<$link to="HelloThere">Link 2</$link>
+</$let>`);
+		});
+		// The only escapes in these specs. This one string holds both an
+		// apostrophe and double quotes, so no quoting choice avoids them.
+		expect(html).toContain("title=\"I'm a link to HelloThere\"");
+	});
+
+	it("should render the tooltip convention documented in LinkWidget", function() {
+		// HelloThere has no tooltip field, so the convention falls back to
+		// the title, which is a CamelCase link.
+		// \define tv-wikilink-tooltip()
+		// <$transclude field="tooltip"><$transclude field="title"/></$transclude>
+		// \end
+		// <$link to="HelloThere">Link</$link>
+		var wiki = createTestWiki();
+		var html = withCamelCaseLinks(wiki,function() {
+			return renderText(wiki,TOOLTIP_MACRO_NAIVE + '<$link to="HelloThere">Link</$link>');
+		});
+		expect(html).toContain('title="HelloThere"');
+	});
+
+	it("should not inherit a tooltip attribute into a nested link", function() {
+		// An attribute is not a variable, so this case never looped. It is
+		// here to keep the difference visible.
+		// <$link to="Community" tooltip="See [[Community]] now">Link</$link>
+		var html = renderText(createTestWiki(),
+			'<$link to="Community" tooltip="See [[Community]] now">Link</$link>');
+		expect(html).toContain('title="See Community now"');
+	});
+
+	it("should set no title attribute for an empty tooltip", function() {
+		// <$link to="Community" tooltip="">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="Community" tooltip="">Link</$link>');
+		expect(html).not.toContain("title=");
+	});
+
+	/* Hostile and malformed markup */
+
+	it("should not render an unsafe element for the tag attribute", function() {
+		// script is in $tw.config.htmlUnsafeElements, so the widget falls
+		// back to an anchor rather than writing a script tag into the page.
+		// <$link to="Community" tag="script">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="Community" tag="script">Link</$link>');
+		expect(html).not.toContain("<script");
+		expect(html).toContain("<a ");
+	});
+
+	it("should not let a javascript URL out of the href", function() {
+		// A tiddler title is untrusted, so a title that looks like a
+		// javascript URL must not become one. The href is always a fragment,
+		// and the colon and the brackets are encoded.
+		// <$link to="javascript:alert(1)">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="javascript:alert(1)">Link</$link>');
+		expect(html).toContain('href="#javascript%3Aalert%281%29"');
+	});
+
+	it("should encode a title that would otherwise break out of the href", function() {
+		// <$link to={{{ [[a"b]] }}}>Link</$link>
+		var html = renderText(createTestWiki(),'<$link to={{{ [[a"b]] }}}>Link</$link>');
+		expect(html).toContain('href="#a%22b"');
+		expect(html).not.toContain('#a"b');
+	});
+
+	it("should encode a title carrying URL punctuation", function() {
+		// A title is not a path, so every reserved character has to survive
+		// the round trip.
+		// <$link to="Q&A #1 50% done?">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="Q&A #1 50% done?">Link</$link>');
+		expect(html).toContain('href="#Q%26A%20%231%2050%25%20done%3F"');
+	});
+
+	it("should handle an empty target title", function() {
+		// <$link to="">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="">Link</$link>');
+		expect(html).toContain('class="tc-tiddlylink tc-tiddlylink-missing"');
+		expect(html).toContain('href="#"');
+	});
+
+	/* Values that look like the ones the widget acts on, but are not */
+
+	it("should ignore surrounding whitespace in tv-wikilinks", function() {
+		// The widget trims the value before comparing it.
+		// <$let tv-wikilinks="  no  ">
+		// <$link to="Community">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilinks="  no  "><$link to="Community">Link</$link></$let>');
+		expect(html).toBe("<p><span>Link</span></p>");
+	});
+
+	it("should treat any other tv-wikilinks value as yes", function() {
+		// Only the exact word no switches links off, so a capitalised value
+		// leaves the link in place.
+		// <$let tv-wikilinks="No">
+		// <$link to="Community">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilinks="No"><$link to="Community">Link</$link></$let>');
+		expect(html).toContain("<a ");
+	});
+
+	it("should ignore a draggable value that is neither yes nor no", function() {
+		// <$link to="Community" draggable="maybe">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="Community" draggable="maybe">Link</$link>');
+		expect(html).not.toContain("draggable=");
+	});
+
+	it("should make a non anchor element explicitly draggable", function() {
+		// An anchor is draggable in the browser already. Any other element
+		// has to be told, or dragging a link out of a button would do
+		// nothing.
+		// <$link to="Community" tag="button">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="Community" tag="button">Link</$link>');
+		expect(html).toContain('draggable="true"');
+	});
+
+	it("should let overrideClass win over class", function() {
+		// <$link to="Community" class="added" overrideClass="only">Link</$link>
+		var html = renderText(createTestWiki(),
+			'<$link to="Community" class="added" overrideClass="only">Link</$link>');
+		expect(html).toContain('class="only"');
+		expect(html).not.toContain("added");
+	});
+
+	it("should use a tv-wikilink-template that carries no placeholder", function() {
+		// Every link then points at the same place, which is odd but is what
+		// the template says.
+		// <$let tv-wikilink-template="/fixed">
+		// <$link to="Community">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilink-template="/fixed"><$link to="Community">Link</$link></$let>');
+		expect(html).toContain('href="/fixed"');
+	});
+
+	/* The href built from a filter. Issue #9977 */
+
+	it("should use an empty tv-filter-export-link result as an empty href", function() {
+		// A filter that deliberately produces an empty string is an author
+		// saying the link has no destination. This is the case that must
+		// survive the fix for #9977.
+		// <$let tv-filter-export-link="[[]]">
+		// <$link to="Community">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-filter-export-link="[[]]"><$link to="Community">Link</$link></$let>');
+		expect(html).toContain('href=""');
+	});
+
+	// Issue #9977. The filter returns no result at all, so
+	// filterTiddlers(...)[0] used to hand undefined to setAttributeNS, and
+	// the browser got href="undefined", a link to a relative path called
+	// undefined. Note the difference from the spec above: a filter that
+	// returns an empty string is an author asking for an empty href, and
+	// that is still honoured.
+	it("should fall back to the default href when tv-filter-export-link matches nothing", function() {
+		// <$let tv-filter-export-link="[tag[nope]]">
+		// <$link to="Community">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-filter-export-link="[tag[nope]]"><$link to="Community">Link</$link></$let>');
+		expect(html).not.toContain('href="undefined"');
+		expect(html).toContain('href="#Community"');
+	});
+
+	it("should double encode a title for $uri_doubleencoded$", function() {
+		// Used where the href passes through a second decoding step, for
+		// example a query string.
+		// <$let tv-wikilink-template="/go?t=$uri_doubleencoded$">
+		// <$link to="Hello There">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilink-template="/go?t=$uri_doubleencoded$"><$link to="Hello There">Link</$link></$let>');
+		expect(html).toContain('href="/go?t=Hello%2520There"');
+	});
+
+	it("should render a link inside the content of another link", function() {
+		// Nested anchors are invalid HTML, but the widget has no say in what
+		// an author writes, and it must not lose the content.
+		// <$link to="Community">outer <$link to="HelloThere">inner</$link></$link>
+		var html = renderText(createTestWiki(),
+			'<$link to="Community">outer <$link to="HelloThere">inner</$link></$link>');
+		expect(html).toContain('href="#Community"');
+		expect(html).toContain('href="#HelloThere"');
+		expect(html).toContain("inner");
+	});
+
+});

--- a/editions/test/tiddlers/tests/test-link-widget.js
+++ b/editions/test/tiddlers/tests/test-link-widget.js
@@ -1,0 +1,501 @@
+/*\
+title: test-link-widget.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+FULL CODE COVERAGE
+
+This file and test-link-widget-adversary.js together cover every branch
+of core/modules/widgets/link.js: render, renderLink, execute, refresh
+and handleClickEvent. A new branch needs a new spec, here when the input
+is meant to work, there when it is hostile or malformed. The adversary
+file also holds the guards for issues #9976 and #9977.
+
+Two branches are exercised but not asserted, because the test document
+has no layout and no namespaces. The svg spec cannot see that the href
+is written in the xlink namespace, and the click specs supply their own
+getBoundingClientRect and hasAttribute. Check those in a browser.
+
+Every spec carries the wikitext it renders, so you can replay it by
+hand. Paste the snippet into a new tiddler, then press F12 and inspect
+the element.
+
+The wiki these specs render against holds:
+
+	HelloThere		an ordinary tiddler
+	Hello There		an ordinary tiddler, with a space in its title
+	ShadowTiddler		supplied by a plugin, not present in the wiki itself
+	OverwrittenTab		supplied by a plugin and overwritten in the wiki
+	PlainTab		an ordinary tiddler carrying a tooltip field
+
+Every place the link widget is tested:
+
+	test-link-widget.js: this file
+	test-link-widget-adversary.js: hostile and edge input
+	test-widget.js: $link cleaning itself up when its children fail to render
+	test-wikitext.js: a to attribute built by a macro, and its URI encoding
+
+	data/widgets/DataAttributes/LinkWidget-DataAttributes.tid
+		data and style attributes on an anchor and on a button
+
+\*/
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+describe("Link widget", function() {
+
+	var widget = require("$:/core/modules/widgets/widget.js");
+
+	// Build the wiki described in the header comment. To reproduce it by
+	// hand, create the ordinary tiddlers and take the two shadow ones from
+	// any plugin you have installed.
+	function createTestWiki() {
+		var wiki = $tw.test.wiki();
+		wiki.addTiddlers([
+			{title: "HelloThere", text: "Welcome"},
+			{title: "Hello There", text: "Welcome"},
+			{title: "PlainTab", tooltip: "A plain tooltip", text: "Welcome"},
+			{title: "OverwrittenTab", text: "The version in the wiki"},
+			{
+				title: "$:/plugins/tiddlywiki/test",
+				type: "application/json",
+				"plugin-type": "plugin",
+				text: JSON.stringify({tiddlers: {
+					"ShadowTiddler": {title: "ShadowTiddler", text: "From the plugin"},
+					"OverwrittenTab": {title: "OverwrittenTab", text: "From the plugin"}
+				}})
+			}
+		]);
+		wiki.readPluginInfo();
+		wiki.registerPluginTiddlers("plugin");
+		wiki.unpackPluginTiddlers();
+		return wiki;
+	}
+
+	// Build the widget tree for a piece of wikitext, the way a tiddler body
+	// is built. Most specs go through renderText below and never need this.
+	function makeWidget(wiki,text) {
+		var parser = wiki.parseText("text/vnd.tiddlywiki",text,{});
+		return new widget.widget({type: "widget", children: parser.tree},{
+			wiki: wiki,
+			document: $tw.fakeDocument
+		});
+	}
+
+	function renderWidget(widgetNode) {
+		$tw.fakeDocument.setSequenceNumber(0);
+		var wrapper = $tw.fakeDocument.createElement("div");
+		widgetNode.render(wrapper,null);
+		return wrapper;
+	}
+
+	// Render wikitext and hand back the HTML, so a spec can assert on the
+	// generated element
+	function renderText(wiki,text) {
+		return renderWidget(makeWidget(wiki,text)).innerHTML;
+	}
+
+	// The click handler reads two things from the DOM node that the test
+	// document does not provide: the position of the link, so the navigation
+	// can animate from it, and hasAttribute. Supply both, faithfully to what
+	// a browser would return.
+	function stubClickDependencies(domNode) {
+		domNode.getBoundingClientRect = function() {
+			return {top: 1, left: 2, width: 3, right: 5, bottom: 4, height: 3};
+		};
+		domNode.hasAttribute = function(name) {
+			return $tw.utils.hop(this.attributes,name);
+		};
+	}
+
+	// Find the link widget inside a rendered tree. Only the click specs need
+	// the widget itself rather than the HTML it produced.
+	function findLinkWidget(widgetNode) {
+		if(widgetNode.parseTreeNode && widgetNode.parseTreeNode.tag === "$link") {
+			return widgetNode;
+		}
+		for(var t=0; t<(widgetNode.children || []).length; t++) {
+			var found = findLinkWidget(widgetNode.children[t]);
+			if(found) {
+				return found;
+			}
+		}
+		return null;
+	}
+
+	/* The element and its classes */
+
+	it("should render an anchor element with the link classes", function() {
+		// <$link to="HelloThere">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere">Link</$link>');
+		expect(html).toBe('<p><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#HelloThere">Link</a></p>');
+	});
+
+	it("should mark a link to a tiddler that does not exist", function() {
+		// <$link to="NotHere">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="NotHere">Link</$link>');
+		expect(html).toContain('class="tc-tiddlylink tc-tiddlylink-missing"');
+	});
+
+	it("should mark a link to a shadow tiddler", function() {
+		// A shadow tiddler is one supplied by a plugin. It does not exist in
+		// the wiki itself, so it is both shadow and missing, and only the
+		// shadow class is applied.
+		// <$link to="ShadowTiddler">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="ShadowTiddler">Link</$link>');
+		expect(html).toContain('class="tc-tiddlylink tc-tiddlylink-shadow"');
+	});
+
+	it("should mark a link to an overwritten shadow tiddler", function() {
+		// Here the plugin supplies the tiddler and the wiki overrides it, so
+		// the link both resolves and is shadow.
+		// <$link to="OverwrittenTab">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="OverwrittenTab">Link</$link>');
+		expect(html).toContain('class="tc-tiddlylink tc-tiddlylink-shadow tc-tiddlylink-resolves"');
+	});
+
+	it("should add the class attribute to the default classes", function() {
+		// <$link to="HelloThere" class="example">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere" class="example">Link</$link>');
+		expect(html).toContain('class="tc-tiddlylink tc-tiddlylink-resolves example"');
+	});
+
+	it("should replace the default classes with overrideClass", function() {
+		// <$link to="HelloThere" overrideClass="example">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere" overrideClass="example">Link</$link>');
+		expect(html).toContain('class="example"');
+		expect(html).not.toContain("tc-tiddlylink");
+	});
+
+	it("should set no class at all for an empty overrideClass", function() {
+		// <$link to="HelloThere" overrideClass="">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere" overrideClass="">Link</$link>');
+		expect(html).toBe('<p><a href="#HelloThere">Link</a></p>');
+	});
+
+	/* The href */
+
+	it("should URI encode the target title into the href", function() {
+		// <$link to="Hello There">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="Hello There">Link</$link>');
+		expect(html).toContain('href="#Hello%20There"');
+	});
+
+	it("should build the href from tv-wikilink-template", function() {
+		// <$let tv-wikilink-template="/read/$uri_encoded$">
+		// <$link to="Hello There">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilink-template="/read/$uri_encoded$"><$link to="Hello There">Link</$link></$let>');
+		expect(html).toContain('href="/read/Hello%20There"');
+	});
+
+	it("should build the href from tv-filter-export-link", function() {
+		// The filter runs with the target tiddler as its input, so addprefix
+		// and addsuffix can build any href you like.
+		// <$let tv-filter-export-link="[addprefix[/static/]addsuffix[.html]]">
+		// <$link to="HelloThere">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-filter-export-link="[addprefix[/static/]addsuffix[.html]]"><$link to="HelloThere">Link</$link></$let>');
+		expect(html).toContain('href="/static/HelloThere.html"');
+	});
+
+	it("should let tv-get-export-link override the href", function() {
+		// tv-get-export-link wins over both of the above. It receives the
+		// target title in the to parameter.
+		// \define tv-get-export-link(to)
+		// /exported/$to$
+		// \end
+		// <$link to="HelloThere">Link</$link>
+		var html = renderText(createTestWiki(),`\\define tv-get-export-link(to)
+/exported/$to$
+\\end
+<$link to="HelloThere">Link</$link>`);
+		expect(html).toContain('href="/exported/HelloThere"');
+	});
+
+	it("should let tv-filter-export-link win over tv-wikilink-template", function() {
+		// Both are set, and the filter is the one that counts.
+		// <$let tv-wikilink-template="/tpl/$uri_encoded$" tv-filter-export-link="[addprefix[/flt/]]">
+		// <$link to="HelloThere">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilink-template="/tpl/$uri_encoded$" tv-filter-export-link="[addprefix[/flt/]]"><$link to="HelloThere">Link</$link></$let>');
+		expect(html).toContain('href="/flt/HelloThere"');
+	});
+
+	it("should let tv-get-export-link win over both of the others", function() {
+		// All three are set. tv-get-export-link is applied last and wins.
+		// \define tv-get-export-link(to)
+		// /get/$to$
+		// \end
+		// <$let tv-wikilink-template="/tpl/$uri_encoded$" tv-filter-export-link="[addprefix[/flt/]]">
+		// <$link to="HelloThere">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),`\\define tv-get-export-link(to)
+/get/$to$
+\\end
+<$let tv-wikilink-template="/tpl/$uri_encoded$" tv-filter-export-link="[addprefix[/flt/]]"><$link to="HelloThere">Link</$link></$let>`);
+		expect(html).toContain('href="/get/HelloThere"');
+	});
+
+	/* The tooltip. See also issue #9976 in the adversary suite */
+
+	it("should use the tooltip attribute as the title", function() {
+		// Hover the link to see it.
+		// <$link to="HelloThere" tooltip="Custom tooltip">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere" tooltip="Custom tooltip">Link</$link>');
+		expect(html).toContain('title="Custom tooltip"');
+	});
+
+	it("should use tv-wikilink-tooltip when there is no tooltip attribute", function() {
+		// <$let tv-wikilink-tooltip="From the variable">
+		// <$link to="HelloThere">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilink-tooltip="From the variable"><$link to="HelloThere">Link</$link></$let>');
+		expect(html).toContain('title="From the variable"');
+	});
+
+	it("should prefer the tooltip attribute over tv-wikilink-tooltip", function() {
+		// <$let tv-wikilink-tooltip="From the variable">
+		// <$link to="HelloThere" tooltip="From the attribute">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilink-tooltip="From the variable"><$link to="HelloThere" tooltip="From the attribute">Link</$link></$let>');
+		expect(html).toContain('title="From the attribute"');
+	});
+
+	it("should render the tooltip with the target as the current tiddler", function() {
+		// This is what makes the documented tooltip convention work. Inside
+		// the tooltip, currentTiddler is the link target, not the tiddler
+		// holding the link.
+		// <$let tv-wikilink-tooltip="Tooltip of <$text text={{!!title}}/>">
+		// <$link to="PlainTab">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilink-tooltip="Tooltip of <$text text={{!!title}}/>"><$link to="PlainTab">Link</$link></$let>');
+		expect(html).toContain('title="Tooltip of PlainTab"');
+	});
+
+	it("should render the documented tooltip convention", function() {
+		// The convention documented in the LinkWidget tiddler: the tooltip
+		// field of the target, falling back to its title.
+		// \procedure tv-wikilink-tooltip()
+		// <$let tv-wikilinks="no"><$transclude $field="tooltip"><$transclude $field="title"/></$transclude></$let>
+		// \end
+		// <$link to="PlainTab">Link</$link>
+		var macro = `\\procedure tv-wikilink-tooltip()
+<$let tv-wikilinks="no"><$transclude $field="tooltip"><$transclude $field="title"/></$transclude></$let>
+\\end
+`;
+		var wiki = createTestWiki();
+		expect(renderText(wiki,macro + '<$link to="PlainTab">Link</$link>')).toContain('title="A plain tooltip"');
+		// HelloThere has no tooltip field, so the title is used instead
+		expect(renderText(wiki,macro + '<$link to="HelloThere">Link</$link>')).toContain('title="HelloThere"');
+	});
+
+	it("should set no title attribute when there is no tooltip", function() {
+		// <$link to="HelloThere">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere">Link</$link>');
+		expect(html).not.toContain("title=");
+	});
+
+	/* The remaining attributes */
+
+	it("should set the tabindex attribute", function() {
+		// <$link to="HelloThere" tabindex="-1">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere" tabindex="-1">Link</$link>');
+		expect(html).toContain('tabindex="-1"');
+	});
+
+	it("should set the role attribute", function() {
+		// <$link to="HelloThere" role="button">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere" role="button">Link</$link>');
+		expect(html).toContain('role="button"');
+	});
+
+	it("should pass through aria- attributes", function() {
+		// <$link to="HelloThere" aria-label="Go home" aria-current="page">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere" aria-label="Go home" aria-current="page">Link</$link>');
+		expect(html).toContain('aria-label="Go home"');
+		expect(html).toContain('aria-current="page"');
+	});
+
+	it("should pass through data- attributes to the span form of a link", function() {
+		// The anchor form is already covered by the Widgets/DataAttributes
+		// wiki test spec. This is the other branch, where the widget renders
+		// a span because links are switched off.
+		// <$let tv-wikilinks="no">
+		// <$link to="HelloThere" data-foo="bar" aria-label="Home">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilinks="no"><$link to="HelloThere" data-foo="bar" aria-label="Home">Link</$link></$let>');
+		expect(html).toContain('data-foo="bar"');
+		expect(html).toContain('aria-label="Home"');
+	});
+
+	it("should render a different element for the tag attribute", function() {
+		// <$link to="HelloThere" tag="span">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere" tag="span">Link</$link>');
+		expect(html).toContain("<span");
+		// Only anchor elements get an href
+		expect(html).not.toContain("href=");
+	});
+
+	it("should mark a link as not draggable", function() {
+		// Anchor elements are draggable in the browser already, so the widget
+		// only writes the attribute to turn dragging off.
+		// <$link to="HelloThere" draggable="no">Link</$link>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere" draggable="no">Link</$link>');
+		expect(html).toContain('draggable="false"');
+	});
+
+	/* Content and defaults */
+
+	it("should default the target to the current tiddler", function() {
+		// Open PlainTab and put this in its body. The link points back at
+		// the tiddler it sits in.
+		// <$link>Link</$link>
+		var html = renderText(createTestWiki(),'<$tiddler tiddler="PlainTab"><$link>Link</$link></$tiddler>');
+		expect(html).toContain('href="#PlainTab"');
+	});
+
+	it("should default the link text to the target title", function() {
+		// <$link to="HelloThere"/>
+		var html = renderText(createTestWiki(),'<$link to="HelloThere"/>');
+		expect(html).toBe('<p><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#HelloThere">HelloThere</a></p>');
+	});
+
+	/* Turning links off */
+
+	it("should render a span instead of a link when tv-wikilinks is no", function() {
+		// Used by print and export templates, where a link is pointless.
+		// <$let tv-wikilinks="no">
+		// <$link to="HelloThere">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-wikilinks="no"><$link to="HelloThere">Link</$link></$let>');
+		expect(html).toBe("<p><span>Link</span></p>");
+	});
+
+	it("should hide a missing link when tv-show-missing-links is no", function() {
+		// The text stays, the link goes.
+		// <$let tv-show-missing-links="no">
+		// <$link to="NotHere">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-show-missing-links="no"><$link to="NotHere">Link</$link></$let>');
+		expect(html).toBe("<p><span>Link</span></p>");
+	});
+
+	it("should still show an existing link when tv-show-missing-links is no", function() {
+		// <$let tv-show-missing-links="no">
+		// <$link to="HelloThere">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-show-missing-links="no"><$link to="HelloThere">Link</$link></$let>');
+		expect(html).toContain("<a ");
+	});
+
+	it("should still show a shadow link when tv-show-missing-links is no", function() {
+		// A shadow tiddler does not exist in the wiki, so it counts as
+		// missing. Hiding it would hide most of the core documentation, so
+		// the widget keeps the link.
+		// <$let tv-show-missing-links="no">
+		// <$link to="ShadowTiddler">Link</$link>
+		// </$let>
+		var html = renderText(createTestWiki(),
+			'<$let tv-show-missing-links="no"><$link to="ShadowTiddler">Link</$link></$let>');
+		expect(html).toContain('class="tc-tiddlylink tc-tiddlylink-shadow"');
+	});
+
+	/* Namespaces, refreshing and navigation */
+
+	it("should render a link inside an svg element", function() {
+		// Inside svg the href has to be written in the xlink namespace, or
+		// the link does nothing in the browser. The test document does not
+		// model namespaces, so this spec only shows that the branch runs and
+		// still produces the href. Check the namespace by hand in F12.
+		// <svg><$link to="HelloThere">Link</$link></svg>
+		var html = renderText(createTestWiki(),'<svg><$link to="HelloThere">Link</$link></svg>');
+		expect(html).toContain('<svg><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#HelloThere">');
+	});
+
+	it("should restyle itself when the target tiddler is created", function() {
+		// By hand: put a link to a tiddler that does not exist in a tiddler,
+		// then create the target. The link turns from missing to resolved
+		// without a reload.
+		// <$link to="NotYet">Link</$link>
+		var wiki = createTestWiki(),
+			widgetNode = makeWidget(wiki,'<$link to="NotYet">Link</$link>'),
+			wrapper = renderWidget(widgetNode);
+		expect(wrapper.innerHTML).toContain("tc-tiddlylink-missing");
+		wiki.addTiddler({title: "NotYet", text: "Here now"});
+		widgetNode.refresh({NotYet: true},wrapper,null);
+		expect(wrapper.innerHTML).toContain("tc-tiddlylink-resolves");
+	});
+
+	it("should send a navigate message when the link is clicked", function() {
+		// By hand: click the link and the target opens in the story river.
+		// <$link to="HelloThere">Link</$link>
+		var wiki = createTestWiki(),
+			widgetNode = makeWidget(wiki,'<$link to="HelloThere">Link</$link>'),
+			messages = [];
+		// Catch the message where it would otherwise leave the widget tree
+		widgetNode.dispatchEvent = function(event) {
+			messages.push(event);
+			return true;
+		};
+		var wrapper = renderWidget(widgetNode),
+			linkWidget = findLinkWidget(widgetNode);
+		// The handler reads the link position so the navigation can animate
+		// from it, and the test document has no layout to read
+		stubClickDependencies(linkWidget.domNodes[0]);
+		linkWidget.handleClickEvent({
+			metaKey: false,
+			ctrlKey: false,
+			altKey: false,
+			shiftKey: false,
+			button: 0,
+			preventDefault: function() {},
+			stopPropagation: function() {}
+		});
+		expect(messages.length).toBe(1);
+		expect(messages[0].type).toBe("tm-navigate");
+		expect(messages[0].navigateTo).toBe("HelloThere");
+		// A plain click navigates, so the browser must not follow the href
+		expect(messages[0].navigateSuppressNavigation).toBe(false);
+		expect(wrapper.innerHTML).toContain('href="#HelloThere"');
+	});
+
+	it("should suppress navigation for a ctrl click", function() {
+		// By hand: ctrl click, or middle click, and the browser opens the
+		// href in a new tab instead of the story river opening the tiddler.
+		// <$link to="HelloThere">Link</$link>
+		var wiki = createTestWiki(),
+			widgetNode = makeWidget(wiki,'<$link to="HelloThere">Link</$link>'),
+			messages = [];
+		widgetNode.dispatchEvent = function(event) {
+			messages.push(event);
+			return true;
+		};
+		renderWidget(widgetNode);
+		var linkWidget = findLinkWidget(widgetNode);
+		stubClickDependencies(linkWidget.domNodes[0]);
+		linkWidget.handleClickEvent({
+			metaKey: false,
+			ctrlKey: true,
+			altKey: false,
+			shiftKey: false,
+			button: 0,
+			preventDefault: function() {},
+			stopPropagation: function() {}
+		});
+		expect(messages[0].navigateSuppressNavigation).toBe(true);
+	});
+
+});

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9979-link-tooltip-and-href.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9979-link-tooltip-and-href.tid
@@ -1,0 +1,23 @@
+change-category: widget
+change-type: bugfix
+created: 20260821202324000
+description: The link widget renders a tooltip or an href that contains a link
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9979
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9979
+type: text/vnd.tiddlywiki
+
+* A tooltip supplied by the `tv-wikilink-tooltip` variable may contain a link. A tooltip is plain text, so the link contributes its text
+* Such a tooltip used to read `Recursive transclusion error in transclude widget`, or stopped the tiddler rendering. A CamelCase word was enough to trigger it
+
+```
+<$let tv-wikilink-tooltip="See [[HelloThere]] now">
+<$link to="HelloThere">hover me</$link>
+</$let>
+```
+
+* A `tv-filter-export-link` filter that matches nothing falls back to the ordinary `#Title` href. It used to write the string `undefined`, so the link pointed at a relative path called `undefined`. A filter that returns an empty string still produces an empty href
+
+Fixed issues: [[#9976|https://github.com/TiddlyWiki/TiddlyWiki5/issues/9976]] and [[#9977|https://github.com/TiddlyWiki/TiddlyWiki5/issues/9977]]


### PR DESCRIPTION
- Fixes #9976 and #9977

**First Commit**

* Add two test suites covering every branch of the widget, one for input meant
  to work and one for input that is hostile or malformed

**Second Commit**

* 9976: Render a tooltip containing a link as its text, instead of looping until the
  recursion guard trips

* 9977: Fall back to the ordinary href when a `tv-filter-export-link` filter matches
  nothing. A filter that returns an empty string still produces an empty href

----------

**Related**

DOC only PR #9978 works around the tooltip fault in the documentation for existing TW versions.

Its `tv-wikilinks` guard becomes optional once this lands. But the example is still valid and best practice. 

