### PR TITLE
Tag picker cancelpopups

### DIFF
--- a/core/ui/Manager/ItemSidebarTags.tid
+++ b/core/ui/Manager/ItemSidebarTags.tid
@@ -25,6 +25,7 @@ caption: {{$:/language/Manager/Item/Tags}}
 </p>
 <p>
 <$fieldmangler>
-<$macrocall $name="tag-picker" actions=<<tag-picker-actions>>/>
+<!-- cancelPopups must stay off here: focussing the input would cancel the popup that reveals this whole panel -->
+<$macrocall $name="tag-picker" actions=<<tag-picker-actions>> cancelPopups="no"/>
 </$fieldmangler>
 </p>

--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -157,7 +157,7 @@ The second ESC tries to close the "draft tiddler"
 \end
 
 <!-- prepare all variables for tag-picker keyboard handling -->
-\procedure tag-picker(actions, tagField:"tags", tiddler, tagListFilter:"[tags[]sort[]]")
+\procedure tag-picker(actions, tagField:"tags", tiddler, tagListFilter:"[tags[]sort[]]", cancelPopups:"yes")
 
 \function _tf.getUserInput() [<storeTitle>get[text]]
 \function _tf.getTag() [<newTagNameTiddler>get[text]]
@@ -184,8 +184,6 @@ The second ESC tries to close the "draft tiddler"
 
 	nonSystemTagsFilter="[subfilter<tagListFilter>!is[system]search:title<userInput>]"
 	systemTagsFilter="[subfilter<tagListFilter>is[system]search:title<userInput>]"
-
-	cancelPopups="yes"
 >
 	<$transclude $variable="tag-picker-inner"/>
 </$let>

--- a/editions/test/tiddlers/tests/test-edit-widgets/test-edit-text-widget-attributes.js
+++ b/editions/test/tiddlers/tests/test-edit-widgets/test-edit-text-widget-attributes.js
@@ -11,10 +11,15 @@ Each spec has a "manual:" comment with a by-hand recipe so a reviewer
 can sanity-check the test against a live wiki.
 
 NOT covered (need a real browser — Playwright territory):
-* `focus`, `focusSelectFromStart`/`End`, `focusPopup`, `cancelPopups` — real DOM focus + selection APIs
+* `focus`, `focusSelectFromStart`/`End` — real DOM focus + selection APIs
 * `inputActions`, `fileDrop` — synthetic events not dispatched by fakedom
 * Pixel measurement / growth of auto-height textareas — `$tw.utils.resizeTextAreaToFit` needs real layout
 * FramedEngine — requires a real iframe document
+
+`focusPopup` and `cancelPopups` are covered in [[test-tag-picker.js]]
+(editions/test/tiddlers/tests/test-tag-picker.js) instead: $tw.popup is
+undefined under Node, so a stub records what a focus would do without a
+real focus event.
 
 \*/
 

--- a/editions/test/tiddlers/tests/test-tag-picker.js
+++ b/editions/test/tiddlers/tests/test-tag-picker.js
@@ -1,0 +1,102 @@
+/*\
+title: test-tag-picker.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Covers what focussing a tag-picker input does to the popup stack: the
+cancelPopups parameter itself, and the two core callers that rely on
+opposite settings.
+
+Guards issue #9995. The tag-picker macro forced cancelPopups="yes" onto
+its input, so focussing the tag input in $:/Manager ran
+$tw.popup.cancel(0) and dropped the popup that reveals the Manager panel
+itself: the panel collapsed and the tag dropdown never appeared.
+
+Real focus events need a browser, but SimpleEngine.handleFocusEvent is a
+plain method and $tw.popup is a plain object, so the popup calls a focus
+would make are observable in fakedom.
+
+manual: open $:/Manager, expand any tiddler, click into the "add tag"
+input. The panel must stay open and the tag dropdown must appear. Repeat
+in a tiddler's edit template, where focussing the tag input must still
+close any other open dropdown.
+
+\*/
+
+"use strict";
+
+describe("tag-picker macro (popup handling on focus)", function() {
+
+	var findEditTextWidget = require("$:/tests/test-edit-widgets/helpers").findEditTextWidget;
+
+	var SNIPPET_TITLE = "$:/temp/test/tag-picker-spec";
+
+	var savedPopup;
+
+	beforeEach(function() {
+		savedPopup = $tw.popup;
+	});
+
+	afterEach(function() {
+		$tw.popup = savedPopup;
+	});
+
+	// Render a tiddler and focus its tag input, returning the popup calls that
+	// focus produced. The core UI tiddlers under test are shadows, so this uses
+	// the test edition's own wiki rather than a bare $tw.test.wiki().
+	function popupCallsOnFocus(title) {
+		var widgetNode = $tw.wiki.makeTranscludeWidget(title,{
+				document: $tw.fakeDocument,
+				importPageMacros: true,
+				variables: {currentTiddler: "TestTiddler"}
+			}),
+			calls = [];
+		widgetNode.render($tw.fakeDocument.createElement("div"),null);
+		$tw.popup = {
+			cancel: function(level) { calls.push("cancel(" + level + ")"); },
+			triggerPopup: function() { calls.push("triggerPopup"); }
+		};
+		findEditTextWidget(widgetNode).engine.handleFocusEvent({type: "focus"});
+		return calls;
+	}
+
+	// The macro needs the global macro scope, which only reaches a tiddler, so a
+	// snippet is parked in one for the duration of a single spec.
+	function popupCallsForSnippet(snippet) {
+		$tw.wiki.addTiddler({title: SNIPPET_TITLE, text: snippet});
+		try {
+			return popupCallsOnFocus(SNIPPET_TITLE);
+		} finally{
+			$tw.wiki.deleteTiddler(SNIPPET_TITLE);
+		}
+	}
+
+	describe("the cancelPopups parameter", function() {
+
+		// manual: <<tag-picker>> in a tiddler, open any other dropdown, then
+		// click the tag input — the other dropdown closes.
+		it("closes open popups by default", function() {
+			expect(popupCallsForSnippet("<<tag-picker>>")).toEqual(["cancel(0)","triggerPopup"]);
+		});
+
+		// manual: as above with <<tag-picker cancelPopups:"no">> — the other
+		// dropdown stays open and the tag dropdown appears alongside it.
+		it("leaves open popups alone when set to no", function() {
+			expect(popupCallsForSnippet('<<tag-picker cancelPopups:"no">>')).toEqual(["triggerPopup"]);
+		});
+
+	});
+
+	describe("core callers", function() {
+
+		it("opens the dropdown without cancelling popups in $:/Manager", function() {
+			expect(popupCallsOnFocus("$:/Manager/ItemSidebar/Tags")).toEqual(["triggerPopup"]);
+		});
+
+		it("still cancels other popups in the edit template", function() {
+			expect(popupCallsOnFocus("$:/core/ui/EditTemplate/tags")).toEqual(["cancel(0)","triggerPopup"]);
+		});
+
+	});
+
+});

