### PR TITLE
Fix typo in list tag, sidebar more plugins tab

### DIFF
--- a/core/ui/MoreSideBar/plugins/Plugins.tid
+++ b/core/ui/MoreSideBar/plugins/Plugins.tid
@@ -2,4 +2,4 @@ title: $:/core/ui/MoreSideBar/Plugins/Plugins
 tags: $:/tags/MoreSideBar/Plugins
 caption: {{$:/language/ControlPanel/Plugins/Plugins/Caption}}
 
-<$list filter="[!has[draft.of]plugin-type[plugin]sort[name]]" template="$:/core/ui/PluginListItemTemplate" emptyMessage={{$:/language/ControlPanel/Plugins/Empty/Hint}}>>/>
+<$list filter="[!has[draft.of]plugin-type[plugin]sort[name]]" template="$:/core/ui/PluginListItemTemplate" emptyMessage={{$:/language/ControlPanel/Plugins/Empty/Hint}}/>


### PR DESCRIPTION
Fix a typo, that causes a redundant P tag that should not be there.
