### PR TITLE
Document that an unquoted parameter value cannot contain a colon

### DIFF
--- a/editions/tw5.com/tiddlers/procedures/calls/Calls.tid
+++ b/editions/tw5.com/tiddlers/procedures/calls/Calls.tid
@@ -21,7 +21,9 @@ By default, parameters are interpreted as being in the same order as in the defi
 
 If no value is specified for a parameter, the default value given for that parameter in the [[procedure definition|Procedure Definitions]], [[function definition|Function Definitions]] or [[macro definition|Macro Definitions]] is used instead. (If no default value was defined, the parameter is blank).
 
-Each parameter value can be enclosed in `'`single quotes`'`, `"`double quotes`"`, `"""`triple double quotes`"""` or `[[`double square brackets`]]`. Triple double quotes allow a value to contain almost anything. If a value contains no spaces or single or double quotes, it requires no delimiters. [[Substituted Attribute Values]] enclosed in single or triple back quotes are also supported.
+Each parameter value can be enclosed in `'`single quotes`'`, `"`double quotes`"`, `"""`triple double quotes`"""` or `[[`double square brackets`]]`. Triple double quotes allow a value to contain almost anything. If a value contains no spaces, single or double quotes, or colons, it requires no delimiters. [[Substituted Attribute Values]] enclosed in single or triple back quotes are also supported.
+
+<<.warning """A colon in an unquoted value is read as the separator of a named parameter: in `<<my-procedure https://example.com>>` the parser takes `https` as a parameter name, and the positional parameter receives nothing. Enclose such a value in quotes, or label it with a parameter name — `<<my-procedure address=https://example.com>>` — in which case no quotes are needed.""">>
 
 See the discussion about [[parser modes|WikiText parser mode: macro examples]]
 


### PR DESCRIPTION
`Calls` currently tells the reader when delimiters may be dropped:

> If a value contains no spaces or single or double quotes, it requires no delimiters.

A colon also requires them. `name:value` is itself call syntax, so the text before the colon is read as a parameter name, the positional parameter is never filled, and the value disappears with no error:

```
\procedure link-to(target)
[target=<<target>>]
\end

<<link-to https://example.com>>    → [target=]
<<link-to 12:30>>                  → [target=]
```

A time of day trips this for the same reason a URI does.

`Call Syntax` already states the grammar correctly — `param-name ":" value` is one of its productions, and `param-name` is a sequence of letters, digits, hyphens and underscores. A URI scheme is spelled with exactly those characters. So this changes only the prose in `Calls`, to match the grammar that is already documented.

### The change

- One sentence: `no spaces or single or double quotes` → `no spaces, single or double quotes, or colons`
- One `<<.warning>>` after that paragraph, naming both ways round it: quote the value, or label it with a parameter name (`target=https://example.com`), which needs no quotes because the `=` binds before the colon is reached.

### Why a tiddler title is unaffected

`$:/some/tiddler` fails the parameter-name test at `$:/some`, so it is taken whole and needs no delimiters. A URI scheme passes that test. That is the whole of the difference, and it is why this is easy to miss.

### Checked

Rendered against this branch:

| call | output |
|---|---|
| `<<link-to https://example.com>>` | `[target=]` |
| `<<link-to 12:30>>` | `[target=]` |
| `<<link-to "https://example.com">>` | `[target=https://example.com]` |
| `<<link-to target="https://example.com">>` | `[target=https://example.com]` |
| `<<link-to target=https://example.com>>` | `[target=https://example.com]` |
| `<<link-to $:/some/tiddler>>` | `[target=$:/some/tiddler]` |

The added warning quotes a call inside a code span, so I checked that the nested `>>` does not close the macro early: the text after the warning survives, and the inner call renders as literal text.
