### PR TITLE
Fix/issue 9977

### DIFF
--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -99,7 +99,8 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 		wikiLinkText = this.wiki.filterTiddlers(wikilinkTransformFilter,this,function(iterator) {
 			iterator(self.wiki.getTiddler(self.to),self.to);
 		})[0];
-	} else {
+	}
+	if(!wikiLinkText) {
 		// Expand the tv-wikilink-template variable to construct the href
 		var wikiLinkTemplateMacro = this.getVariable("tv-wikilink-template"),
 			wikiLinkTemplate = wikiLinkTemplateMacro ? wikiLinkTemplateMacro.trim() : "#$uri_encoded$";


### PR DESCRIPTION
Fixes #9977

### Motivation
When `tv-filter-export-link` is assigned a filter that returns no results, `LinkWidget` previously set the `href` attribute to the string `"undefined"`.

### Description of Changes
Updated `LinkWidget.prototype.renderLink` in `core/modules/widgets/link.js` to check if `wikiLinkText` is undefined after running `tv-filter-export-link`. If no result is produced, it falls back to the default `tv-wikilink-template` logic (e.g. `#HelloThere`).