### PR TITLE
Replace nested $set with $let in the plugin table

### DIFF
--- a/core/ui/ControlPanel/Plugins.tid
+++ b/core/ui/ControlPanel/Plugins.tid
@@ -3,14 +3,13 @@ tags: $:/tags/ControlPanel
 caption: {{$:/language/ControlPanel/Plugins/Caption}}
 
 \define lingo-base() $:/language/ControlPanel/Plugins/
-
 \define plugin-table(type)
 \whitespace trim
-<$set name="plugin-type" value="""$type$""">
-<$set name="qualified-state" value=<<qualify "$:/state/plugin-info">>>
+<$let plugin-type="""$type$""" qualified-state=<<qualify "$:/state/plugin-info">>>
+
 <$list filter="[!has[draft.of]plugin-type[$type$]sort[name]]" emptyMessage=<<lingo "Empty/Hint">> template="$:/core/ui/Components/plugin-info"/>
-</$set>
-</$set>
+
+</$let>
 \end
 
 {{$:/core/ui/ControlPanel/Plugins/AddPlugins}}

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9990-controlpanel-plugin-table-let.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9990-controlpanel-plugin-table-let.tid
@@ -1,0 +1,14 @@
+change-category: internal
+change-type: enhancement
+created: 20260824154230790
+description: The Control Panel plugin table uses one $let instead of two nested $set widgets
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9990
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9990
+type: text/vnd.tiddlywiki
+
+* The `plugin-table` macro behind ''Control Panel'' -> ''Plugins'' sets its two variables with a single `<$let>` instead of two nested `<$set>` widgets
+* The plugin list is separated by blank lines so it keeps block position
+* Nothing changes visually


### PR DESCRIPTION
The plugin-table macro set two variables by nesting two $set widgets, where one $let sets both.

* Collapse the two nested $set widgets into a single $let
* Separate the plugin list with blank lines so it keeps block position

Nothing changes visually.

This PR is slightly related to: #9986
