### PR TITLE
Give each tiddler info tool its own block

### DIFF
--- a/core/ui/TiddlerInfo/Tools.tid
+++ b/core/ui/TiddlerInfo/Tools.tid
@@ -6,20 +6,9 @@ caption: {{$:/language/TiddlerInfo/Tools/Caption}}
 \define config-title()
 $:/config/ViewToolbarButtons/Visibility/$(listItem)$
 \end
-<$set name="tv-config-toolbar-icons" value="yes">
 
-<$set name="tv-config-toolbar-text" value="yes">
-
-<$set name="tv-config-toolbar-class" value="">
-
+<$let tv-config-toolbar-icons="yes" tv-config-toolbar-text="yes" tv-config-toolbar-class="">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbar]!has[draft.of]]" variable="listItem">
-
-<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show"/> <$transclude tiddler=<<listItem>>/> <i class="tc-muted"><$transclude tiddler=<<listItem>> field="description"/></i>
-
+<div class="tc-info-list-item tc-tiny-v-gap-bottom"><$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show"/> <$transclude tiddler=<<listItem>>/> <i class="tc-muted"><$transclude tiddler=<<listItem>> field="description"/></i></div>
 </$list>
-
-</$set>
-
-</$set>
-
-</$set>
+</$let>

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9989-tiddler-info-tools-rows.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9989-tiddler-info-tools-rows.tid
@@ -1,0 +1,15 @@
+change-category: hackability
+change-type: enhancement
+created: 20260824145034442
+description: Each row of the tiddler info Tools tab is its own element and can be styled
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9989
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9989
+type: text/vnd.tiddlywiki
+
+* Each row of the ''Tools'' tab in the tiddler info panel is now a `<div class="tc-info-list-item tc-tiny-v-gap-bottom">` instead of a paragraph produced by the blank lines between rows. Row spacing is unchanged
+* `tc-info-list-item` carries no styling of its own. It is there so a row can be targeted from a custom stylesheet
+
+Fixed issues: [[#9988|https://github.com/TiddlyWiki/TiddlyWiki5/issues/9988]]


### PR DESCRIPTION
This PR fixes #9988

* Each row of the ''Tools'' tab in the tiddler info panel is now a `<div class="tc-info-list-item tc-tiny-v-gap-bottom">` instead of a paragraph produced by the blank lines between rows. Row spacing is unchanged
* Collapse three nested $set into one $let, so the blank lines that
  separated them are no longer needed
* `tc-info-list-item` carries no styling of its own. It is there so a row can be targeted from a custom stylesheet

