### PR TITLE
Theme hackability: Add each stylesheet to its own css layer for easier styling and debugging

### DIFF
--- a/core/ui/PageStylesheet.tid
+++ b/core/ui/PageStylesheet.tid
@@ -2,16 +2,37 @@ title: $:/core/ui/PageStylesheet
 code-body: yes
 
 \import [subfilter{$:/core/config/GlobalImportFilter}]
+
+\function sanitize.css.rule()
+"[^a-zA-Z0-9_-]"=>pattern
+[search-replace[$:/],[system-]search-replace:g:regexp<pattern>,[-]addprefix[tw-]]
+\end
+
 \whitespace trim
 
 <$set name="currentTiddler" value={{$:/language}}>
 
 <$set name="languageTitle" value={{!!name}}>
 
-<$transclude $tiddler="$:/core/stylesheets/custom-properties" $mode="block"/>
+<$text text=`@layer ${
+[[$:/core/stylesheets/custom-properties]]
+[all[shadows+tiddlers]tag[$:/tags/Stylesheet]!has[draft.of]]
++[sanitize.css.rule[]]
++[join[,]]
+}$;
 
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/Stylesheet]!has[draft.of]]">
+`/>
+
+<$list filter="
+[[$:/core/stylesheets/custom-properties]]
+[all[shadows+tiddlers]tag[$:/tags/Stylesheet]!has[draft.of]]
+">
+<$text text=`@layer ${[<currentTiddler>sanitize.css.rule[]]}${
+`/>
 <$transclude mode="block"/>
+<$text text="
+}
+"/>
 </$list>
 
 </$set>

--- a/core/ui/PageStylesheet.tid
+++ b/core/ui/PageStylesheet.tid
@@ -4,7 +4,7 @@ code-body: yes
 \import [subfilter{$:/core/config/GlobalImportFilter}]
 
 \function sanitize.css.rule()
-"[^a-zA-Z0-9_-]"=>pattern
+"[^a-zA-Z0-9_.-]"=>pattern
 [search-replace[$:/],[system-]search-replace:g:regexp<pattern>,[-]addprefix[tw-]]
 \end
 

--- a/core/ui/PageStylesheet.tid
+++ b/core/ui/PageStylesheet.tid
@@ -5,7 +5,8 @@ code-body: yes
 
 \function sanitize.css.rule()
 "[^a-zA-Z0-9_.-]"=>pattern
-[search-replace[$:/],[system-]search-replace:g:regexp<pattern>,[-]addprefix[tw-]]
+"\.([0-9])"=>digit-pattern
+[search-replace[$:/],[system-]search-replace:g:regexp<pattern>,[-]search-replace:g:regexp<digit-pattern>,[.n$1]addprefix[tw-]]
 \end
 
 \whitespace trim

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9982.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9982.tid
@@ -1,0 +1,16 @@
+title: $:/changenotes/5.5.0/#9982
+created: 20260822184413345
+modified: 20260822184413345
+tags: $:/tags/ChangeNote
+change-type: enhancement
+change-category: hackability
+description: Add each stylesheet to its own css layer for easier styling and debugging
+release: 5.5.0
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9982
+github-contributors: DesignThinkerer
+type: text/vnd.tiddlywiki
+
+This pull request wraps each TiddlyWiki stylesheet tiddler in a dedicated CSS `@layer`, directly mapping the wiki's load order to absolute CSS precedence.
+By prioritizing source order over standard selector specificity, users can override complex core styles without ever needing to use `!important`.
+As an added benefit, the dynamically generated layer names act as self-documenting labels in the browser developer tools, 
+making it effortless to trace any active style back to its exact source tiddler.


### PR DESCRIPTION
This PR make tiddlywiki easier to style and debug thanks to css layers: every stylesheet tiddler is now wrapped in its own [CSS `@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@layer).

The benefits are multiples:

- No changes required to the current theme
- User defined styles always win, as long as their stylesheet comes after the core
- We can now see which tiddler generated a CSS rule via the layer name in the dev tools
- Overriding are more predictable, self-documenting and explicit (see example below)

### Override example using the new layers

The vanilla theme contains these css rules:

```css
.tc-modal-centered .tc-modal {
    width: auto;
    top: 50%;
    left: 50%;
    transform: translate(-50%, -50%) !important;
  }
```

To override this transform, because it is using "!important", we can simply append the target layer by wrapping it in the specific layer's name:

```html
<div class="tc-modal-centered">
<div class="tc-modal">
test
</div>
</div>

<style>
@layer tw-system-themes-tiddlywiki-vanilla-base {
.tc-modal-centered .tc-modal {
	transform: translate(0%, 0%)!important;
}
}
</style>
```

<img width="635" height="250" alt="image" src="https://github.com/user-attachments/assets/d3436245-d958-49b6-bcce-d3e9da2ac3c0" />

We can also set the style override in its own stylesheet tiddler, and move it before the tiddler to override ([the priority is reversed when the `!important` flag is used](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@layer).). 

Another way is to use nesting, by creating a stylesheet with the title `$:/themes/tiddlywiki/vanilla/base.override`, we create a nested css layer called `override` inside the css layer `tw-system-themes-tiddlywiki-vanilla-base`, which will place our styles at the same priority level and thus allow our override to work.

This behavior make overriding much more explicit, self documenting, predictable, and avoid error.
