### PR TITLE
Fix #10004 iframe DOM leak in unloadIFrame loop

### DIFF
--- a/core/modules/startup/browser-messaging.js
+++ b/core/modules/startup/browser-messaging.js
@@ -60,7 +60,7 @@ Unload library iframe for given url
 */
 function unloadIFrame(url){
 	var iframes = document.getElementsByTagName("iframe");
-	for(var t=iframes.length-1; t--; t>=0) {
+	for(var t = iframes.length - 1; t >= 0; t--) {
 		var iframe = iframes[t];
 		if(iframe.getAttribute("library") === "true" &&
 		  iframe.getAttribute("src") === url) {

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10018-fix-unload-iframe-leak.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10018-fix-unload-iframe-leak.tid
@@ -1,0 +1,11 @@
+change-category: internal
+change-type: bugfix
+created: 20260907175854854
+description: Fixed a DOM leak when closing the plugin library
+github-links: https://github.com/TiddlyWiki/TiddlyWiki5/pull/10018
+release: 5.5.0
+tags: $:/tags/ChangeNote
+title: $:/changenotes/5.5.0/#10018
+type: text/vnd.tiddlywiki
+
+Fixed a syntax error in the `unloadIFrame` loop that permanently left a hidden `<iframe library="true">` attached to the DOM every time the plugin library modal was closed.

--- a/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10018-fix-unload-iframe-leak.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.5.0/#10018-fix-unload-iframe-leak.tid
@@ -7,5 +7,6 @@ release: 5.5.0
 tags: $:/tags/ChangeNote
 title: $:/changenotes/5.5.0/#10018
 type: text/vnd.tiddlywiki
+github-contributors: DesignThinkerer
 
 Fixed a syntax error in the `unloadIFrame` loop that permanently left a hidden `<iframe library="true">` attached to the DOM every time the plugin library modal was closed.


### PR DESCRIPTION
Merging this will fixes #10004

### Problem

When closing a plugin library, the `tm-unload-plugin-library` message invokes `unloadIFrame(url)` in `core/modules/startup/browser-messaging.js` to remove the background library iframe. 

However, the reverse `for` loop condition was malformed:

```javascript
for(var t=iframes.length-1; t--; t>=0)

```

* The condition block `t--` evaluates to falsy on the first step when `iframes.length === 1` (`t = 0`), terminating the loop before running the body.
* The afterthought block `t>=0` does not control iteration.

As a result, closing a plugin library never cleans up the attached `<iframe library="true">`, causing a DOM leak every time a library modal is opened and closed.

### Solution

Corrected the loop condition to standard backward iteration syntax:

```javascript
for(var t = iframes.length - 1; t >= 0; t--)

```

### Verification

1. Opened the developer console in a blank wiki.
2. Verified `document.querySelectorAll('iframe[library="true"]').length === 0`.
3. Navigated to **Control Panel** > **Plugins** > **Get more plugins** > **Open plugin library**.
4. Closed the modal.
5. Verified `document.querySelectorAll('iframe[library="true"]').length === 0`.
 there are no unintended whitespace changes before committing?"/>