### PR TITLE
Lay out a draggable list as a row with CSS

### DIFF
--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -95,9 +95,9 @@ tags: $:/tags/Macro
 </$set>
 \end
 
-\define list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div",storyview:"",displayField:"title",startactions,endactions)
+\define list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div",storyview:"",displayField:"title",startactions,endactions,class:"")
 \whitespace trim
-<span class="tc-tagged-draggable-list">
+<span class={{{ [[tc-tagged-draggable-list]] [<__class__>!match[]] +[join[ ]] }}}>
 	<$set name="tag" value=<<__tag__>>>
 		<$list
 			filter="[<__tag__>tagging[]$subFilter$]"

--- a/editions/tw5.com/tiddlers/macros/examples/list-links-draggable Macro (Examples).tid
+++ b/editions/tw5.com/tiddlers/macros/examples/list-links-draggable Macro (Examples).tid
@@ -1,7 +1,11 @@
 created: 20170328211011767
-modified: 20170328211211799
+modified: 20260825210000000
 tags: [[list-links-draggable Macro]] [[Macro Examples]]
 title: list-links-draggable Macro (Examples)
 type: text/vnd.tiddlywiki
 
-<$macrocall $name=".example" n="1" eg="""<<list-links-draggable tiddler:"Days of the Week">>"""/>
+Drag an item in either list to reorder it. The two calls differ only by the `class` parameter.
+
+<$list filter="[prefix[TestCases/DraggableLists/]suffix[Links]]">
+<$transclude $variable="testcase" tiddler=<<currentTiddler>>/>
+</$list>

--- a/editions/tw5.com/tiddlers/macros/examples/list-tagged-draggable Macro (Examples).tid
+++ b/editions/tw5.com/tiddlers/macros/examples/list-tagged-draggable Macro (Examples).tid
@@ -1,7 +1,11 @@
 created: 20170329093300835
-modified: 20170329093346982
+modified: 20260825210000000
 tags: [[list-tagged-draggable Macro]] [[Macro Examples]]
 title: list-tagged-draggable Macro (Examples)
 type: text/vnd.tiddlywiki
 
-<$macrocall $name=".example" n="1" eg="""<<list-tagged-draggable tag:"Features">>"""/>
+Drag an item in either list to reorder it. The two calls differ only by the `class` parameter.
+
+<$list filter="[prefix[TestCases/DraggableLists/]suffix[Tagged]]">
+<$transclude $variable="testcase" tiddler=<<currentTiddler>>/>
+</$list>

--- a/editions/tw5.com/tiddlers/macros/list-links-draggable Macro.tid
+++ b/editions/tw5.com/tiddlers/macros/list-links-draggable Macro.tid
@@ -27,6 +27,7 @@ The <<.def list-links-draggable>> [[macro|Macros]] renders the ListField of a ti
 
 ; class
 : Optional space separated classes to add to the wrapper element
+: <<.from-version "5.5.0">> Add `tc-horizontal-draggable` to lay the list out as a row instead of a column. The markup is unchanged, so dragging behaves the same
 
 ; itemTemplate
 : Optional title of a tiddler to use as the template for rendering list items

--- a/editions/tw5.com/tiddlers/macros/list-tagged-draggable Macro.tid
+++ b/editions/tw5.com/tiddlers/macros/list-tagged-draggable Macro.tid
@@ -29,8 +29,12 @@ The <<.def list-tagged-draggable>> [[macro|Macros]] renders the tiddlers with a 
 : <<.var actionTiddler>> variable is available in this action.
 
 ; endactions <<.from-version "5.4.0">>
-: Optional action string that gets invoked when link ''dragging ends'' 
+: Optional action string that gets invoked when link ''dragging ends''
 : <<.var actionTiddler>> variable is available in this action