--- a/editions/tw5.com/tiddlers/macros/tag-picker_Macro.tid
+++ b/editions/tw5.com/tiddlers/macros/tag-picker_Macro.tid
@@ -1,6 +1,6 @@
 caption: tag-picker
 created: 20161128191316701
-modified: 20240708175550512
+modified: 20260826124226250
 tags: Macros [[Core Macros]]
 title: tag-picker Macro
 type: text/vnd.tiddlywiki
@@ -20,7 +20,10 @@ The <<.def tag-picker>> [[macro|Macros]] generates a combination of a text box a
 
 ; tagListFilter
 : <<.from-version 5.3.4>> This parameter defaults to: `[tags[]]` which creates a list of all existing tags. If the tag list should come from a different source the filter should look similar to eg: `[<listSource>get[field-name]enlist-input[]]`. See examples.
-: <<.from-version 5.3.5>> This parameter defaults to: `[tags[]sort[]]`. This change allows a custom sort order, since `sort[]` is not hardcoded into the tag-picker macro anymore. 
+: <<.from-version 5.3.5>> This parameter defaults to: `[tags[]sort[]]`. This change allows a custom sort order, since `sort[]` is not hardcoded into the tag-picker macro anymore.
+
+; cancelPopups
+: <<.from-version 5.5.0>> Defaults to `yes`, which closes any open popup as soon as the tag input is focussed. Set it to `no` where the tag-picker is itself inside a popup, as in $:/Manager, otherwise focussing the input closes the panel around it.
 
 
 <<.macro-examples "tag-picker">>

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9996-manager-tag-input-focus.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#9996-manager-tag-input-focus.tid
@@ -1,0 +1,19 @@
+change-category: usability
+change-type: bugfix
+created: 20260826130119000
+description: Focussing the tag input in $:/Manager no longer closes the panel
+github-contributors: pmario
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9996
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#9996
+type: text/vnd.tiddlywiki
+
+* Clicking the tag input of an expanded tiddler in $:/Manager keeps the panel open and shows the tag dropdown. Since 5.3.4 it collapsed the panel instead
+* The tag-picker macro gained a `cancelPopups` parameter. It defaults to `yes`, which closes any open popup as the input is focussed. Set it to `no` where the tag-picker itself sits inside a popup
+
+```
+<<tag-picker cancelPopups:"no">>
+```
+
+Fixed issue: [[#9995|https://github.com/TiddlyWiki/TiddlyWiki5/issues/9995]]


### PR DESCRIPTION
Focussing the tag input in $:/Manager collapsed the expanded tiddler and never opened the tag dropdown, because the tag-picker macro cancelled every popup including the one that reveals the panel.

* Add a cancelPopups parameter to the tag-picker macro, defaulting to yes, so a caller that sits inside a popup can opt out
* Pass cancelPopups="no" from the Manager tag sidebar
* Document the parameter and cover both settings with specs

This PR : 

- fixes: #9995