### PR TITLE
Fix spurious scrollbar in auto-height textareas

### DIFF
--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -86,8 +86,9 @@ exports.resizeTextAreaToFit = function(domNode,minHeight) {
 	}
 	// Set its height to auto so that it snaps to the correct height
 	domNode.style.height = "auto";
-	// Calculate the revised height
-	var newHeight = Math.max(domNode.scrollHeight + domNode.offsetHeight - domNode.clientHeight,measuredHeight);
+	// Calculate the revised height. The +1 covers the subpixel shortfall from
+	// scrollHeight, offsetHeight and clientHeight all being rounded to integers
+	var newHeight = Math.max(domNode.scrollHeight + domNode.offsetHeight - domNode.clientHeight + 1,measuredHeight);
 	// Restore the original rows attribute state
 	if(!hadRowsAttr) {
 		domNode.removeAttribute("rows");

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9972-textarea-scrollbar.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9972-textarea-scrollbar.tid
@@ -1,0 +1,11 @@
+title: $:/changenotes/5.5.0/#9972
+description: Auto-height editor textareas no longer show a spurious scrollbar
+tags: $:/tags/ChangeNote
+release: 5.5.0
+change-type: bugfix
+change-category: usability
+github-links: TODO pull request url
+github-contributors: TODO ericshulman diagnosed and proposed the fix, twMat reported it
+type: text/vnd.tiddlywiki
+
+Auto-height textareas add a pixel to the height they measure, so the editor no longer shows a vertical scrollbar at some combinations of line count and browser zoom (fixes [[Issue #9972|https://github.com/TiddlyWiki/TiddlyWiki5/issues/9972]])

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9980-textarea-scrollbar.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9980-textarea-scrollbar.tid
@@ -1,11 +1,11 @@
-title: $:/changenotes/5.5.0/#9972
+title: $:/changenotes/5.5.0/#9980
 description: Auto-height editor textareas no longer show a spurious scrollbar
 tags: $:/tags/ChangeNote
 release: 5.5.0
 change-type: bugfix
 change-category: usability
-github-links: TODO pull request url
-github-contributors: TODO ericshulman diagnosed and proposed the fix, twMat reported it
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9980
+github-contributors: pmario
 type: text/vnd.tiddlywiki
 
 Auto-height textareas add a pixel to the height they measure, so the editor no longer shows a vertical scrollbar at some combinations of line count and browser zoom (fixes [[Issue #9972|https://github.com/TiddlyWiki/TiddlyWiki5/issues/9972]])


### PR DESCRIPTION
Absorb the browser's integer rounding of the measured height, so the editor textarea no longer overflows at some combinations of line count and browser zoom

Fixes #9972