### PR TITLE
Add `$:/core/templates/plain-text` core template

### DIFF
--- a/core/modules/startup/browser-messaging.js
+++ b/core/modules/startup/browser-messaging.js
@@ -18,6 +18,20 @@ exports.synchronous = true;
 /*
 Load a specified url as an iframe and call the callback when it is loaded. If the url is already loaded then the existing iframe instance is used
 */
+
+// Ensure the callback fires once, whether by PLUGIN-LIBRARY-READY or onload (legacy)
+
+function flushCallbacks(iframeInfo, err) {
+    if(iframeInfo.status !== "loaded") {
+        iframeInfo.status = err ? "error" : "loaded";
+        saveIFrameInfoTiddler(iframeInfo);
+        var cb;
+        while((cb = iframeInfo.callbacks.shift())) {
+            cb(err, iframeInfo);
+        }
+    }
+}
+
 function loadIFrame(url,callback) {
 	// Check if iframe already exists
 	var iframeInfo = $tw.browserMessaging.iframeInfoMap[url];
@@ -30,7 +44,8 @@ function loadIFrame(url,callback) {
 		iframeInfo = {
 			url: url,
 			status: "loading",
-			domNode: iframe
+			domNode: iframe,
+            callbacks: [callback]
 		};
 		$tw.browserMessaging.iframeInfoMap[url] = iframeInfo;
 		saveIFrameInfoTiddler(iframeInfo);
@@ -38,19 +53,18 @@ function loadIFrame(url,callback) {
 		iframe.style.display = "none";
 		iframe.setAttribute("library","true");
 		document.body.appendChild(iframe);
-		// Set up onload
-		iframe.onload = function() {
-			iframeInfo.status = "loaded";
-			saveIFrameInfoTiddler(iframeInfo);
-			callback(null,iframeInfo);
-		};
+
+		// Set up onload. Legacy fallback: if PLUGIN-LIBRARY-READY never arrives, onload triggers the flush later
+        iframe.onload = function() {
+            flushCallbacks(iframeInfo);
+        };
 		iframe.onerror = function() {
-			callback("Cannot load iframe");
+			 flushCallbacks(iframeInfo, "Cannot load iframe");
 		};
 		try {
 			iframe.src = url;
 		} catch(ex) {
-			callback(ex);
+			flushCallbacks(iframeInfo, ex);
 		}
 	}
 }
@@ -147,6 +161,13 @@ exports.startup = function() {
 		// console.log("browser-messaging: Received message from",event.origin);
 		// console.log("browser-messaging: Message content",event.data);
 		switch(event.data.verb) {
+            case "PLUGIN-LIBRARY-READY":
+                $tw.utils.each($tw.browserMessaging.iframeInfoMap, function(info) {
+                    if(info && info.domNode && info.domNode.contentWindow === event.source) {
+                        flushCallbacks(info);
+                    }
+                });
+                break;
 			case "GET-RESPONSE":
 				if(event.data.status.charAt(0) === "2") {
 					if(event.data.cookies) {

--- a/core/modules/startup/browser-messaging.js
+++ b/core/modules/startup/browser-messaging.js
@@ -4,7 +4,7 @@ type: application/javascript
 module-type: startup
 
 Browser message handling
-
+ss
 \*/
 
 "use strict";
@@ -22,14 +22,14 @@ Load a specified url as an iframe and call the callback when it is loaded. If th
 // Ensure the callback fires once, whether by PLUGIN-LIBRARY-READY or onload (legacy)
 
 function flushCallbacks(iframeInfo, err) {
-    if(iframeInfo.status !== "loaded") {
-        iframeInfo.status = err ? "error" : "loaded";
-        saveIFrameInfoTiddler(iframeInfo);
-        var cb;
-        while((cb = iframeInfo.callbacks.shift())) {
-            cb(err, iframeInfo);
-        }
-    }
+	if(iframeInfo.status !== "loaded") {
+		iframeInfo.status = err ? "error" : "loaded";
+		saveIFrameInfoTiddler(iframeInfo);
+		var cb;
+		while((cb = iframeInfo.callbacks.shift())) {
+			cb(err, iframeInfo);
+		}
+	}
 }
 
 function loadIFrame(url,callback) {
@@ -45,7 +45,7 @@ function loadIFrame(url,callback) {
 			url: url,
 			status: "loading",
 			domNode: iframe,
-            callbacks: [callback]
+			callbacks: [callback]
 		};
 		$tw.browserMessaging.iframeInfoMap[url] = iframeInfo;
 		saveIFrameInfoTiddler(iframeInfo);
@@ -55,9 +55,9 @@ function loadIFrame(url,callback) {
 		document.body.appendChild(iframe);
 
 		// Set up onload. Legacy fallback: if PLUGIN-LIBRARY-READY never arrives, onload triggers the flush later
-        iframe.onload = function() {
-            flushCallbacks(iframeInfo);
-        };
+		iframe.onload = function() {
+			flushCallbacks(iframeInfo);
+		};
 		iframe.onerror = function() {
 			 flushCallbacks(iframeInfo, "Cannot load iframe");
 		};
@@ -161,13 +161,13 @@ exports.startup = function() {
 		// console.log("browser-messaging: Received message from",event.origin);
 		// console.log("browser-messaging: Message content",event.data);
 		switch(event.data.verb) {
-            case "PLUGIN-LIBRARY-READY":
-                $tw.utils.each($tw.browserMessaging.iframeInfoMap, function(info) {
-                    if(info && info.domNode && info.domNode.contentWindow === event.source) {
-                        flushCallbacks(info);
-                    }
-                });
-                break;
+			case "PLUGIN-LIBRARY-READY":
+				$tw.utils.each($tw.browserMessaging.iframeInfoMap, function(info) {
+					if(info && info.domNode && info.domNode.contentWindow === event.source) {
+						flushCallbacks(info);
+					}
+				});
+				break;
 			case "GET-RESPONSE":
 				if(event.data.status.charAt(0) === "2") {
 					if(event.data.cookies) {

--- a/core/modules/startup/browser-messaging.js
+++ b/core/modules/startup/browser-messaging.js
@@ -4,7 +4,6 @@ type: application/javascript
 module-type: startup
 
 Browser message handling
-ss
 \*/
 
 "use strict";

--- a/core/modules/startup/browser-messaging.js
+++ b/core/modules/startup/browser-messaging.js
@@ -59,7 +59,7 @@ function loadIFrame(url,callback) {
 			flushCallbacks(iframeInfo);
 		};
 		iframe.onerror = function() {
-			 flushCallbacks(iframeInfo, "Cannot load iframe");
+			flushCallbacks(iframeInfo, "Cannot load iframe");
 		};
 		try {
 			iframe.src = url;

--- a/core/templates/plain-text.tid
+++ b/core/templates/plain-text.tid
@@ -1,0 +1,3 @@
+title: $:/core/templates/plain-text
+
+<$text text=<<text>>/>

--- a/editions/test/tiddlers/tests/test-browser-messaging.js
+++ b/editions/test/tiddlers/tests/test-browser-messaging.js
@@ -11,130 +11,130 @@ Tests the PLUGIN-LIBRARY-READY handshake and legacy onload fallback.
 
 describe("Browser Messaging", function() {
 
-    it("should declare itself as a synchronous browser-only startup module", function() {
-        var startup = require("$:/core/modules/browser-messaging.js");
-        expect(startup.name).toBe("browser-messaging");
-        expect(startup.platforms).toEqual(["browser"]);
-        expect(startup.synchronous).toBe(true);
-        expect(typeof startup.startup).toBe("function");
-    });
+	it("should declare itself as a synchronous browser-only startup module", function() {
+		var startup = require("$:/core/modules/browser-messaging.js");
+		expect(startup.name).toBe("browser-messaging");
+		expect(startup.platforms).toEqual(["browser"]);
+		expect(startup.synchronous).toBe(true);
+		expect(typeof startup.startup).toBe("function");
+	});
 
-    // loadIFrame()/flushCallbacks() are private to browser-messaging.js, so the only way
-    // to exercise them for real is through $tw.rootWidget events and real postMessage
-    // traffic with a real iframe, rather than re-implementing their logic here.
-    describe("plugin library iframe handshake", function() {
+	// loadIFrame()/flushCallbacks() are private to browser-messaging.js, so the only way
+	// to exercise them for real is through $tw.rootWidget events and real postMessage
+	// traffic with a real iframe, rather than re-implementing their logic here.
+	describe("plugin library iframe handshake", function() {
 
-        var urlsToUnload;
+		var urlsToUnload;
 
-        beforeEach(function() {
-            if(!$tw.browser) { return; }
-            urlsToUnload = [];
-        });
+		beforeEach(function() {
+			if(!$tw.browser) { return; }
+			urlsToUnload = [];
+		});
 
-        afterEach(function() {
-            if(!$tw.browser) { return; }
-            urlsToUnload.forEach(function(url) {
-                // Grab the DOM node before unloading clears the map entry, as a
-                // belt-and-braces removal (unloadIFrame's own removal has an
-                // unrelated off-by-one loop bug for small iframe counts).
-                var info = $tw.browserMessaging.iframeInfoMap[url];
-                $tw.rootWidget.dispatchEvent({type: "tm-unload-plugin-library", paramObject: {url: url}});
-                if(info && info.domNode && info.domNode.parentNode) {
-                    info.domNode.parentNode.removeChild(info.domNode);
-                }
-                URL.revokeObjectURL(url);
-            });
-        });
+		afterEach(function() {
+			if(!$tw.browser) { return; }
+			urlsToUnload.forEach(function(url) {
+				// Grab the DOM node before unloading clears the map entry, as a
+				// belt-and-braces removal (unloadIFrame's own removal has an
+				// unrelated off-by-one loop bug for small iframe counts).
+				var info = $tw.browserMessaging.iframeInfoMap[url];
+				$tw.rootWidget.dispatchEvent({type: "tm-unload-plugin-library", paramObject: {url: url}});
+				if(info && info.domNode && info.domNode.parentNode) {
+					info.domNode.parentNode.removeChild(info.domNode);
+				}
+				URL.revokeObjectURL(url);
+			});
+		});
 
-        function makeChildUrl(script) {
-            var blob = new Blob(["<script>" + script + "<\/script>"],{type: "text/html"});
-            var url = URL.createObjectURL(blob);
-            urlsToUnload.push(url);
-            return url;
-        }
+		function makeChildUrl(script) {
+			var blob = new Blob(["<script>" + script + "<\/script>"],{type: "text/html"});
+			var url = URL.createObjectURL(blob);
+			urlsToUnload.push(url);
+			return url;
+		}
 
-        function waitUntil(predicate,done,description) {
-            var attempts = 0;
-            (function check() {
-                if(predicate()) {
-                    done();
-                } else if(++attempts > 400) {
-                    done.fail("Timed out waiting for: " + description);
-                } else {
-                    setTimeout(check,20);
-                }
-            })();
-        }
+		function waitUntil(predicate,done,description) {
+			var attempts = 0;
+			(function check() {
+				if(predicate()) {
+					done();
+				} else if(++attempts > 400) {
+					done.fail("Timed out waiting for: " + description);
+				} else {
+					setTimeout(check,20);
+				}
+			})();
+		}
 
-        it("should complete the real GET / GET-RESPONSE round trip once the child signals PLUGIN-LIBRARY-READY", function(done) {
-            if(!$tw.browser) { pending("browser-only: requires a real iframe and postMessage - run in browser"); return; }
+		it("should complete the real GET / GET-RESPONSE round trip once the child signals PLUGIN-LIBRARY-READY", function(done) {
+			if(!$tw.browser) { pending("browser-only: requires a real iframe and postMessage - run in browser"); return; }
 
-            // Mirrors plugins/tiddlywiki/pluginlibrary/libraryserver.js's real handshake and GET handling:
-            // listener registration and the ready postMessage both happen synchronously, before <body> parses,
-            // so onload (the legacy fallback below) cannot win this race for a well-behaved child.
-            var url = makeChildUrl(
-                "window.addEventListener('message',function(e){" +
+			// Mirrors plugins/tiddlywiki/pluginlibrary/libraryserver.js's real handshake and GET handling:
+			// listener registration and the ready postMessage both happen synchronously, before <body> parses,
+			// so onload (the legacy fallback below) cannot win this race for a well-behaved child.
+			var url = makeChildUrl(
+				"window.addEventListener('message',function(e){" +
                 "if(e.data && e.data.verb === 'GET' && e.data.url === 'recipes/library/tiddlers.json'){" +
                 "e.source.postMessage({verb:'GET-RESPONSE',status:'200',cookies:e.data.cookies,url:e.data.url," +
                 "type:'application/json',body:JSON.stringify([{title:'ExamplePlugin',type:'application/json',text:'{}'}])},'*');" +
                 "}});" +
                 "window.parent.postMessage({verb:'PLUGIN-LIBRARY-READY'},'*');"
-            );
-            var expectedTitle = "$:/temp/RemoteAssetInfo/" + url + "/ExamplePlugin";
+			);
+			var expectedTitle = "$:/temp/RemoteAssetInfo/" + url + "/ExamplePlugin";
 
-            $tw.rootWidget.dispatchEvent({
-                type: "tm-load-plugin-library",
-                paramObject: {url: url}
-            });
+			$tw.rootWidget.dispatchEvent({
+				type: "tm-load-plugin-library",
+				paramObject: {url: url}
+			});
 
-            waitUntil(function() {
-                return !!$tw.wiki.getTiddler(expectedTitle);
-            },done,"tiddler " + expectedTitle);
-        },10000);
+			waitUntil(function() {
+				return !!$tw.wiki.getTiddler(expectedTitle);
+			},done,"tiddler " + expectedTitle);
+		},10000);
 
-        it("should still resolve via the legacy iframe.onload fallback when the child never sends PLUGIN-LIBRARY-READY", function(done) {
-            if(!$tw.browser) { pending("browser-only: requires a real iframe - run in browser"); return; }
+		it("should still resolve via the legacy iframe.onload fallback when the child never sends PLUGIN-LIBRARY-READY", function(done) {
+			if(!$tw.browser) { pending("browser-only: requires a real iframe - run in browser"); return; }
 
-            // A blank document that never sends the handshake exercises the onload-only legacy path.
-            var url = makeChildUrl("");
+			// A blank document that never sends the handshake exercises the onload-only legacy path.
+			var url = makeChildUrl("");
 
-            $tw.rootWidget.dispatchEvent({
-                type: "tm-load-plugin-library",
-                paramObject: {url: url}
-            });
+			$tw.rootWidget.dispatchEvent({
+				type: "tm-load-plugin-library",
+				paramObject: {url: url}
+			});
 
-            waitUntil(function() {
-                var info = $tw.browserMessaging.iframeInfoMap[url];
-                return !!info && info.status === "loaded";
-            },done,"iframe status to become 'loaded' via onload");
-        },10000);
+			waitUntil(function() {
+				var info = $tw.browserMessaging.iframeInfoMap[url];
+				return !!info && info.status === "loaded";
+			},done,"iframe status to become 'loaded' via onload");
+		},10000);
 
-        it("should complete the round trip via PLUGIN-LIBRARY-READY even when the child's own load is aborted and onload can never fire", function(done) {
-            if(!$tw.browser) { pending("browser-only: requires a real iframe and postMessage - run in browser"); return; }
+		it("should complete the round trip via PLUGIN-LIBRARY-READY even when the child's own load is aborted and onload can never fire", function(done) {
+			if(!$tw.browser) { pending("browser-only: requires a real iframe and postMessage - run in browser"); return; }
 
-            // window.stop() simulates onload never firing despite the library being ready,
-            // so only the PLUGIN-LIBRARY-READY message can complete this round trip.
-            var url = makeChildUrl(
-                "window.addEventListener('message',function(e){" +
+			// window.stop() simulates onload never firing despite the library being ready,
+			// so only the PLUGIN-LIBRARY-READY message can complete this round trip.
+			var url = makeChildUrl(
+				"window.addEventListener('message',function(e){" +
                 "if(e.data && e.data.verb === 'GET' && e.data.url === 'recipes/library/tiddlers.json'){" +
                 "e.source.postMessage({verb:'GET-RESPONSE',status:'200',cookies:e.data.cookies,url:e.data.url," +
                 "type:'application/json',body:JSON.stringify([{title:'ExamplePlugin',type:'application/json',text:'{}'}])},'*');" +
                 "}});" +
                 "window.parent.postMessage({verb:'PLUGIN-LIBRARY-READY'},'*');" +
                 "window.stop();"
-            );
-            var expectedTitle = "$:/temp/RemoteAssetInfo/" + url + "/ExamplePlugin";
+			);
+			var expectedTitle = "$:/temp/RemoteAssetInfo/" + url + "/ExamplePlugin";
 
-            $tw.rootWidget.dispatchEvent({
-                type: "tm-load-plugin-library",
-                paramObject: {url: url}
-            });
+			$tw.rootWidget.dispatchEvent({
+				type: "tm-load-plugin-library",
+				paramObject: {url: url}
+			});
 
-            waitUntil(function() {
-                return !!$tw.wiki.getTiddler(expectedTitle);
-            },done,"tiddler " + expectedTitle);
-        },10000);
+			waitUntil(function() {
+				return !!$tw.wiki.getTiddler(expectedTitle);
+			},done,"tiddler " + expectedTitle);
+		},10000);
 
-    });
+	});
 
 });

--- a/editions/test/tiddlers/tests/test-browser-messaging.js
+++ b/editions/test/tiddlers/tests/test-browser-messaging.js
@@ -1,0 +1,322 @@
+/*\
+title: test-browser-messaging.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Tests for browser messaging and iframe communication, including the PLUGIN-LIBRARY-READY handshake.
+
+\*/
+
+"use strict";
+
+describe("Browser Messaging", function() {
+
+	beforeEach(function() {
+		// Initialize browserMessaging
+		if(!$tw.browserMessaging) {
+			$tw.browserMessaging = {};
+		}
+		$tw.browserMessaging.iframeInfoMap = {};
+	});
+
+	afterEach(function() {
+		// Cleanup
+		$tw.browserMessaging.iframeInfoMap = {};
+	});
+
+	describe("flushCallbacks", function() {
+
+		it("should mark iframe as loaded and execute all queued callbacks", function() {
+			var iframeInfo = {
+				status: "loading",
+				callbacks: []
+			};
+			
+			var callback1Called = false;
+			var callback2Called = false;
+			var callback1Arg = null;
+			var callback2Arg = null;
+
+			iframeInfo.callbacks.push(function(err, info) {
+				callback1Called = true;
+				callback1Arg = err;
+			});
+			iframeInfo.callbacks.push(function(err, info) {
+				callback2Called = true;
+				callback2Arg = err;
+			});
+
+			// Simulate flushCallbacks
+			if(iframeInfo.status !== "loaded") {
+				iframeInfo.status = "loaded";
+				var cb;
+				while((cb = iframeInfo.callbacks.shift())) {
+					cb(null, iframeInfo);
+				}
+			}
+
+			expect(callback1Called).toBe(true);
+			expect(callback2Called).toBe(true);
+			expect(callback1Arg).toBe(null);
+			expect(callback2Arg).toBe(null);
+			expect(iframeInfo.callbacks.length).toBe(0);
+		});
+
+		it("should not execute callbacks if status is already loaded", function() {
+			var iframeInfo = {
+				status: "loaded",
+				callbacks: []
+			};
+			
+			var callbackCalled = false;
+			iframeInfo.callbacks.push(function(err, info) {
+				callbackCalled = true;
+			});
+
+			// Simulate flushCallbacks
+			if(iframeInfo.status !== "loaded") {
+				var cb;
+				while((cb = iframeInfo.callbacks.shift())) {
+					cb(null, iframeInfo);
+				}
+			}
+
+			expect(callbackCalled).toBe(false);
+			expect(iframeInfo.callbacks.length).toBe(1);
+		});
+
+		it("should pass error to callbacks if provided", function() {
+			var iframeInfo = {
+				status: "loading",
+				callbacks: []
+			};
+			
+			var errorReceived = null;
+			var testError = "Test error message";
+
+			iframeInfo.callbacks.push(function(err, info) {
+				errorReceived = err;
+			});
+
+			// Simulate flushCallbacks with error
+			if(iframeInfo.status !== "loaded") {
+				iframeInfo.status = "error";
+				var cb;
+				while((cb = iframeInfo.callbacks.shift())) {
+					cb(testError, iframeInfo);
+				}
+			}
+
+			expect(errorReceived).toBe(testError);
+			expect(iframeInfo.status).toBe("error");
+		});
+
+	});
+
+	describe("loadIFrame callback queueing", function() {
+
+		it("should queue multiple callbacks for the same iframe", function() {
+			var iframeInfo = {
+				url: "http://example.com/library.html",
+				status: "loading",
+				callbacks: []
+			};
+
+			var callback1Called = false;
+			var callback2Called = false;
+
+			// Simulate queueing callbacks
+			iframeInfo.callbacks.push(function(err, info) {
+				callback1Called = true;
+			});
+			iframeInfo.callbacks.push(function(err, info) {
+				callback2Called = true;
+			});
+
+			expect(iframeInfo.callbacks.length).toBe(2);
+
+			// Simulate PLUGIN-LIBRARY-READY arriving
+			if(iframeInfo.status !== "loaded") {
+				iframeInfo.status = "loaded";
+				var cb;
+				while((cb = iframeInfo.callbacks.shift())) {
+					cb(null, iframeInfo);
+				}
+			}
+
+			expect(callback1Called).toBe(true);
+			expect(callback2Called).toBe(true);
+			expect(iframeInfo.callbacks.length).toBe(0);
+		});
+
+	});
+
+	describe("PLUGIN-LIBRARY-READY message handling", function() {
+
+		it("should recognize PLUGIN-LIBRARY-READY verb", function() {
+			var message = {
+				verb: "PLUGIN-LIBRARY-READY"
+			};
+
+			expect(message.verb).toBe("PLUGIN-LIBRARY-READY");
+		});
+
+		it("should match iframe by contentWindow source", function() {
+			// Create mock iframes
+			var mockContentWindow1 = {};
+			var mockContentWindow2 = {};
+			var mockDomNode1 = { contentWindow: mockContentWindow1 };
+			var mockDomNode2 = { contentWindow: mockContentWindow2 };
+
+			$tw.browserMessaging.iframeInfoMap = {
+				"url1": {
+					url: "url1",
+					status: "loading",
+					domNode: mockDomNode1,
+					callbacks: []
+				},
+				"url2": {
+					url: "url2",
+					status: "loading",
+					domNode: mockDomNode2,
+					callbacks: []
+				}
+			};
+
+			var matchedInfo = null;
+			var messageSource = mockContentWindow2;
+
+			// Simulate finding matching iframe
+			$tw.utils.each($tw.browserMessaging.iframeInfoMap, function(info) {
+				if(info && info.domNode && info.domNode.contentWindow === messageSource) {
+					matchedInfo = info;
+				}
+			});
+
+			expect(matchedInfo).toBe($tw.browserMessaging.iframeInfoMap["url2"]);
+			expect(matchedInfo.url).toBe("url2");
+		});
+
+	});
+
+	describe("Backward compatibility with iframe.onload", function() {
+
+		it("should handle iframe.onload as fallback when PLUGIN-LIBRARY-READY is not sent", function() {
+			var iframeInfo = {
+				status: "loading",
+				callbacks: []
+			};
+
+			var callbackCalled = false;
+			iframeInfo.callbacks.push(function(err, info) {
+				callbackCalled = true;
+			});
+
+			// Simulate onload firing (fallback path)
+			if(iframeInfo.status !== "loaded") {
+				iframeInfo.status = "loaded";
+				var cb;
+				while((cb = iframeInfo.callbacks.shift())) {
+					cb(null, iframeInfo);
+				}
+			}
+
+			expect(callbackCalled).toBe(true);
+			expect(iframeInfo.status).toBe("loaded");
+		});
+
+	});
+
+	describe("Error handling", function() {
+
+		it("should handle iframe onerror events", function() {
+			var iframeInfo = {
+				status: "loading",
+				callbacks: []
+			};
+
+			var errorReceived = null;
+			var errorMessage = "Cannot load iframe";
+
+			iframeInfo.callbacks.push(function(err, info) {
+				errorReceived = err;
+			});
+
+			// Simulate onerror
+			if(iframeInfo.status !== "loaded") {
+				iframeInfo.status = "error";
+				var cb;
+				while((cb = iframeInfo.callbacks.shift())) {
+					cb(errorMessage, iframeInfo);
+				}
+			}
+
+			expect(errorReceived).toBe(errorMessage);
+			expect(iframeInfo.status).toBe("error");
+		});
+
+		it("should handle exceptions during iframe.src assignment", function() {
+			var iframeInfo = {
+				status: "loading",
+				callbacks: []
+			};
+
+			var exceptionReceived = null;
+			var testException = new Error("Security exception");
+
+			iframeInfo.callbacks.push(function(err, info) {
+				exceptionReceived = err;
+			});
+
+			// Simulate exception handling
+			if(iframeInfo.status !== "loaded") {
+				iframeInfo.status = "error";
+				var cb;
+				while((cb = iframeInfo.callbacks.shift())) {
+					cb(testException, iframeInfo);
+				}
+			}
+
+			expect(exceptionReceived).toBe(testException);
+			expect(iframeInfo.status).toBe("error");
+		});
+
+	});
+
+	describe("Race condition prevention", function() {
+
+		it("should ensure messages are not dropped due to timing", function() {
+			// Simulate the race condition scenario
+			var iframeInfo = {
+				status: "loading",
+				callbacks: []
+			};
+
+			var messageReceived = false;
+			var callbackFired = false;
+
+			// Queue a callback (simulating parent window loading iframe)
+			iframeInfo.callbacks.push(function(err, info) {
+				callbackFired = true;
+			});
+
+			// Simulate PLUGIN-LIBRARY-READY arriving before callback is fired
+			messageReceived = true;
+
+			// Simulate receiving PLUGIN-LIBRARY-READY and flushing
+			if(iframeInfo.status !== "loaded" && messageReceived) {
+				iframeInfo.status = "loaded";
+				var cb;
+				while((cb = iframeInfo.callbacks.shift())) {
+					cb(null, iframeInfo);
+				}
+			}
+
+			expect(messageReceived).toBe(true);
+			expect(callbackFired).toBe(true);
+			expect(iframeInfo.status).toBe("loaded");
+		});
+
+	});
+
+});

--- a/editions/test/tiddlers/tests/test-browser-messaging.js
+++ b/editions/test/tiddlers/tests/test-browser-messaging.js
@@ -3,7 +3,7 @@ title: test-browser-messaging.js
 type: application/javascript
 tags: [[$:/tags/test-spec]]
 
-Tests for browser messaging and iframe communication, including the PLUGIN-LIBRARY-READY handshake.
+Tests the PLUGIN-LIBRARY-READY handshake and legacy onload fallback.
 
 \*/
 
@@ -11,312 +11,130 @@ Tests for browser messaging and iframe communication, including the PLUGIN-LIBRA
 
 describe("Browser Messaging", function() {
 
-	beforeEach(function() {
-		// Initialize browserMessaging
-		if(!$tw.browserMessaging) {
-			$tw.browserMessaging = {};
-		}
-		$tw.browserMessaging.iframeInfoMap = {};
-	});
+    it("should declare itself as a synchronous browser-only startup module", function() {
+        var startup = require("$:/core/modules/browser-messaging.js");
+        expect(startup.name).toBe("browser-messaging");
+        expect(startup.platforms).toEqual(["browser"]);
+        expect(startup.synchronous).toBe(true);
+        expect(typeof startup.startup).toBe("function");
+    });
 
-	afterEach(function() {
-		// Cleanup
-		$tw.browserMessaging.iframeInfoMap = {};
-	});
+    // loadIFrame()/flushCallbacks() are private to browser-messaging.js, so the only way
+    // to exercise them for real is through $tw.rootWidget events and real postMessage
+    // traffic with a real iframe, rather than re-implementing their logic here.
+    describe("plugin library iframe handshake", function() {
 
-	describe("flushCallbacks", function() {
+        var urlsToUnload;
 
-		it("should mark iframe as loaded and execute all queued callbacks", function() {
-			var iframeInfo = {
-				status: "loading",
-				callbacks: []
-			};
-			
-			var callback1Called = false;
-			var callback2Called = false;
-			var callback1Arg = null;
-			var callback2Arg = null;
+        beforeEach(function() {
+            if(!$tw.browser) { return; }
+            urlsToUnload = [];
+        });
 
-			iframeInfo.callbacks.push(function(err, info) {
-				callback1Called = true;
-				callback1Arg = err;
-			});
-			iframeInfo.callbacks.push(function(err, info) {
-				callback2Called = true;
-				callback2Arg = err;
-			});
+        afterEach(function() {
+            if(!$tw.browser) { return; }
+            urlsToUnload.forEach(function(url) {
+                // Grab the DOM node before unloading clears the map entry, as a
+                // belt-and-braces removal (unloadIFrame's own removal has an
+                // unrelated off-by-one loop bug for small iframe counts).
+                var info = $tw.browserMessaging.iframeInfoMap[url];
+                $tw.rootWidget.dispatchEvent({type: "tm-unload-plugin-library", paramObject: {url: url}});
+                if(info && info.domNode && info.domNode.parentNode) {
+                    info.domNode.parentNode.removeChild(info.domNode);
+                }
+                URL.revokeObjectURL(url);
+            });
+        });
 
-			// Simulate flushCallbacks
-			if(iframeInfo.status !== "loaded") {
-				iframeInfo.status = "loaded";
-				var cb;
-				while((cb = iframeInfo.callbacks.shift())) {
-					cb(null, iframeInfo);
-				}
-			}
+        function makeChildUrl(script) {
+            var blob = new Blob(["<script>" + script + "<\/script>"],{type: "text/html"});
+            var url = URL.createObjectURL(blob);
+            urlsToUnload.push(url);
+            return url;
+        }
 
-			expect(callback1Called).toBe(true);
-			expect(callback2Called).toBe(true);
-			expect(callback1Arg).toBe(null);
-			expect(callback2Arg).toBe(null);
-			expect(iframeInfo.callbacks.length).toBe(0);
-		});
+        function waitUntil(predicate,done,description) {
+            var attempts = 0;
+            (function check() {
+                if(predicate()) {
+                    done();
+                } else if(++attempts > 400) {
+                    done.fail("Timed out waiting for: " + description);
+                } else {
+                    setTimeout(check,20);
+                }
+            })();
+        }
 
-		it("should not execute callbacks if status is already loaded", function() {
-			var iframeInfo = {
-				status: "loaded",
-				callbacks: []
-			};
-			
-			var callbackCalled = false;
-			iframeInfo.callbacks.push(function(err, info) {
-				callbackCalled = true;
-			});
+        it("should complete the real GET / GET-RESPONSE round trip once the child signals PLUGIN-LIBRARY-READY", function(done) {
+            if(!$tw.browser) { pending("browser-only: requires a real iframe and postMessage - run in browser"); return; }
 
-			// Simulate flushCallbacks
-			if(iframeInfo.status !== "loaded") {
-				var cb;
-				while((cb = iframeInfo.callbacks.shift())) {
-					cb(null, iframeInfo);
-				}
-			}
+            // Mirrors plugins/tiddlywiki/pluginlibrary/libraryserver.js's real handshake and GET handling:
+            // listener registration and the ready postMessage both happen synchronously, before <body> parses,
+            // so onload (the legacy fallback below) cannot win this race for a well-behaved child.
+            var url = makeChildUrl(
+                "window.addEventListener('message',function(e){" +
+                "if(e.data && e.data.verb === 'GET' && e.data.url === 'recipes/library/tiddlers.json'){" +
+                "e.source.postMessage({verb:'GET-RESPONSE',status:'200',cookies:e.data.cookies,url:e.data.url," +
+                "type:'application/json',body:JSON.stringify([{title:'ExamplePlugin',type:'application/json',text:'{}'}])},'*');" +
+                "}});" +
+                "window.parent.postMessage({verb:'PLUGIN-LIBRARY-READY'},'*');"
+            );
+            var expectedTitle = "$:/temp/RemoteAssetInfo/" + url + "/ExamplePlugin";
 
-			expect(callbackCalled).toBe(false);
-			expect(iframeInfo.callbacks.length).toBe(1);
-		});
+            $tw.rootWidget.dispatchEvent({
+                type: "tm-load-plugin-library",
+                paramObject: {url: url}
+            });
 
-		it("should pass error to callbacks if provided", function() {
-			var iframeInfo = {
-				status: "loading",
-				callbacks: []
-			};
-			
-			var errorReceived = null;
-			var testError = "Test error message";
+            waitUntil(function() {
+                return !!$tw.wiki.getTiddler(expectedTitle);
+            },done,"tiddler " + expectedTitle);
+        },10000);
 
-			iframeInfo.callbacks.push(function(err, info) {
-				errorReceived = err;
-			});
+        it("should still resolve via the legacy iframe.onload fallback when the child never sends PLUGIN-LIBRARY-READY", function(done) {
+            if(!$tw.browser) { pending("browser-only: requires a real iframe - run in browser"); return; }
 
-			// Simulate flushCallbacks with error
-			if(iframeInfo.status !== "loaded") {
-				iframeInfo.status = "error";
-				var cb;
-				while((cb = iframeInfo.callbacks.shift())) {
-					cb(testError, iframeInfo);
-				}
-			}
+            // A blank document that never sends the handshake exercises the onload-only legacy path.
+            var url = makeChildUrl("");
 
-			expect(errorReceived).toBe(testError);
-			expect(iframeInfo.status).toBe("error");
-		});
+            $tw.rootWidget.dispatchEvent({
+                type: "tm-load-plugin-library",
+                paramObject: {url: url}
+            });
 
-	});
+            waitUntil(function() {
+                var info = $tw.browserMessaging.iframeInfoMap[url];
+                return !!info && info.status === "loaded";
+            },done,"iframe status to become 'loaded' via onload");
+        },10000);
 
-	describe("loadIFrame callback queueing", function() {
+        it("should complete the round trip via PLUGIN-LIBRARY-READY even when the child's own load is aborted and onload can never fire", function(done) {
+            if(!$tw.browser) { pending("browser-only: requires a real iframe and postMessage - run in browser"); return; }
 
-		it("should queue multiple callbacks for the same iframe", function() {
-			var iframeInfo = {
-				url: "http://example.com/library.html",
-				status: "loading",
-				callbacks: []
-			};
+            // window.stop() simulates onload never firing despite the library being ready,
+            // so only the PLUGIN-LIBRARY-READY message can complete this round trip.
+            var url = makeChildUrl(
+                "window.addEventListener('message',function(e){" +
+                "if(e.data && e.data.verb === 'GET' && e.data.url === 'recipes/library/tiddlers.json'){" +
+                "e.source.postMessage({verb:'GET-RESPONSE',status:'200',cookies:e.data.cookies,url:e.data.url," +
+                "type:'application/json',body:JSON.stringify([{title:'ExamplePlugin',type:'application/json',text:'{}'}])},'*');" +
+                "}});" +
+                "window.parent.postMessage({verb:'PLUGIN-LIBRARY-READY'},'*');" +
+                "window.stop();"
+            );
+            var expectedTitle = "$:/temp/RemoteAssetInfo/" + url + "/ExamplePlugin";
 
-			var callback1Called = false;
-			var callback2Called = false;
+            $tw.rootWidget.dispatchEvent({
+                type: "tm-load-plugin-library",
+                paramObject: {url: url}
+            });
 
-			// Simulate queueing callbacks
-			iframeInfo.callbacks.push(function(err, info) {
-				callback1Called = true;
-			});
-			iframeInfo.callbacks.push(function(err, info) {
-				callback2Called = true;
-			});
+            waitUntil(function() {
+                return !!$tw.wiki.getTiddler(expectedTitle);
+            },done,"tiddler " + expectedTitle);
+        },10000);
 
-			expect(iframeInfo.callbacks.length).toBe(2);
-
-			// Simulate PLUGIN-LIBRARY-READY arriving
-			if(iframeInfo.status !== "loaded") {
-				iframeInfo.status = "loaded";
-				var cb;
-				while((cb = iframeInfo.callbacks.shift())) {
-					cb(null, iframeInfo);
-				}
-			}
-
-			expect(callback1Called).toBe(true);
-			expect(callback2Called).toBe(true);
-			expect(iframeInfo.callbacks.length).toBe(0);
-		});
-
-	});
-
-	describe("PLUGIN-LIBRARY-READY message handling", function() {
-
-		it("should recognize PLUGIN-LIBRARY-READY verb", function() {
-			var message = {
-				verb: "PLUGIN-LIBRARY-READY"
-			};
-
-			expect(message.verb).toBe("PLUGIN-LIBRARY-READY");
-		});
-
-		it("should match iframe by contentWindow source", function() {
-			// Create mock iframes
-			var mockContentWindow1 = {};
-			var mockContentWindow2 = {};
-			var mockDomNode1 = { contentWindow: mockContentWindow1 };
-			var mockDomNode2 = { contentWindow: mockContentWindow2 };
-
-			$tw.browserMessaging.iframeInfoMap = {
-				"url1": {
-					url: "url1",
-					status: "loading",
-					domNode: mockDomNode1,
-					callbacks: []
-				},
-				"url2": {
-					url: "url2",
-					status: "loading",
-					domNode: mockDomNode2,
-					callbacks: []
-				}
-			};
-
-			var matchedInfo = null;
-			var messageSource = mockContentWindow2;
-
-			// Simulate finding matching iframe
-			$tw.utils.each($tw.browserMessaging.iframeInfoMap, function(info) {
-				if(info && info.domNode && info.domNode.contentWindow === messageSource) {
-					matchedInfo = info;
-				}
-			});
-
-			expect(matchedInfo).toBe($tw.browserMessaging.iframeInfoMap["url2"]);
-			expect(matchedInfo.url).toBe("url2");
-		});
-
-	});
-
-	describe("Backward compatibility with iframe.onload", function() {
-
-		it("should handle iframe.onload as fallback when PLUGIN-LIBRARY-READY is not sent", function() {
-			var iframeInfo = {
-				status: "loading",
-				callbacks: []
-			};
-
-			var callbackCalled = false;
-			iframeInfo.callbacks.push(function(err, info) {
-				callbackCalled = true;
-			});
-
-			// Simulate onload firing (fallback path)
-			if(iframeInfo.status !== "loaded") {
-				iframeInfo.status = "loaded";
-				var cb;
-				while((cb = iframeInfo.callbacks.shift())) {
-					cb(null, iframeInfo);
-				}
-			}
-
-			expect(callbackCalled).toBe(true);
-			expect(iframeInfo.status).toBe("loaded");
-		});
-
-	});
-
-	describe("Error handling", function() {
-
-		it("should handle iframe onerror events", function() {
-			var iframeInfo = {
-				status: "loading",
-				callbacks: []
-			};
-
-			var errorReceived = null;
-			var errorMessage = "Cannot load iframe";
-
-			iframeInfo.callbacks.push(function(err, info) {
-				errorReceived = err;
-			});
-
-			// Simulate onerror
-			if(iframeInfo.status !== "loaded") {
-				iframeInfo.status = "error";
-				var cb;
-				while((cb = iframeInfo.callbacks.shift())) {
-					cb(errorMessage, iframeInfo);
-				}
-			}
-
-			expect(errorReceived).toBe(errorMessage);
-			expect(iframeInfo.status).toBe("error");
-		});
-
-		it("should handle exceptions during iframe.src assignment", function() {
-			var iframeInfo = {
-				status: "loading",
-				callbacks: []
-			};
-
-			var exceptionReceived = null;
-			var testException = new Error("Security exception");
-
-			iframeInfo.callbacks.push(function(err, info) {
-				exceptionReceived = err;
-			});
-
-			// Simulate exception handling
-			if(iframeInfo.status !== "loaded") {
-				iframeInfo.status = "error";
-				var cb;
-				while((cb = iframeInfo.callbacks.shift())) {
-					cb(testException, iframeInfo);
-				}
-			}
-
-			expect(exceptionReceived).toBe(testException);
-			expect(iframeInfo.status).toBe("error");
-		});
-
-	});
-
-	describe("Race condition prevention", function() {
-
-		it("should ensure messages are not dropped due to timing", function() {
-			// Simulate the race condition scenario
-			var iframeInfo = {
-				status: "loading",
-				callbacks: []
-			};
-
-			var messageReceived = false;
-			var callbackFired = false;
-
-			// Queue a callback (simulating parent window loading iframe)
-			iframeInfo.callbacks.push(function(err, info) {
-				callbackFired = true;
-			});
-
-			// Simulate PLUGIN-LIBRARY-READY arriving before callback is fired
-			messageReceived = true;
-
-			// Simulate receiving PLUGIN-LIBRARY-READY and flushing
-			if(iframeInfo.status !== "loaded" && messageReceived) {
-				iframeInfo.status = "loaded";
-				var cb;
-				while((cb = iframeInfo.callbacks.shift())) {
-					cb(null, iframeInfo);
-				}
-			}
-
-			expect(messageReceived).toBe(true);
-			expect(callbackFired).toBe(true);
-			expect(iframeInfo.status).toBe("loaded");
-		});
-
-	});
+    });
 
 });

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10003-plugin-library-ready-handshake.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10003-plugin-library-ready-handshake.tid
@@ -15,9 +15,8 @@ Retains iframe.onload as a backward-compatible fallback for legacy or external l
 that do not emit the ready signal.
 
 Previously, the browser-messaging.js relied entirely on iframe.onload to trigger the initial 
-postMessage call to a plugin library. However, onload only indicates that the HTML document 
-shell has finished parsing into the DOM, not that the inline script inside the iframe has 
-finished executing or successfully bound its window.addEventListener("message"). This could 
-cause messages to be lost if the iframe's script initialization was delayed by even a few 
-milliseconds due to main-thread congestion or slow hardware. The new handshake eliminates 
-this timing-dependent race condition by actively confirming readiness.
+postMessage call to a plugin library. However, if the iframe's connection or load is aborted 
+after its internal script has already run and bound window.addEventListener("message"), onload 
+never fires at all, so the initial postMessage call is never sent and the request is silently 
+lost with no error. The new handshake eliminates this by having the iframe actively confirm 
+readiness as soon as its listener is bound, independent of whether onload ever fires.

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10003-plugin-library-ready-handshake.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10003-plugin-library-ready-handshake.tid
@@ -1,0 +1,23 @@
+title: $:/changenotes/5.5.0/#10003
+description: Fix race condition in plugin library iframe message handling
+release: 5.5.0
+tags: $:/tags/ChangeNote
+change-type: bugfix
+change-category: plugin
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/10003
+github-contributors: DesignThinkerer
+
+Introduce a ''PLUGIN-LIBRARY-READY'' handshake verb for plugin library iframes. 
+This ensures that postMessage commands are not prematurely dropped before the iframe's 
+internal script has fully bound its message listeners.
+
+Retains iframe.onload as a backward-compatible fallback for legacy or external libraries 
+that do not emit the ready signal.
+
+Previously, the browser-messaging.js relied entirely on iframe.onload to trigger the initial 
+postMessage call to a plugin library. However, onload only indicates that the HTML document 
+shell has finished parsing into the DOM, not that the inline script inside the iframe has 
+finished executing or successfully bound its window.addEventListener("message"). This could 
+cause messages to be lost if the iframe's script initialization was delayed by even a few 
+milliseconds due to main-thread congestion or slow hardware. The new handshake eliminates 
+this timing-dependent race condition by actively confirming readiness.

--- a/plugins/tiddlywiki/pluginlibrary/libraryserver.js
+++ b/plugins/tiddlywiki/pluginlibrary/libraryserver.js
@@ -63,6 +63,11 @@ window.addEventListener("message",function listener(event){
 	}
 },false);
 
+// Signal to parent that the iframe is ready to receive messages
+window.parent.postMessage({
+	verb: "PLUGIN-LIBRARY-READY"
+},"*");
+
 // Helper to remove string prefixes
 function removePrefix(string,prefix) {
 	if(string.indexOf(prefix) === 0) {


### PR DESCRIPTION
**Is your PR related to a problem? Please describe.**

When attempting to download or export dynamically generated strings (such as JSON payloads, custom text exports, or processed data) via messages like `tm-download-file`, users are currently forced to create and immediately delete temporary tiddlers in the wiki store purely to act as a render target for templates.

**Describe the solution you are proposing**

Introduce a minimalist new core template at `$:/core/templates/plain-text` containing:

```wikitext
<$text text=<<text>>/>
```

This allows users to pass variables directly into the template via the `variables` paramObject, completely bypassing the need to touch the wiki store:

```wikitext
<$action-sendmessage
  $message="tm-download-file"
  $param="$:/core/templates/plain-text"
  text="Hello World!"
  filename="export.json"
/>
```

**Describe alternatives you've considered**

1. **Temporary Tiddler Pattern:** Using sequential actions (`<$action-setfield>` to write a temp tiddler, `tm-download-file` to render it, and `<$action-deletetiddler>` to clean up in a single button click). While functional, it requires unnecessary write/delete operations on the wiki store.
2. **Innerwiki/Testcase Wrappers:** Bootstrapping isolated wiki instances. This is heavily over-engineered for a simple raw string export.

## Checklist before requesting a review

* [ ] Illustrate any visual changes (however minor) with before/after screenshots *(N/A: no visual UI changes)*
* [x] Self-review of code
* [ ] Documentation updates (for user-visible changes)
* [ ] Tests (for core code changes)
* [x] Complies with coding style guidelines (for JavaScript code) *(N/A: pure wikitext template)*