+
+; class <<.from-version "5.5.0">>
+: Optional space separated classes to add to the wrapper element
+: Add `tc-horizontal-draggable` to lay the list out as a row instead of a column. The markup is unchanged, so dragging behaves the same
 
 Note that the [[ordering|Order of Tagged Tiddlers]] is accomplished by assigning a new list to the `list` field of the tag tiddler. Any `list-before` or `list-after` fields on any of the other tiddlers carrying the tag are also removed to ensure the `list` field is respected
 

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9992-horizontal-draggable-lists.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9992-horizontal-draggable-lists.tid
@@ -1,0 +1,14 @@
+change-category: hackability
+change-type: feature
+created: 20260825210000000
+description: The draggable list macros can be laid out as a row
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9992
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9992
+type: text/vnd.tiddlywiki
+
+* Passing `class:"tc-horizontal-draggable"` to <<.mlink list-links-draggable>> or <<.mlink list-tagged-draggable>> lays the list out as a row instead of a column
+* The markup is unchanged, so dragging, drop targets and item templates behave the same in both orientations
+* <<.mlink list-tagged-draggable>> gains a `class` parameter, which it had no way of accepting before

--- a/editions/tw5.com/tiddlers/testcases/DraggableLists/HorizontalLinks.tid
+++ b/editions/tw5.com/tiddlers/testcases/DraggableLists/HorizontalLinks.tid
@@ -1,0 +1,35 @@
+created: 20260825200000000
+description: A horizontal list-links-draggable is the vertical one plus a class
+modified: 20260825200000000
+tags: $:/tags/wiki-test-spec
+title: TestCases/DraggableLists/HorizontalLinks
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+Passing `class:"tc-horizontal-draggable"` lays the list out as a row. The markup must not change: it is still a `ul` of `li` elements, and every droppable and placeholder stays where it was, so dragging behaves identically. Only the class attribute differs from a vertical list.
++
+title: Items
+list: Alpha Beta Gamma Delta
++
+title: Alpha
+caption: Alpha
++
+title: Beta
+caption: Beta
++
+title: Gamma
+caption: Gamma
++
+title: Delta
+caption: Delta
++
+title: Output
+
+\import [[$:/core/macros/list]]
+
+<<list-links-draggable tiddler:"Items" class:"tc-horizontal-draggable">>
++
+title: ExpectedResult
+
+<p><span class="tc-links-draggable-list"><ul class="tc-horizontal-draggable"><li class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Alpha">Alpha</a></div></li><li class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Beta">Beta</a></div></li><li class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Gamma">Gamma</a></div></li><li class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Delta">Delta</a></div></li><div class="tc-droppable"><div class="tc-droppable-placeholder"><svg class="tc-image-blank tc-image-button" height="22pt" viewBox="0 0 128 128" width="22pt"></svg></div><div style="height:0.5em;"></div></div></ul></span></p>

--- a/editions/tw5.com/tiddlers/testcases/DraggableLists/HorizontalTagged.tid
+++ b/editions/tw5.com/tiddlers/testcases/DraggableLists/HorizontalTagged.tid
@@ -1,0 +1,32 @@
+created: 20260825200000000
+description: list-tagged-draggable laid out as a row
+modified: 20260825210000000
+tags: $:/tags/wiki-test-spec
+title: TestCases/DraggableLists/HorizontalTagged
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+Passing `class:"tc-horizontal-draggable"` lays the list out as a row. The markup is the same as the vertical list, so dragging behaves identically.
++
+title: Alpha
+tags: Subject
++
+title: Beta
+tags: Subject
++
+title: Gamma
+tags: Subject
++
+title: Delta
+tags: Subject
++
+title: Output
+
+\import [[$:/core/macros/list]]
+
+<<list-tagged-draggable tag:"Subject" class:"tc-horizontal-draggable">>
++
+title: ExpectedResult
+
+<p><span class="tc-tagged-draggable-list tc-horizontal-draggable"><div class="tc-menu-list-item"><span class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Alpha">Alpha</a></div></span></div><div class="tc-menu-list-item"><span class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Beta">Beta</a></div></span></div><div class="tc-menu-list-item"><span class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Delta">Delta</a></div></span></div><div class="tc-menu-list-item"><span class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Gamma">Gamma</a></div></span></div><span class="tc-droppable"><div class="tc-droppable-placeholder"></div><div style="height:0.5em;"></div></span></span></p>

