### PR TITLE
Markdown: Fix crash in inline look-ahead parsing

### DIFF
--- a/editions/test/tiddlers/config.multids
+++ b/editions/test/tiddlers/config.multids
@@ -1,0 +1,3 @@
+title: $:/config/
+
+markdown/linkify: true

--- a/editions/test/tiddlers/tests/data/markdown/CamelCaseLinkText.tid
+++ b/editions/test/tiddlers/tests/data/markdown/CamelCaseLinkText.tid
@@ -1,0 +1,16 @@
+title: Markdown/CamelCaseLinkText
+description: no camelCase link in link text
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+[MarkdownDemo Source](#MarkdownDemo%20Source)
++
+title: ExpectedResult
+
+<div class="markdown">
+<p><a class="tc-tiddlylink tc-tiddlylink-missing _codified_" href="#MarkdownDemo%20Source">MarkdownDemo Source</a>
+</p>
+</div>

--- a/editions/test/tiddlers/tests/data/markdown/CodeBlock.tid
+++ b/editions/test/tiddlers/tests/data/markdown/CodeBlock.tid
@@ -1,0 +1,21 @@
+title: Markdown/CodeBlock
+description: test codeblock widget call
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+<$codeblock code="""var a="This needs \"escaping\"";""" language=js/>
+
+```js
+var a="This needs \"escaping\"";
+```
++
+title: ExpectedResult
+
+<div class="markdown">
+<pre><code>var a="This needs \"escaping\"";</code></pre>
+<pre><code>var a="This needs \"escaping\"";
+</code></pre>
+</div>

--- a/editions/test/tiddlers/tests/data/markdown/CodeSpan.tid
+++ b/editions/test/tiddlers/tests/data/markdown/CodeSpan.tid
@@ -1,0 +1,36 @@
+title: Markdown/CodeSpan
+description: no tw rendering in backticks code span
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+`$:/palette`
+
+`CamelCase`
+
+`{{New Tiddler}}`
+
+`{{{ [[New Tiddler]] }}}`
+
+`&lt;&lt;version&gt;&gt;`
+
+`<<version>>`
++
+title: ExpectedResult
+
+<div class="markdown">
+<p><code class="_codified_">$:/palette</code>
+</p>
+<p><code class="_codified_">CamelCase</code>
+</p>
+<p><code class="_codified_">{{New Tiddler}}</code>
+</p>
+<p><code class="_codified_">{{{ [[New Tiddler]] }}}</code>
+</p>
+<p><code class="_codified_">&amp;lt;&amp;lt;version&amp;gt;&amp;gt;</code>
+</p>
+<p><code class="_codified_">&lt;&lt;version&gt;&gt;</code>
+</p>
+</div>

--- a/editions/test/tiddlers/tests/data/markdown/FilteredTransclusion.tid
+++ b/editions/test/tiddlers/tests/data/markdown/FilteredTransclusion.tid
@@ -1,0 +1,32 @@
+title: Markdown/FilteredTransclusion
+description: filtered transclusion block & inline
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+{{{ [[hello world]] [[foo bar]] +[encodeuri[]] }}}
+block above
+
+{{{ [[hello world]] [[foo bar]] +[encodeuri[]] }}} inline
++
+title: ExpectedResult
+
+<div class="markdown">
+<p><div><a class="tc-tiddlylink tc-tiddlylink-missing" href="#hello%2520world">hello%20world</a></div><div><a class="tc-tiddlylink tc-tiddlylink-missing" href="#foo%2520bar">foo%20bar</a></div><p>block above
+</p></p>
+<p><span><a class="tc-tiddlylink tc-tiddlylink-missing" href="#hello%2520world">hello%20world</a></span><span><a class="tc-tiddlylink tc-tiddlylink-missing" href="#foo%2520bar">foo%20bar</a></span> inline
+</p>
+</div>
++
+title: $:/palette
+
+$:/themes/tiddlywiki/vanilla
++
+title: $:/themes/tiddlywiki/vanilla
+color-scheme: light
++
+title: New Tiddler
+
+Aloha!

--- a/editions/test/tiddlers/tests/data/markdown/FilteredTransclusionAsLinkText.tid
+++ b/editions/test/tiddlers/tests/data/markdown/FilteredTransclusionAsLinkText.tid
@@ -1,0 +1,39 @@
+title: Markdown/FilteredTransclusionAsLinkText
+description: filtered transclusion as link label should not generate links
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+[{{{[{$:/palette}get[color-scheme]]}}}](#New%20Tiddler)
+
+[{{{ [[A]] [[B]] [[C]] }}}](#A)<!-- as text output: only the first item is returned -->
+
+[foo {{{[[New Tiddler?]]}}} bar](#New%20Tiddler)
+
+[<$text text={{{[[New Tiddler?]]}}}/>](#New%20Tiddler)
++
+title: ExpectedResult
+
+<div class="markdown">
+<p><a class="tc-tiddlylink tc-tiddlylink-resolves _codified_" href="#New%20Tiddler">light</a>
+</p>
+<p><a class="tc-tiddlylink tc-tiddlylink-missing _codified_" href="#A">A</a>
+</p>
+<p><a class="tc-tiddlylink tc-tiddlylink-resolves _codified_" href="#New%20Tiddler">foo New Tiddler? bar</a>
+</p>
+<p><a class="tc-tiddlylink tc-tiddlylink-resolves _codified_" href="#New%20Tiddler">New Tiddler?</a>
+</p>
+</div>
++
+title: $:/palette
+
+$:/themes/tiddlywiki/vanilla
++
+title: $:/themes/tiddlywiki/vanilla
+color-scheme: light
++
+title: New Tiddler
+
+Aloha!

--- a/editions/test/tiddlers/tests/data/markdown/Images.tid
+++ b/editions/test/tiddlers/tests/data/markdown/Images.tid
@@ -1,0 +1,20 @@
+title: Markdown/Images
+description: tw image links
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+[img[https://tiddlywiki.com/favicon.ico]]
+
+[[img[https://tiddlywiki.com/favicon.ico]]](https://tiddlywiki.com)<!-- tw image should be allowed -->
++
+title: ExpectedResult
+
+<div class="markdown">
+<p><img src="https://tiddlywiki.com/favicon.ico">
+</p>
+<p><a class="tc-tiddlylink-external _codified_" href="https://tiddlywiki.com" rel="noopener noreferrer" target="_blank"><img src="https://tiddlywiki.com/favicon.ico"></a>
+</p>
+</div>

--- a/editions/test/tiddlers/tests/data/markdown/LinksInMarkdownImageLabel.tid
+++ b/editions/test/tiddlers/tests/data/markdown/LinksInMarkdownImageLabel.tid
@@ -1,0 +1,24 @@
+title: Markdown/LinksInMarkdownImageLabel
+description: md image labels are text only
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+![[[foo](uri1)](uri2)](url3)
+
+![[[New Tiddler]]](url3)
+
+![[ext[hello|http://google.com]]](url3)
++
+title: ExpectedResult
+
+<div class="markdown">
+<p><img alt="[foo](uri2)" src="url3">
+</p>
+<p><img alt="New Tiddler" src="url3">
+</p>
+<p><img alt="hello" src="url3">
+</p>
+</div>

--- a/editions/test/tiddlers/tests/data/markdown/MacroArgs.tid
+++ b/editions/test/tiddlers/tests/data/markdown/MacroArgs.tid
@@ -1,0 +1,20 @@
+title: Markdown/MacroArgs
+description: macro args containing html tags
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+inline text follows <<now "<b>YYYY</b>">> ...the end
+
+testing <<makedatauri 'hi' 'test/plain'>>
++
+title: ExpectedResult
+
+<div class="markdown">
+<p>inline text follows <b>2026</b> ...the end
+</p>
+<p>testing <a class="tc-tiddlylink-external" href="data:test/plain,hi" rel="noopener noreferrer" target="_blank">data:test/plain,hi</a>
+</p>
+</div>

--- a/editions/test/tiddlers/tests/data/markdown/NestedLinks.tid
+++ b/editions/test/tiddlers/tests/data/markdown/NestedLinks.tid
@@ -1,0 +1,24 @@
+title: Markdown/NestedLinks
+description: Nested link label
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+[foo [bar](/uri2)](/uri1)
+
+[foo [FooBar](/uri2)](/uri1)<!-- CameCase -->
+
+[foo [FooBar](/uri2)xyz](/uri1)<!-- CameCase -->
++
+title: ExpectedResult
+
+<div class="markdown">
+<p>[foo <a class="tc-tiddlylink-external _codified_" href="/uri2" rel="noopener noreferrer" target="_blank">bar</a>](/uri1)
+</p>
+<p>[foo <a class="tc-tiddlylink-external _codified_" href="/uri2" rel="noopener noreferrer" target="_blank">FooBar</a>](/uri1)
+</p>
+<p>[foo <a class="tc-tiddlylink-external _codified_" href="/uri2" rel="noopener noreferrer" target="_blank">FooBar</a>xyz](/uri1)
+</p>
+</div>

--- a/editions/test/tiddlers/tests/data/markdown/PrettyExtLinks.tid
+++ b/editions/test/tiddlers/tests/data/markdown/PrettyExtLinks.tid
@@ -1,0 +1,28 @@
+title: Markdown/PrettyExtLnks
+description: prettyext link and linkify on
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+see https://tiddlywiki.com.
+
+[ext[https://tiddlywiki.com]]
+
+[[ext[https://tiddlywiki.com]]](https://tiddlywiki.com)
+
+[ext[TW5|https://tiddlywiki.com]](https://tiddlywiki.com)<!-- markdown link has higher precedence -->
++
+title: ExpectedResult
+
+<div class="markdown">
+<p>see <a class="tc-tiddlylink-external _codified_" href="https://tiddlywiki.com" rel="noopener noreferrer" target="_blank">https://tiddlywiki.com</a>.
+</p>
+<p><a class="tc-tiddlylink-external _codified_" href="https://tiddlywiki.com" rel="noopener noreferrer" target="_blank">https://tiddlywiki.com</a>
+</p>
+<p><a class="tc-tiddlylink-external _codified_" href="https://tiddlywiki.com" rel="noopener noreferrer" target="_blank">[ext[https://tiddlywiki.com]]</a>
+</p>
+<p><a class="tc-tiddlylink-external _codified_" href="https://tiddlywiki.com" rel="noopener noreferrer" target="_blank">ext[TW5|https://tiddlywiki.com]</a>
+</p>
+</div>

--- a/editions/test/tiddlers/tests/data/markdown/PrettyLinks.tid
+++ b/editions/test/tiddlers/tests/data/markdown/PrettyLinks.tid
@@ -1,0 +1,20 @@
+title: Markdown/PrettyLinks
+description: prettylink and linkify on
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+[[[New Tiddler]]](#New%20Tiddler)
+
+[[New Tiddler]]
++
+title: ExpectedResult
+
+<div class="markdown">
+<p><a class="tc-tiddlylink tc-tiddlylink-missing _codified_" href="#New%20Tiddler">[[New Tiddler]]</a>
+</p>
+<p><a class="tc-tiddlylink tc-tiddlylink-missing _codified_" href="#New%20Tiddler">New Tiddler</a>
+</p>
+</div>

--- a/editions/test/tiddlers/tests/data/markdown/RefLInks.tid
+++ b/editions/test/tiddlers/tests/data/markdown/RefLInks.tid
@@ -1,0 +1,26 @@
+title: Markdown/RefLinks
+description: reference links
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+[Foo][foo]
+
+[[Foo Bar]][foo]<!-- markdown link has higher precedence -->
+
+[ext[readme|readme.html]][foo]<!-- markdown link has higher precedence -->
+
+[foo]: #FooTiddler
++
+title: ExpectedResult
+
+<div class="markdown">
+<p><a class="tc-tiddlylink tc-tiddlylink-missing _codified_" href="#FooTiddler">Foo</a>
+</p>
+<p><a class="tc-tiddlylink tc-tiddlylink-missing _codified_" href="#FooTiddler">[Foo Bar]</a>
+</p>
+<p><a class="tc-tiddlylink tc-tiddlylink-missing _codified_" href="#FooTiddler">ext[readme|readme.html]</a>
+</p>
+</div>

--- a/editions/test/tiddlers/tests/data/markdown/SilentInline.tid
+++ b/editions/test/tiddlers/tests/data/markdown/SilentInline.tid
@@ -1,0 +1,37 @@
+title: Markdown/SilentInline
+description: silent look-ahead should not crash
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+~$1.00 [img[https://tiddlywiki.com/favicon.ico]] OK
+
+~$1.00 [[abc]] xyz [[foo bar]] OK
+
+~$1.00 <<currentTiddler>> <<currentTiddler>> OK
+
+~$1.00 {{{ [[hello world]] [[foo bar]] +[encodeuri[]] }}} OK
+
+~$1.00 {{New Tiddler!!title}} | {{!!title}} OK
+
+~$1.00 [ext[https://tiddlywiki.com]] | [ext[https://tiddlywiki.com]] OK
+
++
+title: ExpectedResult
+
+<div class="markdown">
+<p>~$1.00 <img src="https://tiddlywiki.com/favicon.ico"> OK
+</p>
+<p>~$1.00 <a class="tc-tiddlylink tc-tiddlylink-missing _codified_" href="#abc">abc</a> xyz <a class="tc-tiddlylink tc-tiddlylink-missing _codified_" href="#foo%20bar">foo bar</a> OK
+</p>
+<p>~$1.00 Output Output OK
+</p>
+<p>~$1.00 <span><a class="tc-tiddlylink tc-tiddlylink-missing" href="#hello%2520world">hello%20world</a></span><span><a class="tc-tiddlylink tc-tiddlylink-missing" href="#foo%2520bar">foo%20bar</a></span> OK
+</p>
+<p>~$1.00 New Tiddler | Output OK
+</p>
+<p>~$1.00 <a class="tc-tiddlylink-external _codified_" href="https://tiddlywiki.com" rel="noopener noreferrer" target="_blank">https://tiddlywiki.com</a> | <a class="tc-tiddlylink-external _codified_" href="https://tiddlywiki.com" rel="noopener noreferrer" target="_blank">https://tiddlywiki.com</a> OK
+</p>
+</div>

--- a/editions/test/tiddlers/tests/data/markdown/TransclusionAsLinkText.tid
+++ b/editions/test/tiddlers/tests/data/markdown/TransclusionAsLinkText.tid
@@ -1,0 +1,27 @@
+title: Markdown/TransclusionAsLinkText
+description: transclusion as link label should generate text only
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+[{{$:/themes/tiddlywiki/vanilla!!color-scheme}}](#New%20Tiddler)
++
+title: ExpectedResult
+
+<div class="markdown">
+<p><a class="tc-tiddlylink tc-tiddlylink-resolves _codified_" href="#New%20Tiddler">light</a>
+</p>
+</div>
++
+title: $:/palette
+
+$:/themes/tiddlywiki/vanilla
++
+title: $:/themes/tiddlywiki/vanilla
+color-scheme: light
++
+title: New Tiddler
+
+Aloha!

--- a/editions/test/tiddlers/tests/data/markdown/WidgetBlock.tid
+++ b/editions/test/tiddlers/tests/data/markdown/WidgetBlock.tid
@@ -1,0 +1,22 @@
+title: Markdown/WidgetBlock
+description: widget block recognition
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+hello<!-- following is a block, content is treated RAW -->
+
+<$link to="New Tiddler">
+_New_ Tiddler
+</$link>
++
+title: ExpectedResult
+
+<div class="markdown">
+<p>hello
+</p>
+<a class="tc-tiddlylink tc-tiddlylink-missing" href="#New%20Tiddler">
+_New_ Tiddler
+</a></div>

--- a/editions/test/tiddlers/tests/data/markdown/WidgetInline.tid
+++ b/editions/test/tiddlers/tests/data/markdown/WidgetInline.tid
@@ -1,0 +1,22 @@
+title: Markdown/WidgetInline
+description: widget block recognition
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+type: text/markdown
+
+The following content is inline, `_New_` interpreted:<br/>
+<$link to="New Tiddler">
+_New_ Tiddler
+</$link>
++
+title: ExpectedResult
+
+<div class="markdown">
+<p>The following content is inline, <code class="_codified_">_New_</code> interpreted:<br>
+<a class="tc-tiddlylink tc-tiddlylink-missing" href="#New%20Tiddler">
+<em>New</em> Tiddler
+</a>
+</p>
+</div>

--- a/editions/test/tiddlywiki.info
+++ b/editions/test/tiddlywiki.info
@@ -3,7 +3,8 @@
 	"plugins": [
 		"tiddlywiki/jasmine",
 		"tiddlywiki/wikitext-serialize",
-		"tiddlywiki/geospatial"
+		"tiddlywiki/geospatial",
+		"tiddlywiki/markdown"
 	],
 	"themes": [
 		"tiddlywiki/vanilla",
@@ -11,7 +12,11 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","test.html","text/plain",
-			"--test"]
+			"--rendertiddler",
+			"$:/core/save/all",
+			"test.html",
+			"text/plain",
+			"--test"
+		]
 	}
 }

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10007.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10007.tid
@@ -1,0 +1,11 @@
+title: $:/changenotes/5.5.0/#10007
+tags: $:/tags/ChangeNote
+change-type: bugfix
+change-category: plugin
+description: Fix crash in Markdown inline look-ahead parsing
+release: 5.5.0
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/10007
+github-contributors: cdruan
+type: text/vnd.tiddlywiki
+
+Fix improper state.pos updates in some TW inline rules during silent mode. The error was exposed by updated markdown-it.

--- a/plugins/tiddlywiki/highlight/styles-dev.tid
+++ b/plugins/tiddlywiki/highlight/styles-dev.tid
@@ -1,0 +1,38 @@
+title: $:/plugins/tiddlywiki/highlight/styles-dev
+tags: [[$:/tags/Stylesheet]] [[$:/tags/Stylesheet/Highlight]]
+
+/* filter prefix */
+.hljs-property.suffix_ {
+  color: #cb4b16;
+}
+
+.hljs-operator ~ .hljs-property.suffix_ {
+  color: #0050a0;
+}
+
+.hljs-operator.filter_ {
+  font-weight: bold;
+  color: #0050a0;
+}
+
+.hljs-params.variable_ {
+  font-weight: bold;
+}
+
+.hljs-variable.filter_ {
+  font-weight: normal;
+}
+
+.hljs-function.title_ {
+  font-weight: bold;
+}
+
+.hljs-subst {
+  color: purple;
+}
+
+
+.hljs-snippet {
+  color: <<colour foreground>>;
+  -webkit-text-size-adjust:none;
+}

--- a/plugins/tiddlywiki/markdown/markdown-it-tiddlywiki.js
+++ b/plugins/tiddlywiki/markdown/markdown-it-tiddlywiki.js
@@ -124,19 +124,19 @@ function render_token_attrs(token) {
 // given tw parsing rule and starting pos, returns match index or undefined
 // assumes pos >= 0
 function findNextMatch(ruleinfo,pos) {
-	// ruleinfo.matchIndex needs to be -1 at the start of inline state
-	if(ruleinfo.matchIndex < pos) {
-		ruleinfo.matchIndex = ruleinfo.rule.findNextMatch(pos);
-	}
-
+	ruleinfo.matchIndex = ruleinfo.rule.findNextMatch(pos);
 	return ruleinfo.matchIndex;
 }
 
 // Add inline rule "macrocall" to parse <<macroname ...>>
 function tw_macrocallinline(state,silent) {
 	var ruleinfo = pluginOpts.inlineRules.macrocallinline;
-
 	var pos = state.pos;
+
+	if(pos + 1 >= state.posMax) { return false; }
+
+	if(state.src.charCodeAt(pos) !== 0x3c /* < */ || state.src.charCodeAt(pos + 1) !== 0x3c) { return false; }
+
 	var matchIndex = findNextMatch(ruleinfo,pos);
 	if(matchIndex === undefined || matchIndex !== pos) {
 		return false;
@@ -153,8 +153,12 @@ function tw_macrocallinline(state,silent) {
 // parse transclusion elements
 function tw_transcludeinline(state,silent) {
 	var ruleinfo = pluginOpts.inlineRules.transcludeinline;
-
 	var pos = state.pos;
+
+	if(pos + 1 >= state.posMax) { return false; }
+
+	if(state.src.charCodeAt(pos) !== 0x7b /* { */ || state.src.charCodeAt(pos + 1) !== 0x7b) { return false; }
+
 	var matchIndex = findNextMatch(ruleinfo,pos);
 	if(matchIndex === undefined || matchIndex !== pos) {
 		return false;
@@ -171,8 +175,14 @@ function tw_transcludeinline(state,silent) {
 // parse filtered transclusion elements
 function tw_filteredtranscludeinline(state,silent) {
 	var ruleinfo = pluginOpts.inlineRules.filteredtranscludeinline;
-
 	var pos = state.pos;
+
+	if(pos + 2 >= state.posMax) { return false; }
+
+	for(let i=0; i < 3; i++) {
+		if(state.src.charCodeAt(pos + i) !== 0x7b /* { */) { return false; }
+	}
+
 	var matchIndex = findNextMatch(ruleinfo,pos);
 	if(matchIndex === undefined || matchIndex !== pos) {
 		return false;
@@ -277,7 +287,7 @@ function tw_image(state,silent) {
 		});
 		token.markup = "tw_image";
 	}
-	state.pos = ruleinfo.rule.parser.pos;
+	state.pos = ruleinfo.rule.nextImage.end;
 	return true;
 }
 
@@ -291,6 +301,11 @@ function tw_prettylink(state,silent) {
 	}
 
 	var pos = state.pos;
+
+	if(pos + 1 >= state.posMax) { return false; }
+
+	if(state.src.charCodeAt(pos) !== 0x5b /* [ */ || state.src.charCodeAt(pos + 1) !== 0x5b) { return false; }
+
 	var matchIndex = findNextMatch(ruleinfo,pos);
 	if(matchIndex === undefined || matchIndex !== pos) {
 		return false;
@@ -316,7 +331,7 @@ function tw_prettylink(state,silent) {
 		token = state.push("link_close",tag,-1);
 		token.markup = "tw_prettylink";
 	}
-	state.pos = ruleinfo.rule.parser.pos;
+	state.pos = ruleinfo.rule.matchRegExp.lastIndex;
 	return true;
 }
 
@@ -352,7 +367,7 @@ function tw_prettyextlink(state,silent) {
 		token = state.push("link_close","a",-1);
 		token.markup = "tw_prettyextlink";
 	}
-	state.pos = ruleinfo.rule.parser.pos;
+	state.pos = ruleinfo.rule.nextLink.end;
 	return true;
 }
 
@@ -411,7 +426,7 @@ function extendInlineParse(thisArg,origFunc,twInlineRules) {
 			ruleinfo.rule.parser.source = str;
 			ruleinfo.rule.parser.sourceLength = str.length;
 			ruleinfo.rule.parser.pos = 0; // not used
-			ruleinfo.matchIndex = -1;
+			ruleinfo.matchIndex = undefined;
 		}
 		origFunc.call(thisArg,str,md,env,outTokens);
 	};


### PR DESCRIPTION
Fix improper state.pos updates in some TW inline rules during silent mode. The error was exposed by updated markdown-it.

An example that will trigger the crash:

```md
~hello [[New Tiddler]]
```

After the fix, the tiddler will render correctly:

<img width="400" height="50" alt="Screenshot From 2026-09-03 04-03-21" src="https://github.com/user-attachments/assets/7caf0ef7-439a-4738-b8a3-07029b7e5fb7" />



