### PR TITLE
add examples using the new templates $:/core/templates/plain-text and $:/core/templates/rendered-text

### DIFF
--- a/editions/tw5.com/tiddlers/features/Modals.tid
+++ b/editions/tw5.com/tiddlers/features/Modals.tid
@@ -1,5 +1,5 @@
 created: 20160107225427489
-modified: 20211221102625141
+modified: 20260907204047567
 tags: Features
 title: Modals
 type: text/vnd.tiddlywiki
@@ -19,6 +19,29 @@ Note that the footer and subtitle fields are not limited to plain text, and wiki
 
 Modals are displayed with the [[WidgetMessage: tm-modal]].
 
-<$button message="tm-modal" param="SampleWizard">Open demo modal</$button>
-
 <<.tip """<$macrocall $name=".from-version" version="5.2.4"/> allow using "mask-closable" field""">>
+
+!! Examples
+
+<<wikitext-example-without-html """<$button message="tm-modal" param="SampleWizard">Open demo modal</$button>""">>
+
+<<.from-version "5.3.6">> you can use the template $:/core/templates/rendered-text to display a modal if you do not want to create a separate tiddler:
+
+<<wikitext-example-without-html """\procedure text()
+<style class="headless-modal">
+.tc-modal:has(.tc-modal-body .headless-modal) .tc-modal-header{display:none}
+</style>
+
+!! Motovun Jack
+
+{{Motovun Jack.jpg}}
+
+
+<$button message="tm-modal" param="SampleWizard">Open nested modal</$button>
+
+\end
+
+<$button>
+<$action-sendmessage $message="tm-modal" $param="$:/core/templates/rendered-text" text=<<text>>/>
+Click me!
+</$button>""">>

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-download-file.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-download-file.tid
@@ -1,6 +1,6 @@
 caption: tm-download-file
 created: 20140811112201235
-modified: 20230723214745520
+modified: 20260907205338343
 tags: Messages
 title: WidgetMessage: tm-download-file
 type: text/vnd.tiddlywiki
@@ -20,3 +20,40 @@ The following variable names have special behaviour:
 The download file message is usually generated with the ButtonWidget.
 
 The download file message is handled by the TiddlyWiki core SyncMechanism which invokes the current [[SaverModule|SaverModules]].
+
+! Examples
+
+<<.from-version "5.3.6">> you can use the template $:/core/templates/plain-text to create a custom download configuration without creating additional tiddlers:
+
+<<wikitext-example-without-html """\function field.value() [<pluginTitle>get{!!title}]
+
+\function json.plugin()
+	[<pluginTitle>fields[]]:reduce[<accumulator>jsonset{!!title},<field.value>]=>pluginData
+	"[]"+[jsonset:json[0],<pluginData>]
+\end
+
+\define externalPlugin()
+{
+    const tw = globalThis.$tw ??= Object.create(null);
+    tw.preloadTiddlers = (tw.preloadTiddlers ?? []).concat($(json.plugin)$);
+}
+\end
+
+
+<$let pluginTitle="$:/plugins/tiddlywiki/menubar" text=<<externalPlugin>> >
+
+<$button tooltip="Export standalone plugin">{{$:/core/images/export-button}} export <<pluginTitle>> as standalone plugin
+<$action-sendmessage
+  $message="tm-download-file"
+  $param="$:/core/templates/plain-text"
+  text=<<text>>
+  filename={{{ [<pluginTitle>search-replace:g[/],[_]addsuffix[.js]] }}}
+  type="text/javascript"
+/>
+</$button>
+
+You can load the exported plugin by creating a tiddler with the tag <<tag $:/tags/RawMarkupWikified/BottomBody>> containing this:
+
+```
+`<script src="URL_OF_YOUR_PLUGIN_HERE" onerror="alert('Error: Cannot load YOUR_PLUGIN located at URL_OF_YOUR_PLUGIN_HERE');"></script>`
+```""">>

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-notify.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-notify.tid
@@ -1,6 +1,6 @@
 caption: tm-notify
 created: 20140811112304772
-modified: 20230723220728382
+modified: 20260907202408431
 tags: Messages
 title: WidgetMessage: tm-notify
 type: text/vnd.tiddlywiki
@@ -12,3 +12,28 @@ The notify message briefly displays a specified tiddler as a small alert in the 
 |//{any other params}// |Any other parameters are made available as variables to the notify message. |
 
 The notify message is handled by the TiddlyWiki core.
+
+! Examples
+
+<<.from-version "5.3.6">> you can use the template $:/core/templates/plain-text to display simple text in a notification:
+
+<<wikitext-example-without-html """\procedure notify()
+<$action-sendmessage $message="tm-notify" $param="$:/core/templates/plain-text" text={{!!count}} />
+\end notify
+
+<$button set="!!count" setTo={{{ [{!!count}add[1]] }}} tooltip="count" actions="<<notify>>" >
+Count
+</$button>""">>
+
+You can also use the template $:/core/templates/rendered-text to display wikitext:
+
+<<wikitext-example-without-html """\procedure notify()
+\procedure template()
+Current time is <<now>>
+\end template
+<$action-sendmessage $message="tm-notify" $param="$:/core/templates/rendered-text" text=<<template>> />
+\end notify
+
+<$button actions="<<notify>>" >
+What time is it?
+</$button>""">>


### PR DESCRIPTION
> ⚠️ Important: #10017 MUST be merged before merging this PR!

Add doc examples for the pr https://github.com/TiddlyWiki/TiddlyWiki5/pull/10017, demonstrating how to use the two new `$:/core/templates/plain-text` and `$:/core/templates/rendered-text` in the following tiddlers:


- WidgetMessage: tm-download-file
- Modals
- WidgetMessage: tm-notify

Because this PR relies on changes made in #10017, to make the examples work in the preview you need to add the following tiddlers:

```
title: $:/core/templates/plain-text
<$text text=<<text>>/>
```

```
title: $:/core/templates/rendered-text
<<text>>
```

I packaged these two tiddlers in this attachment: [tiddlers.json](https://github.com/user-attachments/files/31928376/tiddlers.4.json)
