### PR TITLE
Add $:/core/templates/plain-text and $:/core/templates/rendered-text

### DIFF
--- a/core/templates/plain-text.tid
+++ b/core/templates/plain-text.tid
@@ -1,0 +1,3 @@
+title: $:/core/templates/plain-text
+
+<$text text=<<text>>/>

--- a/core/templates/rendered-text.tid
+++ b/core/templates/rendered-text.tid
@@ -1,0 +1,3 @@
+title: $:/core/templates/rendered-text
+
+<<text>>

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10017-plain-text-core-template.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10017-plain-text-core-template.tid
@@ -1,0 +1,12 @@
+change-category: internal
+change-type: feature
+created: 20260906234108933
+description: Added new $:/core/templates/plain-text core template for rendering raw variables
+github-contributors: DesignThinkerer
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/10017
+modified: 20260906234439533
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#10017
+
+Added a new core template at `$:/core/templates/plain-text` that renders a single `text` variable as plain text using the `<$text>` widget. This enables developers to export and download dynamic strings via messages like `tm-download-file` using the `variables` paramObject, eliminating the need to create temporary tiddlers in the wiki store.

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10017-plain-text-core-template.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10017-plain-text-core-template.tid
@@ -9,4 +9,4 @@ release: 5.5.0
 tags: $:/tags/ChangeNote
 title: $:/changenotes/5.5.0/#10017
 
-Added a new core template at `$:/core/templates/plain-text` that renders a single `text` variable as plain text using the `<$text>` widget. This enables developers to export and download dynamic strings via messages like `tm-download-file` using the `variables` paramObject, eliminating the need to create temporary tiddlers in the wiki store.
+Added two new core template, `$:/core/templates/plain-text` and `$:/core/templates/rendered-text` that renders respectively a single `text` variable as plain text or wikitext. This allows to export and download dynamic strings via messages like `tm-download-file`, without creating temporary tiddlers in the wiki store.


### PR DESCRIPTION
Rendering dynamic strings (like JSON payloads, script exports, or notifications) via system messages (tm-download-file, tm-notify, tm-modal) currently requires creating and immediately deleting temporary tiddlers in the store purely as render targets. This PR introduce two minimalist core templates to render variables passed via message parameter objects without touching the wiki store: `$:/core/templates/plain-text` and `$:/core/templates/rendered-text`


### Example of use

Custom alert message

```
\procedure notify()
<$action-sendmessage $message="tm-notify" $param="$:/core/templates/plain-text" text={{!!count}} />
\end notify

<$button set="!!count" setTo={{{ [{!!count}add[1]] }}} tooltip="count" actions="""<<notify>>""" >
Count
</$button>
```

Custom modal

```
\procedure text()

!! Motovun Jack

{{Motovun Jack.jpg}}

\end

<$button>
<$action-sendmessage $message="tm-modal" $param="$:/core/templates/rendered-text" text=<<text>>/>
Click me!
</$button>
```

Creating a button for downloading a plugin as an external injectable script

```
\function field.value() [<pluginTitle>get{!!title}]

\function json.plugin()
	[<pluginTitle>fields[]]:reduce[<accumulator>jsonset{!!title},<field.value>]=>pluginData
	"[]"+[jsonset:json[0],<pluginData>]
\end

\define externalPlugin()
{
    const tw = globalThis.$tw ??= Object.create(null);
    tw.preloadTiddlers = (tw.preloadTiddlers ?? []).concat($(json.plugin)$);
}
\end


<$let pluginTitle="$:/plugins/tiddlywiki/menubar" text=<<externalPlugin>> >

<$button tooltip="Export standalone plugin">{{$:/core/images/export-button}}
<$action-sendmessage
  $message="tm-download-file"
  $param="$:/core/templates/plain-text"
  text=<<text>>
  filename={{{ [<pluginTitle>search-replace:g[/],[_]addsuffix[.js]] }}}
  type="text/javascript"
/>
</$button>
```