### PR TITLE
Allow colons in variable names in call syntax

### DIFF
--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -221,7 +221,7 @@ exports.parseMacroInvocationAsTransclusion = function(source,pos) {
 		orderedAttributes: []
 	};
 	// Define our regexps
-	var reVarName = /([^\s>"'=:]+)/y;
+	var reVarName = /([^\s>"'=]+)/y;
 	// Skip whitespace
 	pos = $tw.utils.skipWhiteSpace(source,pos);
 	// Look for a double opening angle bracket
@@ -269,7 +269,7 @@ exports.parseMVVReferenceAsTransclusion = function(source,pos) {
 		orderedAttributes: []
 	};
 	// Define our regexps
-	var reVarName = /([^\s>"'=:)]+)/y;
+	var reVarName = /([^\s>"'=)]+)/y;
 	// Skip whitespace
 	pos = $tw.utils.skipWhiteSpace(source,pos);
 	// Look for a double opening parenthesis

--- a/editions/test/tiddlers/tests/data/multi-valued-variables/AttributeColonVarName.tid
+++ b/editions/test/tiddlers/tests/data/multi-valued-variables/AttributeColonVarName.tid
@@ -1,0 +1,15 @@
+title: MultiValuedVariables/AttributeColonVarName
+description: ((var)) on a widget attribute may name a variable containing a colon (#10013)
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$let my:list={{{ [range[2]] }}}>
+<$text text=((my:list))/>
+</$let>
++
+title: ExpectedResult
+
+<p>1</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-colon-varname-and-param.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-colon-varname-and-param.tid
@@ -1,0 +1,16 @@
+title: Parse/BackCompat/MacrocallColonVarNameAndParam
+description: A colon-named procedure or macro accepts named parameters with either separator (#10013)
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\procedure object:method(p) COLONPROC(<<p>>)
+\define object:macro(p) COLONMACRO($p$)
+<<object:method p:"V">>
+<<object:method p="V">>
+<<object:macro p:"V">>
++
+title: ExpectedResult
+
+<p>COLONPROC(V)</p><p>COLONPROC(V)</p><p>COLONMACRO(V)</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-colon-varname-as-value.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-colon-varname-as-value.tid
@@ -1,0 +1,16 @@
+title: Parse/BackCompat/MacrocallColonVarNameAsValue
+description: A colon-named procedure or macro may be an =-separated parameter value (#10013)
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\procedure object:method() COLONPROC
+\define object:macro() COLONMACRO
+\procedure host(a) [a=<<a>>]
+<<host a=<<object:method>>>>
+<<host a=<<object:macro>>>>
++
+title: ExpectedResult
+
+<p>[a=COLONPROC]</p><p>[a=COLONMACRO]</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-colon-varname.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-colon-varname.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/MacrocallColonVarName
+description: Macro call variable name may contain a colon (#10013)
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\procedure object:method() VAL
+<<object:method>>
++
+title: ExpectedResult
+
+<p>VAL</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/widget-attr-macro-colon-varname.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/widget-attr-macro-colon-varname.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/WidgetAttrMacroColonVarName
+description: Widget attribute macro value may name a variable containing a colon (#10013)
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\procedure object:method() VAL
+<$text text=<<object:method>>/>
++
+title: ExpectedResult
+
+<p>VAL</p>

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10014-colon-in-variable-names.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10014-colon-in-variable-names.tid
@@ -1,0 +1,34 @@
+title: $:/changenotes/5.5.0/#10014
+created: 20260906223932000
+modified: 20260906223932000
+description: Variable names may contain a colon in call and multi-valued variable syntax
+release: 5.5.0
+tags: $:/tags/ChangeNote
+change-type: bugfix
+change-category: hackability
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/10014
+github-contributors: pmario
+
+A variable name may contain a colon in the `<<...>>` call syntax: standalone, with named parameters using either separator, as a nested call, and as a widget attribute value.
+
+```
+\procedure obj:plain() Hello
+\procedure greet:person(name) Hello <<name>>
+\procedure obj:host(a) [<<a>>]
+
+<<obj:plain>>
+<<greet:person name:"world">>
+<<greet:person name="world">>
+<<obj:host a=<<obj:plain>>>>
+<div data-x=<<obj:plain>> ></div>
+```
+
+An `((...))` multi-valued variable reference used as a widget attribute value accepts the same names as the inline syntax:
+
+```
+<$let my:list={{{ [range[3]] }}}>
+<$text text=((my:list))/>
+</$let>
+```
+
+Fixed issue: [[#10013|https://github.com/TiddlyWiki/TiddlyWiki5/issues/10013]]


### PR DESCRIPTION
Edit: Commit that introduced the issue: https://github.com/pmario/TiddlyWiki5/commit/6bc77cf3e27526e6e07b311d1963d710361a0c7e

-------

A variable name may contain a colon in the `<<...>>` call syntax: standalone, with named parameters using either separator, as a nested call, and as a widget attribute value.

```
\procedure obj:plain() Hello
\procedure greet:person(name) Hello <<name>>
\procedure obj:host(a) [<<a>>]

<<obj:plain>>
<<greet:person name:"world">>
<<greet:person name="world">>
<<obj:host a=<<obj:plain>>>>
<div data-x=<<obj:plain>> ></div>
```

An `((...))` multi-valued variable reference used as a widget attribute value accepts the same names as the inline syntax:

```
<$let my:list={{{ [range[3]] }}}>
<$text text=((my:list))/>
</$let>
```

Fixes #10013