--- a/editions/tw5.com/tiddlers/testcases/DraggableLists/VerticalLinks.tid
+++ b/editions/tw5.com/tiddlers/testcases/DraggableLists/VerticalLinks.tid
@@ -1,0 +1,35 @@
+created: 20260825210000000
+description: list-links-draggable with no class, the default column
+modified: 20260825210000000
+tags: $:/tags/wiki-test-spec
+title: TestCases/DraggableLists/VerticalLinks
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+The default list, a `ul` of `li` elements in a column. The horizontal version renders exactly this markup and differs only by a class.
++
+title: Items
+list: Alpha Beta Gamma Delta
++
+title: Alpha
+caption: Alpha
++
+title: Beta
+caption: Beta
++
+title: Gamma
+caption: Gamma
++
+title: Delta
+caption: Delta
++
+title: Output
+
+\import [[$:/core/macros/list]]
+
+<<list-links-draggable tiddler:"Items">>
++
+title: ExpectedResult
+
+<p><span class="tc-links-draggable-list"><ul class=""><li class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Alpha">Alpha</a></div></li><li class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Beta">Beta</a></div></li><li class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Gamma">Gamma</a></div></li><li class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Delta">Delta</a></div></li><div class="tc-droppable"><div class="tc-droppable-placeholder"><svg class="tc-image-blank tc-image-button" height="22pt" viewBox="0 0 128 128" width="22pt"></svg></div><div style="height:0.5em;"></div></div></ul></span></p>

--- a/editions/tw5.com/tiddlers/testcases/DraggableLists/VerticalTagged.tid
+++ b/editions/tw5.com/tiddlers/testcases/DraggableLists/VerticalTagged.tid
@@ -1,0 +1,32 @@
+created: 20260825210000000
+description: list-tagged-draggable with no class, the default column
+modified: 20260825210000000
+tags: $:/tags/wiki-test-spec
+title: TestCases/DraggableLists/VerticalTagged
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+The macro gained a `class` parameter. Passing none must leave the wrapper exactly as it was, reading `tc-tagged-draggable-list` with no trailing space.
++
+title: Alpha
+tags: Subject
++
+title: Beta
+tags: Subject
++
+title: Gamma
+tags: Subject
++
+title: Delta
+tags: Subject
++
+title: Output
+
+\import [[$:/core/macros/list]]
+
+<<list-tagged-draggable tag:"Subject">>
++
+title: ExpectedResult
+
+<p><span class="tc-tagged-draggable-list"><div class="tc-menu-list-item"><span class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Alpha">Alpha</a></div></span></div><div class="tc-menu-list-item"><span class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Beta">Beta</a></div></span></div><div class="tc-menu-list-item"><span class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Delta">Delta</a></div></span></div><div class="tc-menu-list-item"><span class="tc-droppable"><div class="tc-droppable-placeholder"></div><div><a class="tc-tiddlylink tc-tiddlylink-resolves" href="#Gamma">Gamma</a></div></span></div><span class="tc-droppable"><div class="tc-droppable-placeholder"></div><div style="height:0.5em;"></div></span></span></p>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -572,6 +572,38 @@ a.tc-tiddlylink-external:hover {
 	height: 2em;
 }
 
+/* Pass as the class parameter of a list macro to lay it out as a row. Markup unchanged */
+.tc-horizontal-draggable {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	list-style: none;
+	padding-left: 0;
+	margin: 0;
+}
+
+.tc-horizontal-draggable .tc-droppable {
+	display: flex;
+	align-items: center;
+}
+
+/* flex gap is too new for the CSS baseline */
+.tc-horizontal-draggable > * {
+	<<margin-end ".25em">>
+}
+
+/* The drop marker is a bar between items, not a band above one */
+.tc-horizontal-draggable .tc-droppable-placeholder {
+	line-height: normal;
+	height: 1.4em;
+	width: 0;
+}
+
+/* The end zone has no item to sit against, so it needs its own width */
+.tc-horizontal-draggable > .tc-droppable:last-child {
+	min-width: 1em;
+}
+
 .tc-sidebar-tab-open-item {
 	position: relative;
 }


### PR DESCRIPTION
Add a tc-horizontal-draggable class that turns either draggable list macro into a row, without changing what they render.

* Give list-tagged-draggable a class parameter, which it had no way of accepting; list-links-draggable already had one
* Do the layout entirely in the theme, so the markup stays a ul of li and dragging behaves the same in both orientations
* Cover both macros in both orientations with four testcases, one list each, and list them from the example tiddlers